### PR TITLE
fix: rename install builder xml component name var

### DIFF
--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -41,7 +41,7 @@
          </folder>
     </folderList>
 	<initializationActionList>
-		<setInstallerVariable name="all_components" value="${all_components} maya_integrated_submitter"/>
+		<setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_maya"/>
 	</initializationActionList>
 	<readyToInstallActionList>
 		<setInstallerVariable name="maya_installdir" value="${installdir}/Submitters/Maya"/>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Submitter installers are failing to launch because of a component name mismatch between an env var and the top level component name

### What was the solution? (How)
rename env var to the proper name

### What is the impact of this change?
Fix installer

### How was this change tested?
```
hatch run lint
hatch run test
```

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Not required for an xml change.

### Was this change documented?
No

### Is this a breaking change?
No
