### PR TITLE
chore: add changelog url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/aws-deadline/deadline-cloud-for-maya"
 Source = "https://github.com/aws-deadline/deadline-cloud-for-maya"
+Changelog = "https://github.com/aws-deadline/deadline-cloud-for-maya/blob/release/CHANGELOG.md"
 
 [project.scripts]
 maya-openjd = "deadline.maya_adaptor.MayaAdaptor:main"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We weren't linking to our changelog. Ie. look at our pypi entry in the bottom left

![image](https://github.com/user-attachments/assets/bdad64af-a85c-4976-a842-0b33a1279432)


### What was the solution? (How)

Add changelog: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

I chose the release branch, because our release process is what actually modifies the changelog

### What is the impact of this change?

It should show up on Pypi (and hopefully pypi's RSS feed!)

### How was this change tested?

N/A

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

N/A

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
