### PR TITLE
feat!: update to the 2023-09 job template schema

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,11 +22,11 @@ WARNING: This workflow installs additional Python packages into your Maya's pyth
 
 1. Create a development location within which to do your git checkouts. For example `~/deadline-clients`.
    Clone packages from this directory with commands like
-   `git clone git@github.com:casillas2/deadline-cloud-for-maya.git`. You'll also want the `deadline-cloud` and `openjobio` repos.
+   `git clone git@github.com:casillas2/deadline-cloud-for-maya.git`. You'll also want the `deadline-cloud` and `openjd` repos.
 2. Switch to your Maya directory, like `cd "C:\Program Files\Autodesk\Maya2023"`.
 3. Run `.\mayapy -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud` to install the Amazon Deadline Cloud Client
    Library in edit mode.
-4. Run `.\mayapy -m pip install -e C:\Users\<username>\deadline-clients\openjobio` to install the OpenJobIO
+4. Run `.\mayapy -m pip install -e C:\Users\<username>\deadline-clients\openjd` to install the Open Job Description
    Library in edit mode.
 5. Run `.\mayapy -m pip install -e C:\Users\<username>\deadline-clients\deadline-cloud-for-maya` to install the Maya Submtiter
    in edit mode.
@@ -48,21 +48,21 @@ your build of the adaptor for the one in the service.
 
 1. Use the development location from the Submitter Development Workflow.
    Make sure you're running Maya with `set DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` enabled.
-2. Build wheels for `openjobio`, `deadline` and `deadline-cloud-for-maya`.
+2. Build wheels for `openjd`, `deadline` and `deadline-cloud-for-maya`.
    ```
    # If you don't have the build package installed already
    $ pip install build
    ...
    $  mkdir wheels; \
       rm wheels/*; \
-      for dir in ../openjobio ../deadline-cloud ../deadline-cloud-for-maya; \
+      for dir in ../openjd ../deadline-cloud ../deadline-cloud-for-maya; \
         do python -m build --wheel --outdir ./wheels --skip-dependency-check $dir; \
       done
    ...
    $ ls ./wheels
    deadline_cloud_for_maya-<version>-py3-none-any.whl
    deadline-<version>-py3-none-any.whl
-   openjobio-<version>-py3-none-any.whl
+   openjd-<version>-py3-none-any.whl
    ```
 3. Open the Maya integrated submitter, and in the Job-Specific Settings tab, enable the option 'Include Adaptor Wheels'. This
    option is only visible when the environment variable `DEADLINE_ENABLE_DEVELOPER_OPTIONS` is set to `true`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This package has two active branches:
 - `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
 - `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
 
-The deadline.maya_adaptor package is an adaptor that renders maya scenes through MayaPy. It uses the openjobio adaptor_runtime and supports job stickiness.
+The deadline.maya_adaptor package is an adaptor that renders maya scenes through MayaPy. It uses the Open Job Description adaptor_runtime and supports job stickiness.
 
 ## Development
 

--- a/depsBundle.py
+++ b/depsBundle.py
@@ -35,8 +35,8 @@ def _get_dependencies(pyproject_dict: dict[str, Any]) -> list[str]:
         raise Exception("pyproject.toml is missing dependencies section")
 
     dependencies = pyproject_dict["project"]["dependencies"]
-    deps_noopenjobio = filter(lambda dep: not dep.startswith("openjobio"), dependencies)
-    return list(map(lambda dep: dep.replace(" ", ""), deps_noopenjobio))
+    deps_noopenjd = filter(lambda dep: not dep.startswith("openjd"), dependencies)
+    return list(map(lambda dep: dep.replace(" ", ""), deps_noopenjd))
 
 
 def _get_package_version_regex(package: str) -> re.Pattern:

--- a/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
@@ -1,6 +1,6 @@
-specificationVersion: '2022-09-01'
+specificationVersion: jobtemplate-2023-09
 name: cube.ma
-parameters:
+parameterDefinitions:
 - name: MayaSceneFile
   type: PATH
   objectType: FILE
@@ -101,7 +101,7 @@ parameters:
 steps:
 - name: masterLayer
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.Frames}}'
@@ -109,7 +109,7 @@ steps:
       type: STRING
       range:
       - persp
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:

--- a/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
@@ -1,6 +1,6 @@
-specificationVersion: '2022-09-01'
+specificationVersion: jobtemplate-2023-09
 name: layers.ma
-parameters:
+parameterDefinitions:
 - name: MayaSceneFile
   type: PATH
   objectType: FILE
