### PR TITLE
chore: Upgrade deadline-cloud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.48.*",
+    "deadline == 0.49.*",
     "openjd-adaptor-runtime == 0.8.*",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A new minor version of `deadline-cloud` was recently released. However, `deadline-cloud-for-maya` is anchored to the previous version.

### What was the solution? (How)
* Update the dependencies configuration to use deadline 0.49.

### What is the impact of this change?
Use latest dependency.

### How was this change tested?
* `hatch build`
* `hatch run test`
* This change will be tested more thoroughly as part of the release tests.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No. Will do e2e testing as part of the release.

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
