### PR TITLE
Discussion - populate package names with environment variables

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -39,7 +39,16 @@ from .ui.components.scene_settings_tab import SceneSettingsWidget
 from deadline.client.job_bundle.submission import AssetReferences
 
 logger = getLogger(__name__)
-
+ADC_REZ_PACKAGES = os.environ.get('ADC_REZ_PACKAGES') or ' '.join([
+    os.environ.get('ADC_REZ_MAYA', 'adc_maya'),
+    os.environ.get('ADC_REZ_MTOA', 'adc_mtoa'),
+    os.environ.get('ADC_REZ_MAYA_ADAPTER', 'adc_maya_adapter')
+])
+ADC_CONDA_PACKAGES = os.environ.get('ADC_CONDA_PACKAGES') or ' '.join([
+    os.environ.get('ADC_CONDA_MAYA', 'adc_maya'),
+    os.environ.get('ADC_CONDA_MTOA', 'adc_mtoa'),
+    os.environ.get('ADC_CONDA_MAYA_ADAPTER', 'adc_maya_adapter')
+])
 
 @dataclass
 class RenderLayerData:
@@ -412,7 +421,7 @@ def _get_parameter_values(
             + f"{', '.join(parameter_overlap)}"
         )
 
-    # If we're overriding the adaptor with wheels, remove deadline_cloud_for_maya from the RezPackages
+    # If we're overriding the adaptor with wheels, remove adc_maya_adapter from the RezPackages
     if settings.include_adaptor_wheels:
         rez_param = {}
         # Find the RezPackages parameter definition
@@ -425,7 +434,7 @@ def _get_parameter_values(
             rez_param["value"] = " ".join(
                 pkg
                 for pkg in rez_param["value"].split()
-                if not pkg.startswith("deadline_cloud_for_maya")
+                if not pkg.startswith("adc_maya_adapter")
             )
 
     parameter_values.extend(
@@ -637,7 +646,10 @@ def show_maya_render_submitter(parent, f=Qt.WindowFlags()) -> "Optional[SubmitJo
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,
         initial_job_settings=render_settings,
-        initial_shared_parameter_values={"RezPackages": "mayaIO mtoa deadline_cloud_for_maya"},
+        initial_shared_parameter_values={
+            "RezPackages": ADC_REZ_PACKAGES,
+            "CondaPackages": ADC_CONDA_PACKAGES
+        },
         auto_detected_attachments=auto_detected_attachments,
         attachments=attachments,
         on_create_job_bundle_callback=on_create_job_bundle_callback,


### PR DESCRIPTION
## DO NOT MERGE.

I intend for this PR to spur discussion on improvements in this problem area with a concrete example of a potential solution. This PR should not be merged, most of all because I haven't even tried running this code yet.

### What was the problem/requirement? (What/Why)

The current submitter paradigm has a few areas that can be improved.

Chief among them is that there is no easy way for a customer to dynamically and programmatically change the packages this submitter defaults to, absent the user manually editing that package list on submission.

### What was the solution? (How)

While a config file might be used to solution here, referring to environment variables is a tried and true solution which likely meshes nicely with our customers existing solutions. If a customer is using a package environment configuration tool like rez, setting the below environment variables would be trivial. Customers could also cause `$ADC_REZ_PACKAGES` to equal [`$REZ_USED_RESOLVE`](https://rez.readthedocs.io/en/stable/environment.html#envvar-REZ_USED_RESOLVE), resulting in a 1 for 1 match with the submission environment. This assumes the customer has the same rez packages available to their queue environment. This would be highly desirable for most large customers.

### What is the impact of this change?

* All submitters would need to be updated to use environment variables
* Customers would need to reinstall all submitters