@@ -236,7 +236,7 @@ parameters:
 steps:
 - name: layerDefaultFrames
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.layerDefaultFramesFrames}}'
@@ -244,7 +244,7 @@ steps:
       type: STRING
       range:
       - camera1
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:
@@ -309,7 +309,7 @@ steps:
           mode: NOTIFY_THEN_TERMINATE
 - name: layerFrameRange1
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.layerFrameRange1Frames}}'
@@ -318,7 +318,7 @@ steps:
       range:
       - camera1
       - persp
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:
@@ -382,7 +382,7 @@ steps:
           mode: NOTIFY_THEN_TERMINATE
 - name: masterLayer
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.masterLayerFrames}}'
@@ -391,7 +391,7 @@ steps:
       range:
       - camera1
       - persp
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:
@@ -456,7 +456,7 @@ steps:
           mode: NOTIFY_THEN_TERMINATE
 - name: renderSetupLayer2
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.renderSetupLayer2Frames}}'
@@ -466,7 +466,7 @@ steps:
       - camera1
       - camera2
       - camera3
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:
@@ -531,7 +531,7 @@ steps:
           mode: NOTIFY_THEN_TERMINATE
 - name: renderSetupLayer4
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.renderSetupLayer4Frames}}'
@@ -540,7 +540,7 @@ steps:
       range:
       - camera1
       - persp
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:

--- a/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
@@ -1,6 +1,6 @@
-specificationVersion: '2022-09-01'
+specificationVersion: jobtemplate-2023-09
 name: layers_no_variation.ma
-parameters:
+parameterDefinitions:
 - name: MayaSceneFile
   type: PATH
   objectType: FILE
@@ -112,7 +112,7 @@ parameters:
 steps:
 - name: layerTheFIrst
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.Frames}}'
@@ -120,7 +120,7 @@ steps:
       type: STRING
       range:
       - persp
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:
@@ -185,7 +185,7 @@ steps:
           mode: NOTIFY_THEN_TERMINATE
 - name: layerTheSecond
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.Frames}}'
@@ -193,7 +193,7 @@ steps:
       type: STRING
       range:
       - persp
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:
@@ -258,7 +258,7 @@ steps:
           mode: NOTIFY_THEN_TERMINATE
 - name: masterLayer
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.Frames}}'
@@ -266,7 +266,7 @@ steps:
       type: STRING
       range:
       - persp
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.20.*",
-    "openjobio == 0.8.*",
+    "deadline == 0.23.*",
+    "openjd == 0.10.*",
 ]
 
 [project.scripts]

--- a/src/deadline/maya_adaptor/MayaAdaptor/__main__.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/__main__.py
@@ -3,7 +3,7 @@
 import logging
 import sys
 
-from openjobio.adaptor_runtime import EntryPoint
+from openjd.adaptor_runtime import EntryPoint
 
 from .adaptor import MayaAdaptor
 

--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -14,13 +14,13 @@ import time
 from pathlib import Path
 from typing import Callable
 
-from openjobio.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators
-from openjobio.adaptor_runtime_client import Action
-from openjobio.adaptor_runtime.adaptors.configuration import AdaptorConfiguration
-from openjobio.adaptor_runtime.process import LoggingSubprocess
-from openjobio.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
-from openjobio.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
-from openjobio.adaptor_runtime._utils import secure_open
+from openjd.adaptor_runtime.adaptors import Adaptor, AdaptorDataValidators
+from openjd.adaptor_runtime_client import Action
+from openjd.adaptor_runtime.adaptors.configuration import AdaptorConfiguration
+from openjd.adaptor_runtime.process import LoggingSubprocess
+from openjd.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
+from openjd.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
+from openjd.adaptor_runtime._utils import secure_open
 
 _logger = logging.getLogger(__name__)
 
@@ -299,16 +299,16 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
         mayapy_exe = "mayapy"
         regexhandler = RegexHandler(self._get_regex_callbacks())
 
-        # Add the OpenJobIO namespace directory to PYTHONPATH, so that adaptor_runtime_client
+        # Add the openjd namespace directory to PYTHONPATH, so that adaptor_runtime_client
         # will be available directly to the adaptor client.
-        import openjobio.adaptor_runtime_client
+        import openjd.adaptor_runtime_client
         import deadline.maya_adaptor
 
