### PR TITLE
chore: update deadline-cloud dependency 0.45.0

### DIFF
--- a/maya_submitter_plugin/DeadlineCloudForMaya.mod
+++ b/maya_submitter_plugin/DeadlineCloudForMaya.mod
@@ -1,1 +1,1 @@
-+ deadline-cloud-for-maya 0.1.0 .
++ deadline-cloud-for-maya 0.13.2 .

--- a/maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py
+++ b/maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py
@@ -21,7 +21,7 @@ from deadline.maya_submitter import mel_commands, shelf  # type: ignore[import, 
 # Tells maya which version of their api to use.
 maya_useNewAPI = True
 VENDOR = "AWS"
-VERSION = "0.6.0"
+VERSION = "0.13.2"
 
 __log__ = logging.getLogger("Deadline")
 _registered_mel_commands: List[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.41.*",
-    "openjd-adaptor-runtime == 0.5.*",
+    "deadline == 0.45.*",
+    "openjd-adaptor-runtime == 0.6.*",
 ]
 
 [project.scripts]

--- a/test/deadline_submitter_for_maya/unit/__init__.py
+++ b/test/deadline_submitter_for_maya/unit/__init__.py
@@ -20,6 +20,10 @@ mock_modules = [
     "PySide2.QtGui",
     "PySide2.QtWidgets",
     "mtoa.core",
+    "qtpy",
+    "qtpy.QtCore",
+    "qtpy.QtWidgets",
+    "qtpy.QtGui",
     "deadline.maya_submitter.ui.render_submitter",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Out of date dependency of the deadline-cloud client lib
### What was the solution? (How)
update dependency
### What is the impact of this change?
qtpy changes in deadline-cloud will be available in submitters
### How was this change tested?
`hatch build` and `hatch run test`
### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?

### Is this a breaking change?
no