### PR TITLE
fix: maya 2025 submitter failed to load due to qt setMargin being removed

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/depsBundle.py
+++ b/depsBundle.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
-SUPPORTED_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
 SUPPORTED_PLATFORMS = ["win_amd64", "manylinux2014_x86_64", "macosx_10_9_x86_64"]
 NATIVE_DEPENDENCIES = ["xxhash"]
 

--- a/job_bundle_output_tests/cube/scene/cube.ma
+++ b/job_bundle_output_tests/cube/scene/cube.ma
@@ -113,6 +113,7 @@ createNode renderLayer -n "defaultRenderLayer";
 	setAttr ".g" yes;
 createNode aiOptions -s -n "defaultArnoldRenderOptions";
 	rename -uid "6B7909BC-4FCB-0BB1-D4A7-5296F3C7DA96";
+	setAttr ".abort_on_license_fail" yes;
 	setAttr ".version" -type "string" "5.1.0";
 createNode aiAOVFilter -s -n "defaultArnoldFilter";
 	rename -uid "DFD4CBFF-4AFB-E12B-F851-6689C247A620";

--- a/job_bundle_output_tests/layers/scene/layers.ma
+++ b/job_bundle_output_tests/layers/scene/layers.ma
@@ -176,6 +176,7 @@ createNode renderLayer -n "defaultRenderLayer";
 	setAttr ".adjs[0].val" 0;
 createNode aiOptions -s -n "defaultArnoldRenderOptions";
 	rename -uid "6EBFD1EE-4AF3-6A01-F40D-2E8896F9ED86";
+	setAttr ".abort_on_license_fail" no;
 	setAttr ".version" -type "string" "5.1.0";
 createNode aiAOVFilter -s -n "defaultArnoldFilter";
 	rename -uid "19DDC798-46DC-CE52-B92C-88A1CF1F111E";

--- a/job_bundle_output_tests/layers_no_variation/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/layers_no_variation/expected_job_bundle/parameter_values.yaml
@@ -16,7 +16,7 @@ parameterValues:
 - name: RenderSetupIncludeLights
   value: 'true'
 - name: ArnoldErrorOnLicenseFailure
-  value: 'false'
+  value: 'true'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/layers_no_variation/scene/layers_no_variation.ma
+++ b/job_bundle_output_tests/layers_no_variation/scene/layers_no_variation.ma
@@ -123,6 +123,7 @@ createNode renderLayer -n "defaultRenderLayer";
 	setAttr ".g" yes;
 createNode aiOptions -s -n "defaultArnoldRenderOptions";
 	rename -uid "59A3EEE2-49F1-07DE-4FDD-8EBEB0A6DD31";
+	setAttr ".abort_on_license_fail" yes;
 	setAttr ".version" -type "string" "5.1.0";
 createNode aiAOVFilter -s -n "defaultArnoldFilter";
 	rename -uid "96D5B79B-41E5-8DA7-2D18-E3A4482B2713";

--- a/job_bundle_output_tests/referenced_layers/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/referenced_layers/expected_job_bundle/parameter_values.yaml
@@ -16,7 +16,7 @@ parameterValues:
 - name: RenderSetupIncludeLights
   value: 'true'
 - name: ArnoldErrorOnLicenseFailure
-  value: 'false'
+  value: 'true'
 - name: deadline:targetTaskRunStatus
   value: READY
 - name: deadline:maxFailedTasksCount

--- a/job_bundle_output_tests/referenced_layers/scene/referenced_layers.ma
+++ b/job_bundle_output_tests/referenced_layers/scene/referenced_layers.ma
@@ -109,6 +109,7 @@ createNode renderLayer -n "defaultRenderLayer";
 	setAttr ".g" yes;
 createNode aiOptions -s -n "defaultArnoldRenderOptions";
 	rename -uid "9A138AC0-0948-F5B6-6486-93B7C51BB0B6";
+	setAttr ".abort_on_license_fail" yes;
 	setAttr ".version" -type "string" "5.1.0";
 createNode aiAOVFilter -s -n "defaultArnoldFilter";
 	rename -uid "34BABCDD-D041-35C1-8012-4E91D4182313";

