### PR TITLE
chore: add installer descption to support Maya 2025

### DIFF
--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -1,7 +1,7 @@
 <component>
     <name>deadline_cloud_for_maya</name>
-    <description>Deadline Cloud for Maya 2024</description>
-	<detailedDescription>Maya plugin for submitting jobs to AWS Deadline Cloud. Compatible with Maya 2024.</detailedDescription>
+    <description>Deadline Cloud for Maya 2024 - 2025</description>
+	<detailedDescription>Maya plugin for submitting jobs to AWS Deadline Cloud. Compatible with Maya 2024 - 2025.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -72,8 +72,8 @@
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_maya_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Maya 2024
-- Compatible with Maya 2024.
+			<value>Deadline Cloud for Maya 2024 - 2025
+- Compatible with Maya 2024 - 2025.
 - Install the integrated Maya submitter files to the installation directory.
 - Register the plug-in with Maya by creating or updating the MAYA_MODULE_PATH environment variable.</value>
 		</stringParameter>


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)
Need to indicate we support Maya 2025 in the installer

### What was the solution? (How)
Add text to show we support Maya 2025
### What is the impact of this change?
Customer know we have Maya 2025 support
### How was this change tested?
`hatch run test`

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
