### PR TITLE
fix: catch import errors, link to libssl issue

### DIFF
--- a/test/deadline_submitter_for_maya/unit/plugins/test_deadline_submitter_maya.py
+++ b/test/deadline_submitter_for_maya/unit/plugins/test_deadline_submitter_maya.py
@@ -13,6 +13,7 @@ import pytest
 import deadline
 from deadline.maya_submitter import maya_render_submitter
 from deadline.maya_submitter import mel_commands
+from deadline.maya_submitter import shelf
 import DeadlineCloudForMaya
 
 Command = namedtuple("Command", ["name", "cmdCreator"])  # Mock Command Class
@@ -36,7 +37,7 @@ def test_reload_modules(mock_reload: Mock) -> None:
 @patch.object(om.MGlobal, "mayaState")
 @patch.object(om, "MFnPlugin")
 @patch.object(DeadlineCloudForMaya, "reload")
-@patch.object(deadline.maya_submitter.shelf, "build_shelf")
+@patch.object(shelf, "build_shelf")
 @patch.dict(os.environ, {"DEADLINE_ENABLE_DEVELOPER_OPTIONS": "False"})
 def test_initialize_and_uninitialize_plugin(
     mock_build_shelf: Mock,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The maya submitter was failing to load due to some missing links to libraries included in the maya installation. This was a bit troublesome to debug so we should provide a helpful error message so customers know what to do.

### What was the solution? (How)
Move the deadline import so that we can catch it and warn properly.

### What is the impact of this change?
Customers will have an idea of how to fix their setup in order to load the submitter

### How was this change tested?
Tested on a RHEL 9 machine and observed the following message pop-up when trying loading the submitter plugin
![image](https://github.com/casillas2/deadline-cloud-for-maya/assets/119458760/ad810c8b-b524-44cb-a416-5fb1aba3c4ae)


### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, this does not change submission code.

### Is this a breaking change?
No