--- a/job_bundle_output_tests/referenced_layers/scene/scene_file_to_reference.ma
+++ b/job_bundle_output_tests/referenced_layers/scene/scene_file_to_reference.ma
@@ -100,6 +100,7 @@ createNode renderLayer -n "defaultRenderLayer";
 	setAttr ".g" yes;
 createNode aiOptions -s -n "defaultArnoldRenderOptions";
 	rename -uid "1F4DD6D2-4959-340B-8B09-9C999ED675EF";
+	setAttr ".abort_on_license_fail" yes;
 	setAttr ".version" -type "string" "5.1.0";
 createNode aiAOVFilter -s -n "defaultArnoldFilter";
 	rename -uid "B8FC15B5-4212-07EC-0570-A6BE7223DC9B";

--- a/job_bundle_output_tests/renderman/scene/renderman.ma
+++ b/job_bundle_output_tests/renderman/scene/renderman.ma
@@ -264,6 +264,7 @@ createNode renderLayer -n "defaultRenderLayer";
 	setAttr ".g" yes;
 createNode aiOptions -s -n "defaultArnoldRenderOptions";
 	rename -uid "6B7909BC-4FCB-0BB1-D4A7-5296F3C7DA96";
+	setAttr ".abort_on_license_fail" yes;
 	setAttr ".version" -type "string" "5.1.0";
 createNode aiAOVFilter -s -n "defaultArnoldFilter";
 	rename -uid "DFD4CBFF-4AFB-E12B-F851-6689C247A620";

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -18,6 +18,7 @@ class MayaVersion:
     PYTHON_VERSIONS = {
         "2023": "3.9",
         "2024": "3.10",
+        "2025": "3.11",
     }
 
     def __init__(self, arg_version: Optional[str]):
@@ -107,13 +108,27 @@ def _build_deps_env(destination: Path, python_version: str, local_deps: list[Pat
         "install",
         "--target",
         str(destination),
-        "--platform",
-        get_pip_platform(platform.system()),
         "--python-version",
         python_version,
         "--only-binary=:all:",
         *resolved_dependencies,
     ]
+    if python_version == "3.9":
+        # maya 2023 on mac relies on rosetta
+        # should probably swap to maya's pip to avoid specifying platform
+        args = [
+            "pip",
+            "install",
+            "--target",
+            str(destination),
+            "--platform",
+            get_pip_platform(platform.system()),
+            "--python-version",
+            python_version,
+            "--only-binary=:all:",
+            *resolved_dependencies,
+        ]
+
     subprocess.run(args, check=True)
 
 

--- a/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
@@ -40,7 +40,6 @@ class FileSearchLineEdit(QWidget):
 
         lyt = QHBoxLayout(self)
         lyt.setContentsMargins(0, 0, 0, 0)
-        lyt.setMargin(0)
 
         self.edit = QLineEdit(self)
         self.btn = QPushButton("...", parent=self)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Tried submiting jobs from Maya 2025 and ran into a stack trace when loading the scene settings tab. PySide6 was complaining that setMargin no longer exists.

It was deprecated in qt5, and removed in qt6

ref: https://doc.qt.io/qt-5/qlayout-obsolete.html#setMargin

### What was the solution? (How)

Recommendation is to use setContentsMargin instead, which we already were. So I've deleted the problematic line.

I've also updated the dev install (`hatch run install`) to support Maya 2025 which uses python 3.11. On macOS, 2023 was the last year that relied on rosetta, so I've fixed the dependencies discovery for it.

### What is the impact of this change?

Maya 2025 can launch and submit jobs!

### How was this change tested?

Admittedly, I did not test the render. 

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

But I did test the job bundle output tests. Looks like arnold now defaults to true for failing on missing licenses, so I'm now forcibly setting the option in the scenes we have. We probably need to add the ability to differentiate expected output per version.

```

Timestamp: 2024-10-30T15:50:50.623033-05:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2024-10-30T15:50:51.401506-05:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2024-10-30T15:50:51.746398-05:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2024-10-30T15:50:51.746537-05:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2024-10-30T15:50:52.042350-05:00
Running job bundle output test: /Users/morgane/dev/github/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2024-10-30T15:50:54.232503-05:00
```

### Was this change documented?

Yes

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
