### PR TITLE
chore(installer): Fixed install script dependency parsing

### DIFF
--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -32,26 +32,15 @@ def get_project_dict(project_path: Optional[Path] = None) -> dict[str, Any]:
 
 class Dependency:
     name: str
-    operator: Optional[str]
-    version: Optional[str]
+    spec: str
 
     def __init__(self, dep: str):
         components = dep.split(" ")
         self.name = components[0]
-        if len(components) > 2:
-            self.operator = components[1]
-            self.version = components[2]
-        else:
-            self.operator = None
-            self.version = None
-
-    def for_pip(self) -> str:
-        if self.operator is not None and self.version is not None:
-            return f"{self.name}{self.operator}{self.version}"
-        return self.name
+        self.spec = dep
 
     def __repr__(self) -> str:
-        return self.for_pip()
+        return self.spec
 
 
 def get_dependencies(pyproject_dict: dict[str, Any], include_adaptor=True) -> list[Dependency]:

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -80,9 +80,14 @@ def _resolve_dependencies(local_deps: list[Path]) -> dict[str, str]:
     args = [
         "pipgrip",
         "--json",
-        *[dep.for_pip() for dep in flattened_dependency_list],
+        *[dep.spec for dep in flattened_dependency_list],
     ]
-    result = subprocess.run(args, check=True, capture_output=True, text=True)
+    try:
+        result = subprocess.run(args, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(e.stderr)
+        print(e.stdout)
+        raise
     return json.loads(result.stdout)
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The dependency parsing in the install script was too simplistic and was failing with certain dependencies of deadline-cloud when using it as a local dependency.

### What was the solution? (How)

Stop trying to parse the dependencies and just pass through the dependency string.

### What is the impact of this change?

The install script works when using deadline-cloud as a local-dep

### How was this change tested?

Ran the install script and it worked.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Not applicable to this change.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
