### PR TITLE
chore(dev): add hatch run install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dependency_bundle
 /wheels/
 **/test_job_bundle/
 **/test-job-bundle-results.txt
+plugin_env

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ hatch run fmt
 hatch run all:test
 ```
 
+## Use development Submitter in Maya
+
+```bash
+hatch run install
+hatch shell
+```
+Then launch Maya from that terminal.
+
+A development version of deadline-cloud-for-maya is then available to be loaded.
+
 ## Compatibility
 
 This library requires:

--- a/hatch.toml
+++ b/hatch.toml
@@ -19,6 +19,7 @@ lint = [
   "style",
   "typing",
 ]
+install = "python {root}/scripts/install_dev_submitter.py {args:}"
 
 [[envs.all.matrix]]
 python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
@@ -26,6 +27,7 @@ python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 [envs.default.env-vars]
 PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"
+MAYA_ENV_DIR="{root}/plugin_env"
 
 [envs.codebuild.scripts]
 build = "hatch build"

--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -1,0 +1,82 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Optional
+
+
+ADAPTOR_ONLY_DEPENDENCIES = {"openjd-adaptor-runtime"}
+
+
+def get_project_dict(project_path: Optional[Path] = None) -> dict[str, Any]:
+    if sys.version_info < (3, 11):
+        with TemporaryDirectory() as toml_env:
+            toml_install_pip_args = ["pip", "install", "--target", toml_env, "toml"]
+            subprocess.run(toml_install_pip_args, check=True)
+            sys.path.insert(0, toml_env)
+            import toml
+        mode = "r"
+    else:
+        import tomllib as toml
+
+        mode = "rb"
+
+    with open(str((project_path or get_git_root()) / "pyproject.toml"), mode) as pyproject_toml:
+        return toml.load(pyproject_toml)
+
+
+class Dependency:
+    name: str
+    operator: Optional[str]
+    version: Optional[str]
+
+    def __init__(self, dep: str):
+        components = dep.split(" ")
+        self.name = components[0]
+        if len(components) > 2:
+            self.operator = components[1]
+            self.version = components[2]
+        else:
+            self.operator = None
+            self.version = None
+
+    def for_pip(self) -> str:
+        if self.operator is not None and self.version is not None:
+            return f"{self.name}{self.operator}{self.version}"
+        return self.name
+
+    def __repr__(self) -> str:
+        return self.for_pip()
+
+
+def get_dependencies(pyproject_dict: dict[str, Any], include_adaptor=True) -> list[Dependency]:
+    if "project" not in pyproject_dict:
+        raise Exception("pyproject.toml is missing project section")
+    if "dependencies" not in pyproject_dict["project"]:
+        raise Exception("pyproject.toml is missing dependencies section")
+
+    return [
+        Dependency(dep_str)
+        for dep_str in pyproject_dict["project"]["dependencies"]
+        if include_adaptor or dep_str not in ADAPTOR_ONLY_DEPENDENCIES
+    ]
+
+
+def get_git_root() -> Path:
+    return Path(__file__).parents[1].resolve()
+
+
+def get_pip_platform(system_platform: str) -> str:
+    if system_platform == "Windows":
+        return "win_amd64"
+    elif system_platform == "Darwin":
+        return "macosx_10_9_x86_64"
+    elif system_platform == "Linux":
+        return "manylinux2014_x86_64"
+    else:
+        raise Exception(f"Unsupported platform: {system_platform}")

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -1,0 +1,162 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import argparse
+import json
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+from typing import Optional
+
+from _project import get_git_root, get_dependencies, get_project_dict, get_pip_platform
+
+
+class MayaVersion:
+    major: int
+
+    PYTHON_VERSIONS = {
+        "2023": "3.9",
+        "2024": "3.10",
+    }
+
+    def __init__(self, arg_version: Optional[str]):
+        self.major = self._get_maya_version(arg_version)
+
+    @classmethod
+    def _validate_version(cls, version: str) -> str:
+        return str(int(version))
+
+    @classmethod
+    def _get_maya_version(cls, arg: Optional[str]) -> str:
+        if arg is not None:
+            return cls._validate_version(arg)
+        maya_version_file = get_git_root() / "maya_version.txt"
+        if maya_version_file.exists():
+            with open(maya_version_file, "r", encoding="utf-8") as f:
+                return cls._validate_version(f.read().strip())
+        return cls._validate_version(input("Please enter the Maya version: "))
+
+    def python_major_minor(self) -> str:
+        major = self.major
+        if major in self.PYTHON_VERSIONS:
+            return self.PYTHON_VERSIONS[major]
+        raise ValueError(f"Unknown Maya version: {major}")
+
+
+def _get_maya_env_file(version: str) -> Path:
+    if platform.system() == "Windows":
+        return Path.home() / "Documents" / "maya" / version / "Maya.env"
+    elif platform.system() == "Darwin":
+        return Path.home() / "Library" / "Preferences" / "Autodesk" / "maya" / version / "Maya.env"
+    elif platform.system() == "Linux":
+        return Path.home() / "maya" / version / "Maya.env"
+    else:
+        raise RuntimeError(f"Unsupported platform: {platform.system()}")
+
+
+def _setup_maya_env_file(maya_mod_path: Path, install_path: Path):
+    """MAYA_ENV_DIR will point to this Maya.env file to discover the submitter"""
+    maya_env = f"MAYA_MODULE_PATH={install_path}"
+
+    with open(maya_mod_path / "Maya.env", "w") as f:
+        f.write(maya_env)
+
+
+def _resolve_dependencies(local_deps: list[Path]) -> dict[str, str]:
+    project_dict = get_project_dict()
+    local_dep_project_dicts = [get_project_dict(local_dep) for local_dep in local_deps]
+    local_dep_names = set([local_dep["project"]["name"] for local_dep in local_dep_project_dicts])
+    all_project_dicts = [*local_dep_project_dicts, project_dict]
+    dependency_lists = [get_dependencies(project_dict) for project_dict in all_project_dicts]
+    filtered_dependency_lists = [
+        [dep for dep in dependency_list if dep.name not in local_dep_names]
+        for dependency_list in dependency_lists
+    ]
+    flattened_dependency_list = [
+        dep for dependency_list in filtered_dependency_lists for dep in dependency_list
+    ]
+
+    args = [
+        "pipgrip",
+        "--json",
+        *[dep.for_pip() for dep in flattened_dependency_list],
+    ]
+    result = subprocess.run(args, check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+def _build_deps_env(destination: Path, python_version: str, local_deps: list[Path]) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    if not destination.is_dir():
+        raise Exception(f"{str(destination)} is not a directory")
+
+    resolved_dependencies_dict = _resolve_dependencies(local_deps)
+    resolved_dependencies = [
+        f"{dep_name}=={resolved_version}"
+        for dep_name, resolved_version in resolved_dependencies_dict.items()
+    ]
+
+    args = [
+        "pip",
+        "install",
+        "--target",
+        str(destination),
+        "--platform",
+        get_pip_platform(platform.system()),
+        "--python-version",
+        python_version,
+        "--only-binary=:all:",
+        *resolved_dependencies,
+    ]
+    subprocess.run(args, check=True)
+
+
+def _copy_maya_submitter_source(dest_path: Path):
+    shutil.copytree(get_git_root() / "src", dest_path, dirs_exist_ok=True)
+
+
+def _copy_maya_submitter_plugin(dest_path: Path):
+    shutil.copytree(get_git_root() / "maya_submitter_plugin", dest_path, dirs_exist_ok=True)
+
+
+def install_submitter_package(maya_version_arg: Optional[str], local_deps: list[Path]) -> None:
+    """Installs deadline-cloud-for-maya similarly to install builder.
+    Requires `hatch shell` activation and then launching Maya
+    """
+    maya_version = MayaVersion(maya_version_arg)
+    plugin_env_path = get_git_root() / "plugin_env"
+    scripts_path = plugin_env_path / "scripts"
+    shutil.rmtree(plugin_env_path, ignore_errors=True)
+    _build_deps_env(
+        scripts_path,
+        maya_version.python_major_minor(),
+        local_deps,
+    )
+    _copy_maya_submitter_source(dest_path=scripts_path)
+    _copy_maya_submitter_plugin(dest_path=plugin_env_path)
+
+    # TODO: For actual installation, we'll want to use the env
+    # file in the installation, skipping for now
+    maya_mod_path = plugin_env_path
+    _setup_maya_env_file(plugin_env_path, maya_mod_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--maya-version",
+        help="Maya version to install the submitter for",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--local-dep",
+        help="Path to a repository containing a dependency for in-place install",
+        action="append",
+        type=str,
+    )
+    args = parser.parse_args()
+    local_deps = [Path(dep) for dep in args.local_dep or []]
+
+    install_submitter_package(args.maya_version, local_deps)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

No automated way to set up a dev installer similar to the submitter installer

### What was the solution? (How)

make a `hatch run install` command similar to houdini's (a lot of it was taken wholesale, like the _project file and bits of the install dev submitter file)

### What is the impact of this change?

Users can now run

```bash
hatch run install
hatch shell
# launch maya, here's macos
open /Applications/Autodesk/maya2023/Maya.app
```
and then load it in the plugin window. Organization matches the install_builder component

![image](https://github.com/casillas2/deadline-cloud-for-maya/assets/60796713/8d98fc87-4e7d-4d22-af5d-440633f8c711)

It's definitely not the most perfected workflow, but it's an easy way to set-up the submitter that could then be used as the starting point for an installation script that lives outside of install builder.

### How was this change tested?

Did it myself! I then loaded the submitter and confirmed that it used the development one

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

N/A

### Was this change documented?

Added to README

### Is this a breaking change?

N/A