### PR TITLE
fix: frame override checkbox does not enable frame list in Maya 2025

### DIFF
--- a/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
@@ -200,4 +200,4 @@ class SceneSettingsWidget(QWidget):
         """
         Set the activated/deactivated status of the Frame override text box
         """
-        self.frame_override_txt.setEnabled(state == Qt.Checked)
+        self.frame_override_txt.setEnabled(Qt.CheckState(state) == Qt.Checked)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Maya 2025 support was just added that uses PySide6. PySide6 changed how they handle enum values: https://doc.qt.io/qtforpython-6/considerations.html#the-new-python-enums. So the way we're checking does not enable the frame list properly.

### What was the solution? (How)

PR for inspiration: https://github.com/aws-deadline/deadline-cloud-for-blender/pull/90

### What is the impact of this change?

It works!

### How was this change tested?

```
hatch run lint
hatch run test
```

Will test manually first before merging.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

N/A, this is for the UI, not the job bundles.

### Was this change documented?

N/A

### Is this a breaking change?

Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
