### PR TITLE
ci: set release to watch mainline changelog

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -4,7 +4,7 @@ run-name: "Release: ${{ github.event.head_commit.message }}"
 on:
   push:
     branches:
-      - release
+      - mainline
     paths:
       - CHANGELOG.md
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
release: publish is not starting because its watching the wrong branch for changelog changes

### What was the solution? (How)
Change the branch from release to mainline

### What is the impact of this change?
release: publish will now start when changes to the mainline changelog are pushed.

### How was this change tested?
n/a

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
