### PR TITLE
chore: Update to only use OpenMaya 2.0, remove references to 1.0

### DIFF
--- a/src/deadline/maya_submitter/logging.py
+++ b/src/deadline/maya_submitter/logging.py
@@ -11,7 +11,7 @@ import os
 import tempfile
 from typing import Any
 
-import maya.OpenMaya as om  # type: ignore # pylint: disable=import-error
+import maya.api.OpenMaya as om  # type: ignore # pylint: disable=import-error
 
 DEBUG = logging.DEBUG
 INFO = logging.INFO

--- a/test/deadline_submitter_for_maya/unit/__init__.py
+++ b/test/deadline_submitter_for_maya/unit/__init__.py
@@ -12,7 +12,6 @@ mock_modules = [
     "maya.app.renderSetup.model.renderSetupPreferences",
     "maya.app.general.fileTexturePathResolver",
     "maya.app.general.mayaMixin",
-    "maya.OpenMaya",
     "maya.cmds",
     "maya.utils",
     "PySide2",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I encountered errors about `maya.OpenMaya` in Maya 2025. This should work, so is likely an issue in the installation, but it's better not to mix OpenMaya 1.0 and 2.0, we can switch it fully to use 2.0

### What was the solution? (How)

Change it to only use `maya.api.OpenMaya`, also known as OpenMaya 2.0.

### What is the impact of this change?

The code only uses the new API, not the old one.

### How was this change tested?

In progress testing...

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, this change is in the adaptor side, not the submitter side that these tests cover.

### Was this change documented?

No change to functionality.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
