### PR TITLE
ci: package and publish the Maya plugin to the GitHub release

### DIFF
--- a/.github/actions/bump_precommit_hook/action.yaml
+++ b/.github/actions/bump_precommit_hook/action.yaml
@@ -1,0 +1,14 @@
+
+inputs:
+  semver:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Update plugin Version
+    run: |
+      echo "+ deadline-cloud-for-maya ${{inputs.semver}} ." > ./maya_submitter_plugin/DeadlineCloudForMaya.mod
+
+      git add ./maya_submitter_plugin/DeadlineCloudForMaya.mod

--- a/.github/actions/prepush_release_hook/action.yaml
+++ b/.github/actions/prepush_release_hook/action.yaml
@@ -1,0 +1,18 @@
+
+inputs:
+  semver:
+    required: true
+    type: string
+  tag:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Zip submitter plugin
+    run: |
+      mkdir dist_extras
+      cd maya_submitter_plugin 
+      zip -r  ../dist_extras/maya_submitter_plugin_${{inputs.semver}}.zip .
+      cd ..

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
+/dist_extras
 *.egg-info/
 __pycache__/
 .coverage


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The actual plugin files for the Maya submitter:
1. Are not having their version number modified when we release a new version of the submitter; and
2. Are not made available to customers other than by requiring that they git clone the release branch of this repository.

### What was the solution? (How)

Modify the GitHub workflows to:
1. Overwrite the DeadlineCloudForMaya.mod file with the correct version during creation of the bump PR; and
2. Zip the contents of the maya_submitter_plugin directory into the dist_extras/ directory during the actual release workflow. The shared release workflow has been modified in the .github repository to publish all files in dist_extras/ to the GitHub release page.

### What is the impact of this change?

With this change, we can have instructions for how to install the Maya submitter in the package README that looks like:

1. Install the submitter support files into Maya using mayapy. Reference the Maya online documentation to find the location of mayapy on your system. e.g. For Maya 2024: https://help.autodesk.com/view/MAYAUL/2024/ENU/?guid=GUID-72A245EC-CDB4-46AB-BEE0-4BBBF9791627 Follow the instructions in Maya's official online documentation to install the `deadline-cloud-for-maya` Python library and its dependencies to be available to Maya. For example, to install in Maya's default global location: 
```
mayapy -m pip install deadline-cloud-for-maya --upgrade
```
2. Download the appropriate version of the maya_submitter_plugin.zip file from the GitHub release for this package.
3. Unzip the maya_submitter_plugin into the location of your MAYA_MODULE_PATH. See the Maya online documentation on "File path variables". e.g. For Maya 2024 https://help.autodesk.com/view/MAYAUL/2024/ENU/?guid=GUID-228CCA33-4AFE-4380-8C3D-18D23F7EAC72

### How was this change tested?

I believe the only way to test it is in live. I've tested out the packaging and .mod file generation commands manually outside of the GitHub action workflow.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

N/A

### Was this change documented?

N/A

### Is this a breaking change?

It it not intended to be so.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
