### PR TITLE
fix: remove double nesting in the submitter folder structure

### DIFF
--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -13,7 +13,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-maya/maya_submitter_plugin</origin>
+                    <origin>components/deadline-cloud-for-maya/maya_submitter_plugin/*</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>
@@ -24,7 +24,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-maya/src/deadline/maya_submitter</origin>
+                    <origin>components/deadline-cloud-for-maya/src/deadline/maya_submitter/*</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We are double nesting the submitter and plugin files

### What was the solution? (How)
change the component to distribute files within the plugin and submitter source folders.

### What is the impact of this change?
Fix maya submitter installation

### How was this change tested?
proper folder structure was tested by a developer

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

CI changes, these tests are not needed

### Was this change documented?
No

### Is this a breaking change?
No