### PR TITLE
fix: Unit test fix when DEADLINE_ENABLE_DEVELOPER_OPTIONS is True

### DIFF
--- a/test/deadline_submitter_for_maya/unit/plugins/test_deadline_submitter_maya.py
+++ b/test/deadline_submitter_for_maya/unit/plugins/test_deadline_submitter_maya.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import os
 import re
 from collections import namedtuple
 from typing import Any
@@ -36,6 +37,7 @@ def test_reload_modules(mock_reload: Mock) -> None:
 @patch.object(om, "MFnPlugin")
 @patch.object(DeadlineCloudForMaya, "reload")
 @patch.object(deadline.maya_submitter.shelf, "build_shelf")
+@patch.dict(os.environ, {"DEADLINE_ENABLE_DEVELOPER_OPTIONS": "False"})
 def test_initialize_and_uninitialize_plugin(
     mock_build_shelf: Mock,
     mock_reload: Mock,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `test_initialize_and_uninitialize_plugin` unit test would fail if DEADLINE_ENABLE_DEVELOPER_OPTIONS was set to True:

Error: 
```
E           AssertionError: Expected 'registerCommand' to be called once. Called 2 times.
E           Calls: [call('DeadlineCloudSubmitter', <class 'deadline.maya_submitter.mel_commands.DeadlineCloudSubmitterCmd'>),
E            call('DeadlineCloudJobBundleOutputTests', <class 'deadline.maya_submitter.mel_commands.DeadlineCloudJobBundleOutputTestsCmd'>)].
```
RegisterCommad is called twice if DEADLINE_ENABLE_DEVELOPER_OPTIONS is set to True: https://github.com/casillas2/deadline-cloud-for-maya/blob/mainline/maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py#L71

### What was the solution? (How)
Set DEADLINE_ENABLE_DEVELOPER_OPTIONS to False when running unit test

### What is the impact of this change?
Tests pass when DEADLINE_ENABLE_DEVELOPER_OPTIONS is set to True in shell environment

### How was this change tested?
Ran unit tests locally

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
N/A to change. Tests pass

### Was this change documented?
No

### Is this a breaking change?
No