### PR TITLE
ci: add bash shell to bump and release actions

### DIFF
--- a/.github/actions/bump_precommit_hook/action.yaml
+++ b/.github/actions/bump_precommit_hook/action.yaml
@@ -8,6 +8,7 @@ runs:
   using: composite
   steps:
   - name: Update plugin Version
+    shell: bash
     run: |
       echo "+ deadline-cloud-for-maya ${{inputs.semver}} ." > ./maya_submitter_plugin/DeadlineCloudForMaya.mod
       sed -i "s/^VERSION =.*/VERSION = \"${{inputs.semver}}\"/" ./maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py

--- a/.github/actions/prepush_release_hook/action.yaml
+++ b/.github/actions/prepush_release_hook/action.yaml
@@ -11,6 +11,7 @@ runs:
   using: composite
   steps:
   - name: Zip submitter plugin
+    shell: bash
     run: |
       mkdir dist_extras
       cd maya_submitter_plugin 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A shell needs to be specified for the bump and release hook actions

### What was the solution? (How)
Specify bash for the shell

### What is the impact of this change?
allows actions to run shell commands

### How was this change tested?
Yes, in a developer github account


### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Not required, this is a CI change.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
