### PR TITLE
chore: Updating DEVELOPMENT.md with some helpful dev hints

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,7 +10,7 @@ and straightforward enough that we recommend you read it directly to update/modi
 
 ## Adding Dependencies
 
-All of the testing and development dependencies are in the `setup.cfg` and are meant to be included idiomatically.
+All of the testing and development dependencies are in the `requirements-testing.txt` and are meant to be included idiomatically.
 
 ## Testing
 
@@ -19,6 +19,13 @@ All of the testing and development dependencies are in the `setup.cfg` and are m
 ## Submitter Development Workflow
 
 WARNING: This workflow installs additional Python packages into your Maya's python distribution.
+
+NOTE: If you receieve an error from `mayapy`: 
+```
+ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode: C:\Users\<User>\deadline-cloud
+(A "pyproject.toml" file was found, but editable mode currently requires a setuptools-based build.)
+```
+Then first update mayapy's version of pip with `./mayapy -m pip install --upgrade pip`. 
 
 1. Create a development location within which to do your git checkouts. For example `~/deadline-clients`. Clone packages from this directory with commands like `git clone git@github.com:casillas2/deadline-cloud-for-maya.git`. You'll also want the `deadline-cloud` and `openjd` repos.
 2. Switch to your Maya directory, like `cd "C:\Program Files\Autodesk\Maya2023"`.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
I noticed while attempting to follow the submitter development workflow that mayapy would give an error about setup.cfg not existing when attempting to install the dev packages into it's environment. Specifically in Maya 2023. 

I also noticed that the document mentioned a setup.cfg that no longer existed.

### What was the solution? (How)
Updated the documentation.

### What is the impact of this change?
Better dev experience as the DEVELOPMENT.md now provides a workaround for such an error.

### How was this change tested?
It's a doc update only.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No.

### Was this change documented?
No.

### Is this a breaking change?
No.