### PR TITLE
fix: Switch to using `byFrameStep` instead of `byFrame`

### DIFF
--- a/src/deadline/maya_submitter/scene.py
+++ b/src/deadline/maya_submitter/scene.py
@@ -56,7 +56,7 @@ class Animation:
         """
         Returns the frame step of the current render.
         """
-        return int(maya.cmds.getAttr("defaultRenderGlobals.byFrame"))
+        return int(maya.cmds.getAttr("defaultRenderGlobals.byFrameStep"))
 
     @staticmethod
     def extension_padding() -> int:


### PR DESCRIPTION
Fixes: #220 

### What was the problem/requirement? (What/Why)

This is talked about in the following link:
https://help.autodesk.com/view/MAYAUL/2023/ENU/?guid=__Nodes_renderGlobals_html

Essentially `byFrame` is no longer used but kept for backwards compatibility. And the value it gives us is different than `byFrameStep`

### What was the solution? (How)
Switch to `byFrameStep`
### What is the impact of this change?
Frame rates working as expected
### How was this change tested?
Using the scene files provided in #220

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
