### PR TITLE
Fix: rename duplicate folder name in install builder xml

### DIFF
--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -9,7 +9,7 @@
         <folder>
             <description>Maya Plug-in Module</description>
             <destination>${maya_installdir}</destination>
-            <name>maya</name>
+            <name>mayaplugin</name>
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Install Builder is failing to build due to `maya` being used for two folder names. There cannot be duplicates.

### What was the solution? (How)
Rename the plugin distributions folder name to `mayaplugin`

### What is the impact of this change?
Fix build of the submitter installer

### How was this change tested?
```
hatch run lint
hatch run test
```
This will be tested in CI/CD

### Did you run the "Job Bundle Output Tests"? 
No, this is an xml change to the installer.


### Was this change documented?
No

### Is this a breaking change?
No
