### PR TITLE
fix: add new regex to handle arnold license error

### DIFF
--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -214,7 +214,7 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
                 RegexCallback(
                     [
                         re.compile(
-                            "(aborting render because the abort_on_license_fail option was enabled)"
+                            "(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled)"
                         )
                     ],
                     self._handle_error,

--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -214,7 +214,7 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
                 RegexCallback(
                     [
                         re.compile(
-                            "(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled)"
+                            "(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled))"
                         )
                     ],
                     self._handle_error,

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -866,7 +866,9 @@ class TestMayaAdaptor_on_cleanup:
         init_data["error_on_arnold_license_fail"] = error_on_arnold_license_fail
         adaptor = MayaAdaptor(init_data)
         expected_regex_list = [
-            re.compile("(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled))")
+            re.compile(
+                "(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled))"
+            )
         ]
 
         # WHEN

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -866,7 +866,9 @@ class TestMayaAdaptor_on_cleanup:
         init_data["error_on_arnold_license_fail"] = error_on_arnold_license_fail
         adaptor = MayaAdaptor(init_data)
         expected_regex_list = [
-            re.compile("(aborting render because the abort_on_license_fail option was enabled)")
+            re.compile(
+                "(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled))"
+            )
         ]
 
         # WHEN

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -866,9 +866,7 @@ class TestMayaAdaptor_on_cleanup:
         init_data["error_on_arnold_license_fail"] = error_on_arnold_license_fail
         adaptor = MayaAdaptor(init_data)
         expected_regex_list = [
-            re.compile(
-                "(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled))"
-            )
+            re.compile("(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled))")
         ]
 
         # WHEN


### PR DESCRIPTION
Fixes: *NA*

### What was the problem/requirement? (What/Why)
A customer reported an issue where their Maya job succeeds even when abort_on_license_fail option is enabled and license checkout for Arnold fails. This is happening because the string which we are trying to match in adaptor.py line#217 is different from what is actually printing in the log. What was the solution? (How)
I changed the string to catch both the error messages:
- aborting render because the abort_on_license_fail option was enabled
- borting render because this is a batch render and abort_on_license_fail option is enabled

### What is the impact of this change?
It will catch Arnold license error an fail the job.

### How was this change tested?
I ran the unit test by running `hatch run all:test`, I got `Required test coverage of 41.0% reached. Total coverage: 44.05%`

- Have you run the unit tests?
Yes. The result is here: [MayaUnitTest.txt](https://github.com/user-attachments/files/18698399/MayaUnitTest.txt)

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, I ran the adaptor locally and tested it with real scene file. I did not have any licenses for Arnold so my job failed on the error message. 
![MayaAdaptor](https://github.com/user-attachments/assets/876a3bc1-4dfa-4f5c-a664-0a74b537a0ea)

### Was this change documented?
NA

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
