### PR TITLE
fix(adaptor): import HTTPClientInterface correctly on Windows

### DIFF
--- a/src/deadline/maya_adaptor/MayaClient/maya_client.py
+++ b/src/deadline/maya_adaptor/MayaClient/maya_client.py
@@ -10,11 +10,20 @@ from typing import Optional
 # so that importing just the adaptor_runtime_client should work.
 try:
     from adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
+except (ImportError, ModuleNotFoundError):
+    try:
+        from openjd.adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
+    except (ImportError, ModuleNotFoundError):
+        # TODO: Remove this try/except once we bump to openjd.adaptor_runtime_client 0.9+
+        # On Windows, HTTPClientInterface is not available, only ClientInterface
+        from openjd.adaptor_runtime_client import ClientInterface as HTTPClientInterface  # type: ignore[import]
+
+
+try:
     from maya_adaptor.MayaClient.render_handlers import (  # type: ignore[import]
         get_render_handler,
     )
 except (ImportError, ModuleNotFoundError):
-    from openjd.adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
     from deadline.maya_adaptor.MayaClient.render_handlers import (  # type: ignore[import]
         get_render_handler,
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Maya adaptor does not work on Windows and crashes with an ImportError, stack trace below:

```
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: INFO: Running command: mayapy "C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\deadline\maya_adaptor\MayaClient\maya_client.py"
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR: Traceback (most recent call last):
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR:   File "C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\deadline\maya_adaptor\MayaClient\maya_client.py", line 12, in <module>
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR:     from adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR: ImportError: cannot import name 'HTTPClientInterface' from 'adaptor_runtime_client' (C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\openjd\adaptor_runtime_client\__init__.py)
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR: 
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR: During handling of the above exception, another exception occurred:
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR: 
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR: Traceback (most recent call last):
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR:   File "C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\deadline\maya_adaptor\MayaClient\maya_client.py", line 17, in <module>
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR:     from openjd.adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: STDERR: ImportError: cannot import name 'HTTPClientInterface' from 'openjd.adaptor_runtime_client' (C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\openjd\adaptor_runtime_client\__init__.py)
2024/10/16 17:55:12-07:00 ADAPTOR_OUTPUT: INFO: Deadline Cloud telemetry is enabled.
2024/10/16 17:55:12-07:00 openjd_fail: Error encountered while starting adaptor: Maya encountered an error and was not able to complete initialization actions.
2024/10/16 17:55:12-07:00 ERROR: Entrypoint failed: INFO: Creating Named Pipe with name: \\.\pipe\AdaptorServerNamedPipe_8492
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 INFO: Running command: mayapy "C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\deadline\maya_adaptor\MayaClient\maya_client.py"
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR: Traceback (most recent call last):
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR:   File "C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\deadline\maya_adaptor\MayaClient\maya_client.py", line 12, in <module>
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR:     from adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR: ImportError: cannot import name 'HTTPClientInterface' from 'adaptor_runtime_client' (C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\openjd\adaptor_runtime_client\__init__.py)
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR: 
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR: During handling of the above exception, another exception occurred:
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR: 
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR: Traceback (most recent call last):
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR:   File "C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\deadline\maya_adaptor\MayaClient\maya_client.py", line 17, in <module>
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR:     from openjd.adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
2024/10/16 17:55:12-07:00  
2024/10/16 17:55:12-07:00 STDERR: ImportError: cannot import name 'HTTPClientInterface' from 'openjd.adaptor_runtime_client' (C:\Program Files\Autodesk\MayaIO2024\Python\lib\site-packages\openjd\adaptor_runtime_client\__init__.py)
```

### What was the solution? (How)

Fix the ImportError by importing the correct name

### What is the impact of this change?

The ImportError is fixed and the adaptor works on Windows

### How was this change tested?

Manual testing with a Windows CMF worker and a job submitted via the submitter

- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, I did manual testing to confirm. This is an adaptor only change.

### Was this change documented?

No, it is not needed

### Is this a breaking change?

No, it is backwards compatible

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
