### PR TITLE
fix: set installbuilder summary to match component name

### DIFF
--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -71,7 +71,7 @@
          </if>
 	</readyToInstallActionList>
 	<parameterList>
-		<stringParameter name="maya_integrated_submitter_summary" ask="0" cliOptionShow="0">
+		<stringParameter name="deadline_cloud_for_maya_summary" ask="0" cliOptionShow="0">
 			<value>Deadline Cloud for Maya
 - Install the integrated Maya submitter files to the installation directory.
 - Register the plug-in with Maya by creating or updating the MAYA_MODULE_PATH environment variable.</value>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`maya_integrated_submitter_summary` needs to be `deadline_cloud_for_maya_summary`

### What was the solution? (How)
rename

### What is the impact of this change?
Fix installer build

### How was this change tested?
Will be tested in CI

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
CI changes, not required

### Was this change documented?
No

### Is this a breaking change?
No
