### PR TITLE
fix: startfile mock on non-win platforms

### DIFF
--- a/src/deadline/maya_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/maya_submitter/job_bundle_output_test_runner.py
@@ -193,7 +193,7 @@ def _run_job_bundle_output_test(test_dir: str, dcc_scene_file: str, report_fh, m
             "create_job_history_bundle_dir",
             return_value=temp_job_bundle_dir,
         ), mock.patch.object(submit_job_to_deadline_dialog, "QMessageBox"), mock.patch.object(
-            os, "startfile"
+            os, "startfile", create=True  # only exists on win. Just create to avoid AttributeError
         ):
             submitter.on_save_bundle()
         QApplication.processEvents()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

One job-bundle fails on non windows platform because a platform-dependent attribute will not exist and cannot be mocked.

### What was the solution? (How)

Add `create=True` to the mock call. This will create the attribute on linux/macOS. Could also conditionally mock but in my opinion would look more ugly and this does not harm anything.

### What is the impact of this change?

Unblock this test on linux/mac

### How was this change tested?

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, because this does not change job-bundle related code and this change is simple enough to not warrant it.

### Was this change documented?

No

### Is this a breaking change?

No