### PR TITLE
fix(submitter): read includeAllLights setting correctly

### DIFF
--- a/src/deadline/maya_submitter/render_layers.py
+++ b/src/deadline/maya_submitter/render_layers.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from enum import IntEnum
 from typing import List
 
+import maya.app.renderSetup.model.renderSetupPreferences as renderSetupPrefs  # type: ignore
 import maya.cmds
 import maya.mel
 
@@ -64,8 +65,10 @@ def render_setup_include_all_lights() -> bool:
     Returns whether a Render Layer should contain all lights in the scene automatically
     (machine level setting)
     """
-    # The maya.cmds.optionVar query did not work
-    return bool(maya.mel.eval("optionVar -q renderSetup_includeAllLights"))
+    try:
+        return renderSetupPrefs.IncludeAllLightsSetting.isEnabled()
+    except AttributeError:
+        return True
 
 
 @contextmanager


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/206

### What was the problem/requirement? (What/Why)

The IncludeAllLights by default setting for render layers is not being captured correctly by the submitter. The current implementation queries if the corresponding optionVar is set, however if it is not set, then it treats the value as false, even if the actual check box is checked. This value is fed into the `RenderSetupIncludeLights` job parameter which is used by the adaptor to enable/disable the feature for all render layers. This causes confusion when renders submitted to Deadline Cloud return images with incorrect lighting that cannot be reproduced locally since the option is checked locally but not in Deadline Cloud.

### What was the solution? (How)

Revert the logic for populating the `RenderSetupIncludeLights` job parameter to the [original implementation](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/e39114c6554cbc08977e948192109c8b47b4e57c/src/deadline_submitter_for_maya/scripts/aws_deadline/render_layers.py#L61-L69)

### What is the impact of this change?

The `RenderSetupIncludeLights` job parameter reflects the current state of the corresponding option

### How was this change tested?
- Ran unit tests
- Manually tested in Maya. Verified that a scene file that has the option checked but has the corresponding option var unset generates a job bundle with RenderSetupIncludeLights set to true.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2025-01-07T17:37:26.535028-08:00
Running job bundle output test: /Users/jericht/Repositories/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2025-01-07T17:37:27.595248-08:00
Running job bundle output test: /Users/jericht/Repositories/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2025-01-07T17:37:28.054335-08:00
Running job bundle output test: /Users/jericht/Repositories/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2025-01-07T17:37:28.054420-08:00
Running job bundle output test: /Users/jericht/Repositories/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2025-01-07T17:37:28.588416-08:00
Running job bundle output test: /Users/jericht/Repositories/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2025-01-07T17:37:31.931839-08:00
```

### Was this change documented?

N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