-        openjobio_namespace_dir = os.path.dirname(
-            os.path.dirname(openjobio.adaptor_runtime_client.__file__)
+        openjd_namespace_dir = os.path.dirname(
+            os.path.dirname(openjd.adaptor_runtime_client.__file__)
         )
         deadline_namespace_dir = os.path.dirname(os.path.dirname(deadline.maya_adaptor.__file__))
-        python_path_addition = f"{openjobio_namespace_dir}{os.pathsep}{deadline_namespace_dir}"
+        python_path_addition = f"{openjd_namespace_dir}{os.pathsep}{deadline_namespace_dir}"
         if "PYTHONPATH" in os.environ:
             os.environ[
                 "PYTHONPATH"

--- a/src/deadline/maya_adaptor/MayaClient/maya_client.py
+++ b/src/deadline/maya_adaptor/MayaClient/maya_client.py
@@ -6,7 +6,7 @@ import os
 from types import FrameType
 from typing import Optional
 
-# The Maya Adaptor adds the `openjobio` namespace directory to PYTHONPATH,
+# The Maya Adaptor adds the `openjd` namespace directory to PYTHONPATH,
 # so that importing just the adaptor_runtime_client should work.
 try:
     from adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
@@ -14,7 +14,7 @@ try:
         get_render_handler,
     )
 except (ImportError, ModuleNotFoundError):
-    from openjobio.adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
+    from openjd.adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
     from deadline.maya_adaptor.MayaClient.render_handlers import (  # type: ignore[import]
         get_render_handler,
     )

--- a/src/deadline/maya_submitter/adaptor_override_environment.yaml
+++ b/src/deadline/maya_submitter/adaptor_override_environment.yaml
@@ -1,10 +1,10 @@
-specificationVersion: '2022-09-01'
-parameters:
+specificationVersion: 'jobtemplate-2023-09'
+parameterDefinitions:
 - name: OverrideAdaptorWheels
   type: PATH
   objectType: DIRECTORY
   dataFlow: IN
-  description: A directory that contains wheels for openjobio, deadline, and the overridden adaptor.
+  description: A directory that contains wheels for openjd, deadline, and the overridden adaptor.
 - name: OverrideAdaptorName
   type: STRING
   description: The name of the adaptor to override, for example NukeAdaptor or MayaAdaptor.
@@ -40,7 +40,7 @@ environment:
         echo ""
 
         echo "Installing adaptor into the venv"
-        pip install {{Param.OverrideAdaptorWheels}}/openjobio*.whl
+        pip install {{Param.OverrideAdaptorWheels}}/openjd*.whl
         pip install {{Param.OverrideAdaptorWheels}}/deadline*.whl
         echo ""
 
@@ -79,6 +79,6 @@ environment:
 
         for k, v in put.items():
             print(f"updating {k}={v}")
-            print(f"openjobio_env: {k}={v}")
+            print(f"openjd_env: {k}={v}")
         for k in delete:
-            print(f"openjobio_unset_env: {k}")
+            print(f"openjd_unset_env: {k}")

--- a/src/deadline/maya_submitter/default_maya_job_template.yaml
+++ b/src/deadline/maya_submitter/default_maya_job_template.yaml
@@ -1,6 +1,6 @@
-specificationVersion: '2022-09-01'
+specificationVersion: 'jobtemplate-2023-09'
 name: Default Maya Job Template
-parameters:
+parameterDefinitions:
 - name: MayaSceneFile
   type: PATH
   objectType: FILE
@@ -78,11 +78,11 @@ parameters:
 steps:
 - name: Render
   parameterSpace:
-    parameters:
+    taskParameterDefinitions:
     - name: Frame
       type: INT
       range: '{{Param.Frames}}'
-  environments:
+  stepEnvironments:
   - name: Maya
     description: Runs Maya in the background.
     script:

--- a/test/deadline_adaptor_for_maya/unit/MayaAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_maya/unit/MayaAdaptor/test_adaptor.py
@@ -11,7 +11,7 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 import jsonschema  # type: ignore
-from openjobio.adaptor_runtime_client import PathMappingRule
+from openjd.adaptor_runtime_client import PathMappingRule
 
 import deadline.maya_adaptor.MayaAdaptor.adaptor as adaptor_module
 from deadline.maya_adaptor.MayaAdaptor import MayaAdaptor


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The job template schema is being updated prior to launch.

The existing template format is

```json
{
    "specificationVersion": "2022-09-01",
    "parameters": [...],
    "environments": [...],
    "steps": [
        {
            "name": "name",
            "parameterSpace": {
                "parameters": [...]
            },
            "environments": [...],
            "requiredCapabilities": [
                {
                    "name": "amount.worker.vcpu",
                    "min": 2
                },
                {
                    "name": "attr.worker.os.family",
                    "anyOf": ["linux", "macos"]
                },
                ...
            ],
            ...
        }
    ]
}
```

And the new template format will is:
```json
{
    "specificationVersion": "jobtemplate-2023-09",
    "parameterDefinitions": [...],
    "jobEnvironments": [...],
    "steps": [
        {
            "name": "name",
            "parameterSpace": {
                "taskParameterDefinitions": [...]
            },
            "stepEnvironments": [...],
            "hostRequirements": {
                "amounts": [
                    {
                        "name": "amount.worker.vcpu",
                        "min": 2
                    },
                    ...
                ],
                "attributes": [
                    {
                        "name": "attr.worker.os.family",
                        "anyOf": ["linux", "macos"]
                    },
                    ...
                ]
            },
            ...
        }
    ]
}
```

### What was the solution? (How)

Updating the templates encoded in to the submitter, and bumping the dep version of the library.

### What is the impact of this change?

Compatibility with the service going forward.

### How was this change tested?

I have not yet tested it; I'm not at all set up for it. The change is simple, but I wouldn't turn down a volunteer to run it through its paces before we merge.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?

Yes, in the template schema

### Is this a breaking change?

Yes.