### PR TITLE
chore: add supported version to description

### DIFF
--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -1,7 +1,7 @@
 <component>
     <name>deadline_cloud_for_maya</name>
-    <description>Deadline Cloud for Maya</description>
-	<detailedDescription>Maya plugin for submitting jobs to Amazon Deadline Cloud.</detailedDescription>
+    <description>Deadline Cloud for Maya 2023-2024</description>
+	<detailedDescription>Maya plugin for submitting jobs to Amazon Deadline Cloud. Compatible with Maya 2023-2024.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -72,7 +72,8 @@
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_maya_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Maya
+			<value>Deadline Cloud for Maya 2023-2024
+- Compatible with Maya 2023-2024.
 - Install the integrated Maya submitter files to the installation directory.
 - Register the plug-in with Maya by creating or updating the MAYA_MODULE_PATH environment variable.</value>
 		</stringParameter>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
It was unclear at installation time what version(s) of the DCC the submitter will be available in.
### What was the solution? (How)
Explicitly call out which version(s) of the DCC the submitter will be available in.
### What is the impact of this change?
Less confusion when installing
### How was this change tested?
Built an installer, confirmed wording appeared accurate:
![image](https://github.com/casillas2/deadline-cloud-for-maya/assets/119458760/55c5765d-57e9-4a81-b96e-14c94d8683ab)

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, this doesn't affect the integration.

### Was this change documented?
No
### Is this a breaking change?
No