### PR TITLE
feat: Add telemetry data to submitter and adaptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ You can download this package from:
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
+## Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.40.*",
+    "deadline == 0.41.*",
     "openjd-adaptor-runtime == 0.5.*",
 ]
 

--- a/src/deadline/maya_adaptor/MayaClient/maya_client.py
+++ b/src/deadline/maya_adaptor/MayaClient/maya_client.py
@@ -29,8 +29,10 @@ class MayaClient(HTTPClientInterface):
             }
         )
         import maya.standalone
+        import maya.cmds
 
         maya.standalone.initialize()
+        print(f"MayaClient: Maya Version {maya.cmds.about(version=True)}")
 
     def set_renderer(self, renderer: dict):
         render_handler = get_render_handler(renderer["renderer"])

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 
 import maya.cmds  # pylint: disable=import-error
 
+from deadline.client.api import get_deadline_cloud_library_telemetry_client
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint: disable=import-error
     SubmitJobToDeadlineDialog,
@@ -35,7 +36,7 @@ from .render_layers import (
     LayerSelection,
 )
 from .cameras import get_renderable_camera_names, ALL_CAMERAS
-from ._version import version_tuple as adaptor_version_tuple
+from ._version import version, version_tuple as adaptor_version_tuple
 from .ui.components.scene_settings_tab import SceneSettingsWidget
 from deadline.client.job_bundle.submission import AssetReferences
 
@@ -650,6 +651,13 @@ def show_maya_render_submitter(parent, f=Qt.WindowFlags()) -> "Optional[SubmitJo
     # Need Maya and the Maya OpenJD application interface adaptor
     rez_packages = f"mayaIO-{maya_version} deadline_cloud_for_maya"
     conda_packages = f"maya={maya_version}.* maya-openjd={adaptor_version}.*"
+    # Initialize telemetry client, opt-out is respected
+    get_deadline_cloud_library_telemetry_client().update_common_details(
+        {
+            "deadline-cloud-for-maya-submitter-version": version,
+            "maya-version": maya_version,
+        }
+    )
     # Add any additional renderers that are used
     if "arnold" in all_renderers:
         rez_packages += " mtoa"

--- a/test/deadline_submitter_for_maya/unit/scripts/test_utils.py
+++ b/test/deadline_submitter_for_maya/unit/scripts/test_utils.py
@@ -2,7 +2,9 @@
 
 import re
 
-from deadline.maya_submitter.utils import timed_func
+import pytest
+
+from deadline.maya_submitter.utils import join_paths, timed_func
 
 
 def test_timed_func(capsys):
@@ -33,3 +35,28 @@ def test_timed_func(capsys):
     )
     match = re.search(expected_re, output.out)
     assert match is not None
+
+
+@pytest.mark.parametrize(
+    ("first_path, second_path, expected_output"),
+    [
+        (
+            "test\\path",
+            "path\\",
+            "test/path/path/",
+        ),
+        (
+            "test",
+            "path",
+            "test/path",
+        ),
+        (
+            "test/path",
+            "path",
+            "test/path/path",
+        ),
+    ],
+)
+def test_join_paths(first_path: str, second_path: str, expected_output: str):
+    """Basic test to ensure backslash paths are replaced"""
+    assert join_paths(first_path, second_path) == expected_output


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We can't currently tell if anyone is using Maya submitters / adaptors

### What was the solution? (How)
Uses changes from https://github.com/casillas2/deadline-cloud/pull/205 to capture more package information when sending telemetry data, and changes from https://github.com/casillas2/deadline-cloud/pull/212 to opt out of telemetry from an environment variable.

### What is the impact of this change?
We can better tell how customers use our software and if they use Maya

### How was this change tested?
- ran the integrated submitter, and submitted a job, verifying it wrote telemetry (and didn't when opted out)
- ran the adaptor locally, confirming it wrote telemetry (and didn't when opted out)
- ran unit tests using deadline-cloud changes from mainline, they passed

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

N/A

### Was this change documented?

### Is this a breaking change?
