### PR TITLE
docs: update readme

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,20 +1,51 @@
-# AWS Deadline Cloud for Maya Development
+# Development documentation
 
-**You will need to have your runtimes set up via `asdf` or `pyenv` to match your build platform to
-use `./build.sh` similarly to your build platform**
+This package has two active branches:
 
-## Building
+- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
+- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
 
-The build logic runs in `build.sh` which is relatively short
-and straightforward enough that we recommend you read it directly to update/modify your build process.
+## Build / Test / Release
 
-## Adding Dependencies
+### Build the package
 
-All of the testing and development dependencies are in the `setup.cfg` and are meant to be included idiomatically.
+```bash
+hatch build
+```
 
-## Testing
+### Run tests
 
-`./build.sh` will build and run `pytest`.
+```bash
+hatch run test
+```
+
+### Run linting
+
+```bash
+hatch run lint
+```
+
+### Run formatting
+
+```bash
+hatch run fmt
+```
+
+### Run tests for all supported Python versions
+
+```bash
+hatch run all:test
+```
+
+## Use development Submitter in Maya
+
+```bash
+hatch run install
+hatch shell
+```
+Then launch Maya from that terminal.
+
+A development version of deadline-cloud-for-maya is then available to be loaded.
 
 ## Submitter Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -1,64 +1,51 @@
+[![pypi](https://img.shields.io/pypi/v/deadline-cloud-for-maya.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-maya)
+[![python](https://img.shields.io/pypi/pyversions/deadline-cloud-for-maya.svg?style=flat)](https://pypi.python.org/pypi/deadline-cloud-for-maya)
+[![license](https://img.shields.io/pypi/l/deadline-cloud-for-maya.svg?style=flat)](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/LICENSE)
+
 # AWS Deadline Cloud for Maya
 
-This package has two active branches:
+AWS Deadline Cloud for Maya is a python package that allows users to create [AWS Deadline Cloud][deadline-cloud] jobs from within Maya. Using the [Open Job Description (OpenJD) Adaptor Runtime][openjd-adaptor-runtime] this package also provides a command line application that adapts Maya's command line interface to support the [OpenJD specification][openjd].
 
-- `mainline` -- For active development. This branch is not intended to be consumed by other packages. Any commit to this branch may break APIs, dependencies, and so on, and thus break any consumer without notice.
-- `release` -- The official release of the package intended for consumers. Any breaking releases will be accompanied with an increase to this package's interface version.
-
-The deadline.maya_adaptor package is an adaptor that renders maya scenes through MayaPy. It uses the Open Job Description adaptor_runtime and supports job stickiness.
-
-## Development
-
-See [DEVELOPMENT](DEVELOPMENT.md) for more information.
-
-## Build / Test / Release
-
-### Build the package
-
-```bash
-hatch build
-```
-
-### Run tests
-
-```bash
-hatch run test
-```
-
-### Run linting
-
-```bash
-hatch run lint
-```
-
-### Run formatting
-
-```bash
-hatch run fmt
-```
-
-### Run tests for all supported Python versions
-
-```bash
-hatch run all:test
-```
-
-## Use development Submitter in Maya
-
-```bash
-hatch run install
-hatch shell
-```
-Then launch Maya from that terminal.
-
-A development version of deadline-cloud-for-maya is then available to be loaded.
+[deadline-cloud]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/what-is-deadline-cloud.html
+[deadline-cloud-client]: https://github.com/casillas2/deadline-cloud
+[openjd]: https://github.com/OpenJobDescription/openjd-specifications/wiki
+[openjd-adaptor-runtime]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python
+[openjd-adaptor-runtime-lifecycle]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/blob/release/README.md#adaptor-lifecycle
 
 ## Compatibility
 
 This library requires:
 
+1. Maya 2023 - 2024,
 1. Python 3.9 or higher; and
-2. Linux, MacOS, or Windows operating system.
+1. Linux, Windows, or a macOS operating system.
+
+## Submitter
+
+This package provides a Maya plugin that creates jobs for AWS Deadline Cloud using the [AWS Deadline Cloud client library][deadline-cloud-client]. Based on the loaded scene it determines the files required, allows the user to specify render options, and builds an [OpenJD template][openjd] that defines the workflow.
+
+## Adaptor
+
+The Maya Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch Maya and feed it commands. This gives the following benefits:
+* a standardized render application interface,
+* sticky rendering, where the application stays open between tasks,
+* path mapping, that enables cross-platform rendering
+
+Jobs created by the submitter use this adaptor by default.
+
+### Getting Started
+
+The adaptor can be installed by the standard python packaging mechanisms:
+```sh
+$ pip install deadline-cloud-for-maya
+```
+
+After installation it can then be used as a command line tool:
+```sh
+$ maya-openjd --help
+```
+
+For more information on the commands the OpenJD adaptor runtime provides, see [here][openjd-adaptor-runtime-lifecycle].
 
 ## Versioning
 
@@ -70,25 +57,13 @@ versions will increment during this initial development stage, they are describe
 2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
 3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
 
-## Downloading
-
-You can download this package from:
-- [GitHub releases](https://github.com/casillas2/deadline-cloud-for-maya/releases)
-
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/release/CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## Telemetry
 
-This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
-
-You can opt out of telemetry data collection by either:
-
-1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
-2. Setting the config file: `deadline config set telemetry.opt_out true`
-
-Note that setting the environment variable supersedes the config file setting.
+See [telemetry](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/release/docs/telemetry.md) for more information.
 
 ## License
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,10 @@
+# Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We are preparing for the first public release which includes publishing our distribution artifacts to PyPI. The description of the package on PyPI will include the `README.md` contents of this repository. Any links in the `README.md` that are relative need to be made absolute since they will not resolve correctly on PyPI. When choosing the absolute link, the link must refer to the correct branch (`mainline` vs `release`) depending on the context of the link.

Additionally, once the repository becomes public, visitors will be looking for basic information about the project such as:

*   what is it?
*   what can it be used for?
*   how can it be used and operated?
*   how can people interact with the project?

### What was the solution? (How)

* Wrote it in VSCode with .md rendering
* view in Github rendering

### What is the impact of this change?

Readers landing on our published PyPI and GitHub pages will have a more clear and curated introduction to the project, emphasizing why they might find it important and providing information to help them get started using it and contributing to it.

### How was this change tested?

*   Using Visual Studio Code's markdown preview feature
*   Reviewing GitHub's markdown rendered version

### Was this change documented?

This change is documentation :)

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
