### PR TITLE
DRAFT EXAMPLE: feat: add automated job bundle test mode

### DIFF
--- a/src/deadline/maya_submitter/mel_commands.py
+++ b/src/deadline/maya_submitter/mel_commands.py
@@ -79,4 +79,6 @@ class DeadlineCloudJobBundleOutputTestsCmd(om.MPxCommand):
         """
         Runs a set of job bundle output tests from a directory.
         """
-        run_maya_render_submitter_job_bundle_output_test()
+        result = run_maya_render_submitter_job_bundle_output_test()
+        if result:
+            DeadlineCloudJobBundleOutputTestsCmd.setResult(result.success)


### PR DESCRIPTION
# THIS IS AN EXAMPLE IMPLEMENTATION

### What was the problem/requirement? (What/Why)
We need a way to run the job bundle output tests in an automated way for our CI/CD pipeline since they currently require user interaction to complete

### What was the solution? (How)
Add a new "automated" mode for the job bundle output tests that is activated by setting the following environment variables:
- `DEADLINE_ENABLE_DEVELOPER_OPTIONS=true` - required to turn on the job bundle tests
- `JOB_BUNDLE_OUTPUT_TESTS_AUTOMATED=true` - tells the job bundle test runner to use automated mode
- `JOB_BUNDLE_OUTPUT_TESTS_DIR=/path/to/job_bundle_output_tests` - path to the job bundle tests

Once activated, you can run it in an automated way by running `maya` on the command line like this: (example in PowerShell)
```ps1
$proc = Start-Process maya.exe -ArgumentList "-command",'"loadPlugin DeadlineCloudForMaya; python(\"import maya.cmds; [success] = maya.cmds.DeadlineCloudJobBundleOutputTests(); maya.cmds.quit(exitCode=0 if success else 1, force=True, abort=True)\")"' -PassThru
$proc.WaitForExit()
if ($proc.ExitCode -ne 0) {
    # Handle failure
}
```

### What is the impact of this change?
We have a way to run the job bundle tests in our CI/CD pipeline

### How was this change tested?
Ran the above PowerShell scripting on my Windows laptop with Maya2023 and verified maya ran through the job bundle tests and reported failure correctly

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Yes, they are failing for me.

```

Timestamp: 2023-12-08T17:21:42.666476-06:00
Running job bundle output test: C:\Users\jericht\Repositories\deadline-cloud-for-maya\job_bundle_output_tests\cube

cube
Test failed, found differences
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -14,7 +14,7 @@
 - name: OutputFilePath
   value: /normalized/job/bundle/dir/images
 - name: RenderSetupIncludeLights
-  value: 'true'
+  value: 'false'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

Timestamp: 2023-12-08T17:21:47.788017-06:00
Running job bundle output test: C:\Users\jericht\Repositories\deadline-cloud-for-maya\job_bundle_output_tests\layers

layers
Test failed, found differences
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -46,7 +46,7 @@
 - name: OutputFilePath
   value: /normalized/job/bundle/dir/images
 - name: RenderSetupIncludeLights
-  value: 'true'
+  value: 'false'
 - name: ArnoldErrorOnLicenseFailure
   value: 'false'
 - name: deadline:targetTaskRunStatus

Timestamp: 2023-12-08T17:21:49.560697-06:00
Running job bundle output test: C:\Users\jericht\Repositories\deadline-cloud-for-maya\job_bundle_output_tests\layers_no_variation

layers_no_variation
Test failed, found differences
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -14,7 +14,7 @@
 - name: OutputFilePath
   value: /normalized/job/bundle/dir/images
 - name: RenderSetupIncludeLights
-  value: 'true'
+  value: 'false'
 - name: ArnoldErrorOnLicenseFailure
   value: 'false'
 - name: deadline:targetTaskRunStatus

Failed 3 tests, succeeded 0.
Timestamp: 2023-12-08T17:21:50.248839-06:00
```

### Was this change documented?
No

### Is this a breaking change?
No
