### PR TITLE
feat!: Create a script to build adaptor packaging artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,12 @@ requires-python = ">=3.7"
 
 dependencies = [
     "deadline == 0.37.*",
-    "openjd-adaptor-runtime == 0.3.*",
+    "openjd-adaptor-runtime == 0.4.*",
 ]
 
 [project.scripts]
+maya-openjd = "deadline.maya_adaptor.MayaAdaptor:main"
+# The binary name 'MayaAdaptor' is deprecated.
 MayaAdaptor = "deadline.maya_adaptor.MayaAdaptor:main"
 
 [tool.hatch.build]
@@ -129,7 +131,7 @@ source = [
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 45
+fail_under = 44
 
 [tool.semantic_release]
 # Can be removed or set to true once we are v1

--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+set -xeou pipefail
+
+APP=maya
+ADAPTOR_NAME=deadline-cloud-for-$APP
+
+# This script generates an tar.gz artifact from $ADAPTOR_NAME and its dependencies
+# that can be used to create a package for running the adaptor.
+
+SCRIPTDIR=$(realpath $(dirname $0))
+
+SOURCE=0
+# Python 3.11 is for https://vfxplatform.com/ CY2024
+PYTHON_VERSION=3.11
+CONDA_PLATFORM=linux-64
+TAR_BASE=
+
+while [ $# -gt 0 ]; do
+    case "${1}" in
+    --source) SOURCE=1 ; shift ;;
+    --platform) CONDA_PLATFORM="$2" ; shift 2 ;;
+    --python) PYTHON_VERSION="$2" ; shift 2 ;;
+    --tar-base) TAR_BASE="$2" ; shift 2 ;;
+    *) echo "Unexpected option: $1"; exit 1 ;;
+  esac
+done
+
+if [ "$CONDA_PLATFORM" = "linux-64" ]; then
+    PYPI_PLATFORM=manylinux2014_x86_64
+elif [ "$CONDA_PLATFORM" = "win-64" ]; then
+    PYPI_PLATFORM=win_amd64
+elif [ "$CONDA_PLATFORM" = "osx-64" ]; then
+    PYPI_PLATFORM=macosx_10_9_x86_64
+else
+    echo "Unknown Conda operating system option --platform $CONDA_PLATFORM"
+    exit 1
+fi
+
+if [ "$TAR_BASE" = "" ]; then
+    TAR_BASE=$SCRIPTDIR/../$APP-openjd-py$PYTHON_VERSION-$CONDA_PLATFORM
+fi
+
+# Create a temporary prefix
+WORKDIR=$(mktemp -d adaptor-pkg.XXXXXXXXXX)
+function cleanup_workdir {
+    echo "Cleaning up $WORKDIR"
+    rm -rf $WORKDIR
+}
+trap cleanup_workdir EXIT
+
+PREFIX=$WORKDIR/prefix
+
+if [ "$CONDA_PLATFORM" = "win-64" ]; then
+    BINDIR=$PREFIX/Library/bin
+    PACKAGEDIR=$PREFIX/Library/opt/$ADAPTOR_NAME
+else
+    BINDIR=$PREFIX/bin
+    PACKAGEDIR=$PREFIX/opt/$ADAPTOR_NAME
+fi
+
+
+mkdir -p $PREFIX
+mkdir -p $PACKAGEDIR
+mkdir -p $BINDIR
+
+# Install the adaptor into the virtual env
+if [ $SOURCE = 1 ]; then
+    # In source mode, openjd-adaptor-runtime-for-python must be alongside this adaptor source
+    RUNTIME_INSTALLABLE=$SCRIPTDIR/../../openjd-adaptor-runtime-for-python
+    ADAPTOR_INSTALLABLE=$SCRIPTDIR/..
+
+    if [ "$CONDA_PLATFORM" = "win-64" ]; then
+        DEPS="pyyaml jsonschema pywin32"
+    else
+        DEPS="pyyaml jsonschema"
+    fi
+
+    for DEP in $DEPS; do
+        pip install \
+            --target $PACKAGEDIR \
+            --platform $PYPI_PLATFORM \
+            --python-version $PYTHON_VERSION \
+            --ignore-installed \
+            --only-binary=:all: \
+            $DEP
+    done
+
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $RUNTIME_INSTALLABLE
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $ADAPTOR_INSTALLABLE
+else
+    # In PyPI mode, PyPI and/or a CodeArtifact must have these packages
+    RUNTIME_INSTALLABLE=openjd-adaptor-runtime-for-python
+    ADAPTOR_INSTALLABLE=$ADAPTOR_NAME
+
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --only-binary=:all: \
+        $RUNTIME_INSTALLABLE
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $ADAPTOR_INSTALLABLE
+fi
+
+
+# Remove the submitter code
+rm -r $PACKAGEDIR/deadline/*_submitter
+
+# Remove the bin dir if there is one
+if [ -d $PACKAGEDIR/bin ]; then
+    rm -r $PACKAGEDIR/bin
+fi
+
+PYSCRIPT="from pathlib import Path
+import sys
+reentry_exe = Path(sys.argv[0]).absolute()
+sys.path.append(str(reentry_exe.parent.parent / \"opt\" / \"$ADAPTOR_NAME\"))
+from deadline.${APP}_adaptor.${APP^}Adaptor.__main__ import main
+sys.exit(main(reentry_exe=reentry_exe))
+"
+
+cat <<EOF > $BINDIR/$APP-openjd
+#!/usr/bin/env python3.11
+$PYSCRIPT
+EOF
+
+# Temporary
+cp $BINDIR/$APP-openjd $BINDIR/${APP^}Adaptor
+
+chmod u+x $BINDIR/$APP-openjd $BINDIR/${APP^}Adaptor
+
+if [ $CONDA_PLATFORM = "win-64" ]; then
+    # Install setuptools to get cli-64.exe
+    mkdir -p $WORKDIR/tmp
+    pip install \
+        --target $WORKDIR/tmp \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        setuptools
+
+    # Use setuptools' cli-64.exe to define the entry point
+    cat <<EOF > $BINDIR/$APP-openjd-script.py
+#!C:\\Path\\To\\Python.exe
+$PYSCRIPT
+EOF
+    cp $WORKDIR/tmp/setuptools/cli-64.exe $BINDIR/$APP-openjd.exe
+fi
+
+# Everything between the first "-" and the next "+" is the package version number
+PACKAGEVER=$(cd $PACKAGEDIR; echo deadline_cloud_for*)
+PACKAGEVER=${PACKAGEVER#*-}
+PACKAGEVER=${PACKAGEVER%+*}
+echo "Package version number is $PACKAGEVER"
+
+# Create the tar artifact
+GIT_TIMESTAMP="$(env TZ=UTC git log -1 --date=iso-strict-local --format="%ad")"
+pushd $PREFIX
+# See https://reproducible-builds.org/docs/archives/ for information about
+# these options
+#tar --mtime=$GIT_TIMESTAMP \
+#     --sort=name \
+#     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+#    --owner=0 --group=0 --numeric-owner \
+#    -cf $TAR_BASE .
+# TODO Switch to the above command once the build environment has tar version > 1.28
+tar --owner=0 --group=0 --numeric-owner \
+    -cf $TAR_BASE-$PACKAGEVER.tar.gz .
+sha256sum $TAR_BASE-$PACKAGEVER.tar.gz
+popd

--- a/src/deadline/maya_adaptor/MayaAdaptor/__main__.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/__main__.py
@@ -11,7 +11,7 @@ __all__ = ["main"]
 _logger = logging.getLogger(__name__)
 
 
-def main():
+def main(reentry_exe=None):
     _logger.info("About to start the MayaAdaptor")
 
     package_name = vars(sys.modules[__name__])["__package__"]
@@ -19,13 +19,14 @@ def main():
         raise RuntimeError(f"Must be run as a module. Do not run {__file__} directly")
 
     try:
-        EntryPoint(MayaAdaptor).start()
+        EntryPoint(MayaAdaptor).start(reentry_exe=reentry_exe)
     except Exception as e:
         _logger.error(f"Entrypoint failed: {e}")
-        sys.exit(1)
+        return 1
 
     _logger.info("Done MayaAdaptor main")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -139,11 +139,11 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
             str: The socket path the adaptor server is running on.
         """
         is_not_timed_out = self._get_timer(self._SERVER_START_TIMEOUT_SECONDS)
-        while (self._server is None or self._server.socket_path is None) and is_not_timed_out():
+        while (self._server is None or self._server.server_path is None) and is_not_timed_out():
             time.sleep(0.01)
 
-        if self._server is not None and self._server.socket_path is not None:
-            return self._server.socket_path
+        if self._server is not None and self._server.server_path is not None:
+            return self._server.server_path
 
         raise RuntimeError(
             "Could not find a socket path because the server did not finish initializing"
@@ -160,14 +160,14 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
     def _start_maya_server_thread(self) -> None:
         """
         Starts the maya adaptor server in a thread.
-        Sets the environment variable "MAYA_ADAPTOR_SOCKET_PATH" to the socket the server is running
+        Sets the environment variable "MAYA_ADAPTOR_SERVER_PATH" to the socket the server is running
         on after the server has finished starting.
         """
         self._server_thread = threading.Thread(
             target=self._start_maya_server, name="MayaAdaptorServerThread"
         )
         self._server_thread.start()
-        os.environ["MAYA_ADAPTOR_SOCKET_PATH"] = self._wait_for_socket()
+        os.environ["MAYA_ADAPTOR_SERVER_PATH"] = self._wait_for_socket()
 
     def _get_regex_callbacks(self) -> list[RegexCallback]:
         """

--- a/src/deadline/maya_adaptor/MayaClient/maya_client.py
+++ b/src/deadline/maya_adaptor/MayaClient/maya_client.py
@@ -21,8 +21,8 @@ except (ImportError, ModuleNotFoundError):
 
 
 class MayaClient(HTTPClientInterface):
-    def __init__(self, socket_path: str) -> None:
-        super().__init__(socket_path=socket_path)
+    def __init__(self, server_path: str) -> None:
+        super().__init__(server_path=server_path)
         self.actions.update(
             {
                 "renderer": self.set_renderer,
@@ -48,21 +48,21 @@ class MayaClient(HTTPClientInterface):
 
 
 def main():
-    socket_path = os.environ.get("MAYA_ADAPTOR_SOCKET_PATH")
-    if not socket_path:
+    server_path = os.environ.get("MAYA_ADAPTOR_SERVER_PATH")
+    if not server_path:
         raise OSError(
             "MayaClient cannot connect to the Adaptor because the environment variable "
-            "MAYA_ADAPTOR_SOCKET_PATH does not exist"
+            "MAYA_ADAPTOR_SERVER_PATH does not exist"
         )
 
-    if not os.path.exists(socket_path):
+    if not os.path.exists(server_path):
         raise OSError(
             "MayaClient cannot connect to the Adaptor because the socket at the path defined by "
-            "the environment variable MAYA_ADAPTOR_SOCKET_PATH does not exist. Got: "
-            f"{os.environ['MAYA_ADAPTOR_SOCKET_PATH']}"
+            "the environment variable MAYA_ADAPTOR_SERVER_PATH does not exist. Got: "
+            f"{os.environ['MAYA_ADAPTOR_SERVER_PATH']}"
         )
 
-    client = MayaClient(socket_path)
+    client = MayaClient(server_path)
     client.poll()
 
 

--- a/test/deadline_adaptor_for_maya/unit/MayaAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_maya/unit/MayaAdaptor/test_adaptor.py
@@ -69,7 +69,7 @@ class TestMayaAdaptor_on_start:
     ) -> None:
         """Tests that on_start completes without error"""
         adaptor = MayaAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         adaptor.on_start()
 
     @patch("time.sleep")
@@ -90,7 +90,7 @@ class TestMayaAdaptor_on_start:
         socket_mock = PropertyMock(
             side_effect=[None, None, None, "/tmp/9999", "/tmp/9999", "/tmp/9999"]
         )
-        type(mock_server.return_value).socket_path = socket_mock
+        type(mock_server.return_value).server_path = socket_mock
 
         # WHEN
         adaptor.on_start()
@@ -133,7 +133,7 @@ class TestMayaAdaptor_on_start:
         """
         # GIVEN
         adaptor = MayaAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         new_timeout = 0.01
 
         with patch.object(adaptor, "_MAYA_START_TIMEOUT_SECONDS", new_timeout), pytest.raises(
@@ -165,7 +165,7 @@ class TestMayaAdaptor_on_start:
         """
         # GIVEN
         adaptor = MayaAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
 
         with pytest.raises(RuntimeError) as exc_info:
             # WHEN
@@ -198,7 +198,7 @@ class TestMayaAdaptor_on_start:
             }
         )
 
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
 
         adaptor.on_start()
 
@@ -243,7 +243,7 @@ class TestMayaAdaptor_on_start:
             }
         )
 
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
 
         adaptor.on_start()
 
@@ -285,7 +285,7 @@ class TestMayaAdaptor_on_start:
                 destination_path="/destination",
             )
         ]
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         adaptor = MayaAdaptor(
             {
                 "renderer": renderer,
@@ -421,7 +421,7 @@ class TestMayaAdaptor_on_run:
         """Tests that on_run completes without error, and waits"""
         # GIVEN
         adaptor = MayaAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         # First side_effect value consumed by setter
         is_rendering_mock = PropertyMock(side_effect=[None, True, False])
         MayaAdaptor._is_rendering = is_rendering_mock
@@ -462,7 +462,7 @@ class TestMayaAdaptor_on_run:
         mock_maya_is_running.side_effect = [True, True, True, False, False]
         mock_logging_subprocess.return_value.returncode = 1
         adaptor = MayaAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         adaptor.on_start()
 
         # WHEN
@@ -491,7 +491,7 @@ class TestMayaAdaptor_on_run:
         """Tests that on_run completes without error, and waits"""
         # GIVEN
         adaptor = MayaAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         # First side_effect value consumed by setter
         is_rendering_mock = PropertyMock(side_effect=[None, True, False])
         MayaAdaptor._is_rendering = is_rendering_mock
@@ -526,7 +526,7 @@ class TestMayaAdaptor_on_stop:
         """Tests that on_stop completes without error"""
         # GIVEN
         adaptor = MayaAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         is_rendering_mock = PropertyMock(return_value=False)
         MayaAdaptor._is_rendering = is_rendering_mock
         adaptor.on_start()
@@ -605,7 +605,7 @@ class TestMayaAdaptor_on_cleanup:
         """Tests that on_stop completes without error"""
         # GIVEN
         adaptor = MayaAdaptor(init_data)
-        mock_server.return_value.socket_path = "/tmp/9999"
+        mock_server.return_value.server_path = "/tmp/9999"
         is_rendering_mock = PropertyMock(return_value=False)
         MayaAdaptor._is_rendering = is_rendering_mock
 

--- a/test/deadline_adaptor_for_maya/unit/MayaClient/test_client.py
+++ b/test/deadline_adaptor_for_maya/unit/MayaClient/test_client.py
@@ -12,12 +12,12 @@ class TestMayaClient:
     @patch("deadline.maya_adaptor.MayaClient.maya_client.HTTPClientInterface")
     def test_mayaclient(self, mock_httpclient: Mock) -> None:
         """Tests that the maya client can initialize, set a renderer and close"""
-        client = MayaClient(socket_path=str(9999))
+        client = MayaClient(server_path=str(9999))
         client.set_renderer({"renderer": "mayaSoftware"})
         client.close()
 
     @patch("deadline.maya_adaptor.MayaClient.maya_client.os.path.exists")
-    @patch.dict(os.environ, {"MAYA_ADAPTOR_SOCKET_PATH": "socket_path"})
+    @patch.dict(os.environ, {"MAYA_ADAPTOR_SERVER_PATH": "server_path"})
     @patch("deadline.maya_adaptor.MayaClient.MayaClient.poll")
     @patch("deadline.maya_adaptor.MayaClient.maya_client.HTTPClientInterface")
     def test_main(self, mock_httpclient: Mock, mock_poll: Mock, mock_exists: Mock) -> None:
@@ -29,7 +29,7 @@ class TestMayaClient:
         main()
 
         # THEN
-        mock_exists.assert_called_once_with("socket_path")
+        mock_exists.assert_called_once_with("server_path")
         mock_poll.assert_called_once()
 
     @patch.dict(os.environ, {}, clear=True)
@@ -43,11 +43,11 @@ class TestMayaClient:
         # THEN
         assert str(exc_info.value) == (
             "MayaClient cannot connect to the Adaptor because the environment variable "
-            "MAYA_ADAPTOR_SOCKET_PATH does not exist"
+            "MAYA_ADAPTOR_SERVER_PATH does not exist"
         )
         mock_poll.assert_not_called()
 
-    @patch.dict(os.environ, {"MAYA_ADAPTOR_SOCKET_PATH": "/a/path/that/does/not/exist"})
+    @patch.dict(os.environ, {"MAYA_ADAPTOR_SERVER_PATH": "/a/path/that/does/not/exist"})
     @patch("deadline.maya_adaptor.MayaClient.maya_client.os.path.exists")
     @patch("deadline.maya_adaptor.MayaClient.MayaClient.poll")
     def test_main_server_socket_not_exists(self, mock_poll: Mock, mock_exists: Mock) -> None:
@@ -60,10 +60,10 @@ class TestMayaClient:
             main()
 
         # THEN
-        mock_exists.assert_called_once_with(os.environ["MAYA_ADAPTOR_SOCKET_PATH"])
+        mock_exists.assert_called_once_with(os.environ["MAYA_ADAPTOR_SERVER_PATH"])
         assert str(exc_info.value) == (
             "MayaClient cannot connect to the Adaptor because the socket at the path defined by "
-            "the environment variable MAYA_ADAPTOR_SOCKET_PATH does not exist. Got: "
-            f"{os.environ['MAYA_ADAPTOR_SOCKET_PATH']}"
+            "the environment variable MAYA_ADAPTOR_SERVER_PATH does not exist. Got: "
+            f"{os.environ['MAYA_ADAPTOR_SERVER_PATH']}"
         )
         mock_poll.assert_not_called()


### PR DESCRIPTION
* The breaking change is due to updating the adaptor runtime dependency to 0.4

### What was the problem/requirement? (What/Why)

We have designed a new structure for how we lay out application interface adaptors into packages. In order to simplify the packaging step, we'll put a script that generates an artifact with that layout into each adaptor git repo.

In order to perform the layout we wanted, I needed to modify the adaptor runtime. Those changes are in https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/69

The adaptor runtime dependency was out of date, After updating, it required changes from a socket_path to a server_path parameter.

### What was the solution? (How)

- Create a script to build adaptor packaging artifacts that follow the structure we designed
- Also deprecate the binary name MayaAdaptor, and add the name maya-openjd
- Update the adaptor runtime dependency to 0.4, and fix up socket path into server path
- Update the submitter to provide both Rez and Conda packages metadata. The Rez package names are the same for now to keep backwards compatibility.

### What is the impact of this change?

The repo has a script that can generate a .tar archive containing a prefix layout of the adaptor python library and its dependencies, along with an entry point.

### How was this change tested?

The generated .tar archive was used to create a package, and that was tested on a Deadline Cloud farm.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes.

```

Timestamp: 2024-02-07T23:28:17.849524-08:00
Running job bundle output test: D:\deadline-clients\deadline-cloud-for-maya\job_bundle_output_tests\cube

cube
Test succeeded

Timestamp: 2024-02-07T23:28:18.498383-08:00
Running job bundle output test: D:\deadline-clients\deadline-cloud-for-maya\job_bundle_output_tests\layers

layers
Test succeeded

Timestamp: 2024-02-07T23:28:19.650601-08:00
Running job bundle output test: D:\deadline-clients\deadline-cloud-for-maya\job_bundle_output_tests\layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 3 total.
Timestamp: 2024-02-07T23:28:23.355375-08:00
```

### Was this change documented?

No

### Is this a breaking change?

Yes, it updates the openjd adaptor runtime dependency which had a breaking change.
