### PR TITLE
fix: Load scene settings when the submitter is open

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -444,7 +444,9 @@ def _get_parameter_values(
     return parameter_values
 
 
-def show_maya_render_submitter(parent, f=Qt.WindowFlags()) -> "Optional[SubmitJobToDeadlineDialog]":
+def show_maya_render_submitter(
+    parent, f=Qt.WindowFlags(), load_sticky_setting: bool = False
+) -> Optional[SubmitJobToDeadlineDialog]:
     with open(Path(__file__).parent / "default_maya_job_template.yaml") as fh:
         default_job_template = yaml.safe_load(fh)
 
@@ -457,7 +459,8 @@ def show_maya_render_submitter(parent, f=Qt.WindowFlags()) -> "Optional[SubmitJo
     render_settings.output_path = Scene.output_path()
 
     # Load the sticky settings
-    render_settings.load_sticky_settings(Scene.name())
+    if load_sticky_setting:
+        render_settings.load_sticky_settings(Scene.name())
 
     # Create a dictionary for the layers, and accumulate data about each layer
     render_layer_names = get_all_renderable_render_layer_names()

--- a/src/deadline/maya_submitter/mel_commands.py
+++ b/src/deadline/maya_submitter/mel_commands.py
@@ -59,12 +59,18 @@ class DeadlineCloudSubmitterCmd(om.MPxCommand):
                         DeadlineCloudSubmitterCmd.dialog.close()
                     DeadlineCloudSubmitterCmd.dialog = None
 
-                # Show existing submitter dialog, or create new one if needed
+                # Create a new submitter dialog. If this is the first time the submitter is
+                # opened, load the sticky settings. If this is not the first time, close
+                # the existing dialog and create a new one without loading the sticky
+                # settings.
                 if DeadlineCloudSubmitterCmd.dialog:
-                    DeadlineCloudSubmitterCmd.dialog.show()
+                    DeadlineCloudSubmitterCmd.dialog.close()
+                    DeadlineCloudSubmitterCmd.dialog = show_maya_render_submitter(
+                        parent=mainwin, f=Qt.Tool, load_sticky_setting=False
+                    )
                 else:
                     DeadlineCloudSubmitterCmd.dialog = show_maya_render_submitter(
-                        parent=mainwin, f=Qt.Tool
+                        parent=mainwin, f=Qt.Tool, load_sticky_setting=True
                     )
                     DeadlineCloudSubmitterCmd.dialog_scene_name = scene_name
 

--- a/test/unit/deadline_submitter_for_maya/test_mel_commands.py
+++ b/test/unit/deadline_submitter_for_maya/test_mel_commands.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from deadline.maya_submitter.mel_commands import DeadlineCloudSubmitterCmd
+from unittest.mock import patch, Mock
+import maya.api.OpenMaya as om  # pylint: disable=import-error
+from qtpy.QtCore import Qt  # type: ignore
+from qtpy.QtWidgets import (  # type: ignore
+    QApplication,
+)
+
+
+@patch("deadline.maya_submitter.mel_commands.show_maya_render_submitter")
+@patch.object(QApplication, "instance")
+@patch.object(om.MGlobal, "mayaState")
+def test_deadline_cloud_submitter_cmd_sticky_setting_load_only_once(
+    mock_maya_state: Mock, mock_q_app: Mock, mock_show_maya_render_submitter: Mock
+) -> None:
+    mock_maya_state.return_value = om.MGlobal.kInteractive
+    maya_widget: Mock = Mock()
+    maya_widget.objectName.return_value = "MayaWindow"
+    q_app_instance: Mock = Mock()
+    q_app_instance.topLevelWidgets.return_value = [maya_widget]
+    mock_q_app.return_value = q_app_instance
+    submitter_dialog: Mock = Mock()
+    mock_show_maya_render_submitter.return_value = submitter_dialog
+
+    DeadlineCloudSubmitterCmd.doIt(Mock())
+
+    mock_show_maya_render_submitter.assert_called_once_with(
+        parent=maya_widget, f=Qt.Tool, load_sticky_setting=True
+    )
+
+    DeadlineCloudSubmitterCmd.doIt(Mock())
+
+    mock_show_maya_render_submitter.assert_called_with(
+        parent=maya_widget, f=Qt.Tool, load_sticky_setting=False
+    )
+    submitter_dialog.close.assert_called_once()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/167

### What was the problem/requirement? (What/Why)
The submitter setting are only updated when Maya is opened or the scene name changes.

### What was the solution? (How)
Update the submitter settings whenever the submitter is opened.

### What is the impact of this change?
Improved UX.

### How was this change tested?
* Replicated the reported issue.
* Checked that the submitter settings are updated when opened.
* Submitted job and verified it completed successfully.

- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, the test button kept saying that the module wasn't installed. However, the submitter worked with the regular button.

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
