### PR TITLE
fix: Update the warning message used when the scene has unsaved changes

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -538,7 +538,10 @@ def show_maya_render_submitter(
             scene_name = maya.cmds.file(q=True, sn=True)
             button = maya.cmds.confirmDialog(
                 title="Warning: Scene Changes not Saved",
-                message=("Save scene to %s before submitting?" % scene_name),
+                message=(
+                    "The scene has unsaved local changes that will not be included in the job submission.\n\nDo you want to save the scene to %s before submitting?"
+                    % scene_name
+                ),
                 button=["Yes", "No"],
                 defaultButton="No",
                 cancelButton="No",


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/225

### What was the problem/requirement? (What/Why)
An issue was reported regarding job submissions failing when the render layer was renamed. However, after troubleshooting, we realized that the issue would only arise if the scene wasn't saved before submitting the job.

### What was the solution? (How)
Update the warning message displayed when the scene isn't saved, to make it more clear.

### What is the impact of this change?
Better UX.

### How was this change tested?
* `hatch build`
*  `hatch run test`
*  Installed submitter and verified.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes. 3 tests passed, the renderman test fails due to setup issues.
```
Timestamp: 2025-02-11T21:25:45.507541+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\cube

cube
Test succeeded

Timestamp: 2025-02-11T21:25:47.199259+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\layers

layers
Test succeeded

Timestamp: 2025-02-11T21:25:47.640302+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\layers_no_variation

layers_no_variation
Test succeeded

Timestamp: 2025-02-11T21:25:47.937191+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\referenced_layers
```

### Was this change documented?
N/A

### Is this a breaking change?
No

<img width="537" alt="Screenshot 2025-02-11 at 12 56 01 PM" src="https://github.com/user-attachments/assets/14d0439e-2f88-42f2-ba17-e3597ea7644c" />



----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*