### PR TITLE
fix: include description in job submission

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -70,8 +70,10 @@ def _get_job_template(
 ) -> dict[str, Any]:
     job_template = deepcopy(default_job_template)
 
-    # Set the job's name
+    # Set the job's name and description
     job_template["name"] = settings.name
+    if settings.description:
+        job_template["description"] = settings.description
 
     # If there are multiple frame ranges, split up the Frames parameter by layer
     if render_layers[0].frames_parameter_name:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
* Maya job submissions were not including the description field, even when filled out in the submitter UI.

### What was the solution? (How)
* Include the description

### What is the impact of this change?
* Jobs submitted with the maya submitter will include the description when populated

### How was this change tested?
Ran the submitter with a local installation of Maya and verified newly submitted jobs include the description field in the Deadline Cloud Monitor.

- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2024-10-24T11:20:44.903849-07:00
Running job bundle output test: /Users/larbe/github/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2024-10-24T11:20:46.045940-07:00
Running job bundle output test: /Users/larbe/github/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2024-10-24T11:20:46.501578-07:00
Running job bundle output test: /Users/larbe/github/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2024-10-24T11:20:46.501665-07:00
Running job bundle output test: /Users/larbe/github/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2024-10-24T11:20:47.150117-07:00
Running job bundle output test: /Users/larbe/github/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2024-10-24T11:20:54.336125-07:00
```

### Was this change documented?
N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
