### PR TITLE
fix: properly fill out allowed values for camera job parameter

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -64,8 +64,8 @@ def _get_job_template(
     settings: RenderSubmitterUISettings,
     renderers: set[str],
     render_layers: list[RenderLayerData],
-    all_layer_selectable_cameras,
-    current_layer_selectable_cameras,
+    all_layer_selectable_cameras: list[str],
+    current_layer_selectable_cameras: list[str],
 ) -> dict[str, Any]:
     job_template = deepcopy(default_job_template)
 
@@ -177,10 +177,12 @@ def _get_job_template(
 
     # If we're rendering a specific camera, add the Camera job parameter
     if settings.camera_selection != ALL_CAMERAS:
+        selectable_cameras: list[str]
         if settings.render_layer_selection == LayerSelection.ALL:
             selectable_cameras = all_layer_selectable_cameras
         else:
             selectable_cameras = current_layer_selectable_cameras
+
         camera_param = {
             "name": "Camera",
             "type": "STRING",
@@ -502,20 +504,19 @@ def show_maya_render_submitter(parent, f=Qt.WindowFlags()) -> "Optional[SubmitJo
     render_layers.sort(key=lambda layer: layer.display_name)
 
     # Tell the settings tab the selectable cameras when only the current layer is in the job
-    current_layer_selectable_cameras = get_renderable_camera_names()
+    current_layer_selectable_cameras: list[str] = get_renderable_camera_names()
     render_settings.current_layer_selectable_cameras = [ALL_CAMERAS] + sorted(
         current_layer_selectable_cameras
     )
 
     # Tell the settings tab the selectable cameras when all layers are in the job
-    all_layer_selectable_cameras = set(render_layers[0].renderable_camera_names)
+    all_layer_selectable_cameras_set: set[str] = set(render_layers[0].renderable_camera_names)
     for layer in render_layers:
-        all_layer_selectable_cameras = all_layer_selectable_cameras.intersection(
+        all_layer_selectable_cameras_set = all_layer_selectable_cameras_set.intersection(
             layer.renderable_camera_names
         )
-    render_settings.all_layer_selectable_cameras = [ALL_CAMERAS] + sorted(
-        all_layer_selectable_cameras
-    )
+    all_layer_selectable_cameras: list[str] = list(sorted(all_layer_selectable_cameras_set))
+    render_settings.all_layer_selectable_cameras = [ALL_CAMERAS] + all_layer_selectable_cameras
 
     all_renderers: set[str] = {layer_data.renderer_name for layer_data in render_layers}
 
@@ -594,12 +595,12 @@ def show_maya_render_submitter(parent, f=Qt.WindowFlags()) -> "Optional[SubmitJo
         renderers: set[str] = {layer_data.renderer_name for layer_data in submit_render_layers}
 
         job_template = _get_job_template(
-            default_job_template,
-            settings,
-            renderers,
-            submit_render_layers,
-            all_layer_selectable_cameras,
-            current_layer_selectable_cameras,
+            default_job_template=default_job_template,
+            settings=settings,
+            renderers=renderers,
+            render_layers=submit_render_layers,
+            all_layer_selectable_cameras=all_layer_selectable_cameras,
+            current_layer_selectable_cameras=current_layer_selectable_cameras,
         )
         parameter_values = _get_parameter_values(
             settings, renderers, submit_render_layers, queue_parameters


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

If you select a specific camera, the job would fail to create:

```
// Error: deadline.client.ui.dialogs.submit_job_to_deadline_dialog : error submitting job
// Traceback (most recent call last):
//   File "/Users/morgane/dev/github/deadline-cloud-for-maya/plugin_env/scripts/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py", line 461, in on_submit
//     self.create_job_response = job_progress_dialog.start_submission(
//   File "/Users/morgane/dev/github/deadline-cloud-for-maya/plugin_env/scripts/deadline/client/ui/dialogs/submit_job_progress_dialog.py", line 126, in start_submission
//     self._start_submission()
//   File "/Users/morgane/dev/github/deadline-cloud-for-maya/plugin_env/scripts/deadline/client/ui/dialogs/submit_job_progress_dialog.py", line 193, in _start_submission
//     job_bundle_parameters = read_job_bundle_parameters(self._job_bundle_dir)
//   File "/Users/morgane/dev/github/deadline-cloud-for-maya/plugin_env/scripts/deadline/client/job_bundle/parameters.py", line 706, in read_job_bundle_parameters
//     return [
//   File "/Users/morgane/dev/github/deadline-cloud-for-maya/plugin_env/scripts/deadline/client/job_bundle/parameters.py", line 707, in <listcomp>
//     validate_job_parameter({"name": name, **values})
//   File "/Users/morgane/dev/github/deadline-cloud-for-maya/plugin_env/scripts/deadline/client/job_bundle/parameters.py", line 168, in validate_job_parameter
//     raise TypeError(
// TypeError: Job parameter "Camera" got set for "allowedValues" but expected list
```

and if you exported the job bundle, you'd end up with:

```
- name: Camera
  type: STRING
  userInterface:
    control: DROPDOWN_LIST
    groupLabel: Maya Settings
  description: Select which camera to render.
  allowedValues: !!set
    persp: null
```

So something is turning the renderable cameras into a set instead of a list.

I was actually able to reproduce this just by type hinting the `_get_job_template` function and running `hatch run lint`

```
src/deadline/maya_submitter/maya_render_submitter.py:601: error: Argument 5 to "_get_job_template" has incompatible type "set[str]";
expected "list[str]"  [arg-type]
                all_layer_selectable_cameras,
```


Problem 2
Also looks like the job bundle tests are now breaking on my machine since the populated value for including the `RenderSetupIncludeLights` is being set to False in all the job bundles. This appears to be a machine level setting which isn't all that nice since it'll break for users depending if they have a different set-up. Need to make it consistent for all users so that tests are repeatable

### What was the solution? (How)

I added some type hints, and cleaned up how we were handling `all_layer_selectable_cameras` which fixed the issue. 

For the second issue I added a context manager to set machine level options on test start, and re-apply the old settings when they finish (regardless of success/fail)

### What is the impact of this change?

Users can now select a camera to submit a job!

### How was this change tested?

```
hatch run fmt
hatch run lint
hatch build
hatch run test
```

the linting now passed. I then ran `hatch run install` from a WIP branch and verified that I could submit jobs by selecting a camera.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2024-02-26T21:48:55.448429-06:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2024-02-26T21:48:56.080044-06:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2024-02-26T21:48:56.385134-06:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 3 total.
Timestamp: 2024-02-26T21:48:58.872040-06:00

```

### Was this change documented?

N/A

### Is this a breaking change?

fixing :)
