### PR TITLE
fix: adaptor wheel override

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -291,12 +291,6 @@ def _get_job_template(
                 + f"Actual: {wheels_path_package_names}"
             )
 
-        override_adaptor_wheels_param = [
-            param
-            for param in override_environment["parameterDefinitions"]
-            if param["name"] == "OverrideAdaptorWheels"
-        ][0]
-        override_adaptor_wheels_param["default"] = str(wheels_path)
         override_adaptor_name_param = [
             param
             for param in override_environment["parameterDefinitions"]
@@ -418,6 +412,9 @@ def _get_parameter_values(
 
     # If we're overriding the adaptor with wheels, remove the adaptor from the Packages parameters
     if settings.include_adaptor_wheels:
+        wheels_path = str(Path(__file__).parent.parent.parent.parent / "wheels")
+        parameter_values.append({"name": "OverrideAdaptorWheels", "value": wheels_path})
+
         rez_param = {}
         conda_param = {}
         # Find the Packages parameter definition


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The adaptor wheel override was broken by a [change](https://github.com/aws-deadline/deadline-cloud/pull/171) in deadline-cloud which made it so that PATH Job Parameter defaults can't be absolute paths. The way the adaptor wheel directory was being added to the template was by adding in a new job parameter with a default value of what was specified by the user. This would result in an error like below on submission:

### What was the solution? (How)

Remove the setting of the default value of the AdaptorWheel Job Parameter and instead set it when the other Job Parameters.

### What is the impact of this change?

The adaptor wheel override works again

### How was this change tested?

Tested with and without the adaptor wheel override set and verified in the jobs that were run that the adaptors were overridden or not.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
