### PR TITLE
fix: Tighten adaptors error and V-Ray progress regex pattern

### DIFF
--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -202,22 +202,25 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
             re.compile("\\[PROGRESS\\] ([0-9]+) percent"),
             re.compile("([0-9]+)% done"),  # arnold
             re.compile("R90000\\s+([0-9]+)%"),  # renderman
-            re.compile("V-Ray: +([0-9]+)%"),  #vray
-            re.compile("V-Ray: +([0-9]+) %"),  #vray
+            re.compile("V-Ray: +([0-9]+)%"),  # vray
+            re.compile("V-Ray: +([0-9]+) %"),  # vray
         ]
         error_regexes = [
-            re.compile( r"Frame rendering aborted.", re.IGNORECASE),
-            re.compile( r"Rendering was internally aborted", re.IGNORECASE),
-            re.compile( r'Cannot find procedure "rsPreference"', re.IGNORECASE),
-            re.compile( r"\[mtoa\] Failed batch render", re.IGNORECASE),
-            re.compile( r"Plug-in, \"mtoa\", was not found on MAYA_PLUG_IN_PATH", re.IGNORECASE),
-            re.compile( r".*V-Ray error: .*", re.IGNORECASE),
-            re.compile( r".*The system does not support the required CUDA compute capabilities.*", re.IGNORECASE),
-            re.compile( r".*Failed to init the CUDA driver API.*", re.IGNORECASE),
-            re.compile( r".*CUDA_ERROR_UNKNOWN.*", re.IGNORECASE),
-            re.compile( r"Render failed", re.IGNORECASE),
-            re.compile( r".*Exception:.*|.*Error:.*|.*SEVERE.*"),
-            ]
+            re.compile(r"Frame rendering aborted.", re.IGNORECASE),
+            re.compile(r"Rendering was internally aborted", re.IGNORECASE),
+            re.compile(r'Cannot find procedure "rsPreference"', re.IGNORECASE),
+            re.compile(r"\[mtoa\] Failed batch render", re.IGNORECASE),
+            re.compile(r"Plug-in, \"mtoa\", was not found on MAYA_PLUG_IN_PATH", re.IGNORECASE),
+            re.compile(r".*V-Ray error: .*", re.IGNORECASE),
+            re.compile(
+                r".*The system does not support the required CUDA compute capabilities.*",
+                re.IGNORECASE,
+            ),
+            re.compile(r".*Failed to init the CUDA driver API.*", re.IGNORECASE),
+            re.compile(r".*CUDA_ERROR_UNKNOWN.*", re.IGNORECASE),
+            re.compile(r"Render failed", re.IGNORECASE),
+            re.compile(r".*Exception:.*|.*Error:.*|.*SEVERE.*"),
+        ]
         version_regexes = [re.compile("MayaClient: Maya Version ([0-9]+)")]
 
         callback_list.append(RegexCallback(completed_regexes, self._handle_complete))

--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -202,8 +202,22 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
             re.compile("\\[PROGRESS\\] ([0-9]+) percent"),
             re.compile("([0-9]+)% done"),  # arnold
             re.compile("R90000\\s+([0-9]+)%"),  # renderman
+            re.compile("V-Ray: +([0-9]+)%"),  #vray
+            re.compile("V-Ray: +([0-9]+) %"),  #vray
         ]
-        error_regexes = [re.compile(".*Exception:.*|.*Error:.*|.*Warning.*|.*SEVERE.*")]
+        error_regexes = [
+            re.compile( r"Frame rendering aborted.", re.IGNORECASE),
+            re.compile( r"Rendering was internally aborted", re.IGNORECASE),
+            re.compile( r'Cannot find procedure "rsPreference"', re.IGNORECASE),
+            re.compile( r"\[mtoa\] Failed batch render", re.IGNORECASE),
+            re.compile( r"Plug-in, \"mtoa\", was not found on MAYA_PLUG_IN_PATH", re.IGNORECASE),
+            re.compile( r".*V-Ray error: .*", re.IGNORECASE),
+            re.compile( r".*The system does not support the required CUDA compute capabilities.*", re.IGNORECASE),
+            re.compile( r".*Failed to init the CUDA driver API.*", re.IGNORECASE),
+            re.compile( r".*CUDA_ERROR_UNKNOWN.*", re.IGNORECASE),
+            re.compile( r"Render failed", re.IGNORECASE),
+            re.compile( r".*Exception:.*|.*Error:.*|.*Warning.*|.*SEVERE.*"),
+            ]
         version_regexes = [re.compile("MayaClient: Maya Version ([0-9]+)")]
 
         callback_list.append(RegexCallback(completed_regexes, self._handle_complete))

--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -216,7 +216,7 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
             re.compile( r".*Failed to init the CUDA driver API.*", re.IGNORECASE),
             re.compile( r".*CUDA_ERROR_UNKNOWN.*", re.IGNORECASE),
             re.compile( r"Render failed", re.IGNORECASE),
-            re.compile( r".*Exception:.*|.*Error:.*|.*Warning.*|.*SEVERE.*"),
+            re.compile( r".*Exception:.*|.*Error:.*|.*SEVERE.*"),
             ]
         version_regexes = [re.compile("MayaClient: Maya Version ([0-9]+)")]
 

--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -202,8 +202,8 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
             re.compile("\\[PROGRESS\\] ([0-9]+) percent"),
             re.compile("([0-9]+)% done"),  # arnold
             re.compile("R90000\\s+([0-9]+)%"),  # renderman
-            re.compile("V-Ray: +([0-9]+)%"),  # vray
-            re.compile("V-Ray: +([0-9]+) %"),  # vray
+            re.compile("V-Ray: +(\d+)%"),  # vray
+            re.compile("V-Ray: +(\d+) %"),  # vray
         ]
         error_regexes = [
             re.compile(r"Frame rendering aborted.", re.IGNORECASE),

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -729,7 +729,7 @@ class TestMayaAdaptor_on_cleanup:
         (1, " 45% done - 11 rays/pixel", 45),
         (2, "R90000   24%", 24),
         (3, "V-Ray: 55%", 55),
-        (4, "V-Ray: 30 %", 30)
+        (4, "V-Ray: 30 %", 30),
     ]
 
     @pytest.mark.parametrize("regex_index, stdout, expected_progress", handle_progress_params)
@@ -847,18 +847,21 @@ class TestMayaAdaptor_on_cleanup:
         init_data["strict_error_checking"] = strict_error_checking
         adaptor = MayaAdaptor(init_data)
         error_regexes = [
-            re.compile( r"Frame rendering aborted.", re.IGNORECASE),
-            re.compile( r"Rendering was internally aborted", re.IGNORECASE),
-            re.compile( r'Cannot find procedure "rsPreference"', re.IGNORECASE),
-            re.compile( r"\[mtoa\] Failed batch render", re.IGNORECASE),
-            re.compile( r"Plug-in, \"mtoa\", was not found on MAYA_PLUG_IN_PATH", re.IGNORECASE),
-            re.compile( r".*V-Ray error: .*", re.IGNORECASE),
-            re.compile( r".*The system does not support the required CUDA compute capabilities.*", re.IGNORECASE),
-            re.compile( r".*Failed to init the CUDA driver API.*", re.IGNORECASE),
-            re.compile( r".*CUDA_ERROR_UNKNOWN.*", re.IGNORECASE),
-            re.compile( r"Render failed", re.IGNORECASE),
-            re.compile( r".*Exception:.*|.*Error:.*|.*SEVERE.*"),
-            ]
+            re.compile(r"Frame rendering aborted.", re.IGNORECASE),
+            re.compile(r"Rendering was internally aborted", re.IGNORECASE),
+            re.compile(r'Cannot find procedure "rsPreference"', re.IGNORECASE),
+            re.compile(r"\[mtoa\] Failed batch render", re.IGNORECASE),
+            re.compile(r"Plug-in, \"mtoa\", was not found on MAYA_PLUG_IN_PATH", re.IGNORECASE),
+            re.compile(r".*V-Ray error: .*", re.IGNORECASE),
+            re.compile(
+                r".*The system does not support the required CUDA compute capabilities.*",
+                re.IGNORECASE,
+            ),
+            re.compile(r".*Failed to init the CUDA driver API.*", re.IGNORECASE),
+            re.compile(r".*CUDA_ERROR_UNKNOWN.*", re.IGNORECASE),
+            re.compile(r"Render failed", re.IGNORECASE),
+            re.compile(r".*Exception:.*|.*Error:.*|.*SEVERE.*"),
+        ]
 
         # WHEN
         callbacks = adaptor._get_regex_callbacks()

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -857,7 +857,7 @@ class TestMayaAdaptor_on_cleanup:
             re.compile( r".*Failed to init the CUDA driver API.*", re.IGNORECASE),
             re.compile( r".*CUDA_ERROR_UNKNOWN.*", re.IGNORECASE),
             re.compile( r"Render failed", re.IGNORECASE),
-            re.compile( r".*Exception:.*|.*Error:.*|.*Warning.*|.*SEVERE.*"),
+            re.compile( r".*Exception:.*|.*Error:.*|.*SEVERE.*"),
             ]
 
         # WHEN

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -727,9 +727,9 @@ class TestMayaAdaptor_on_cleanup:
     handle_progress_params = [
         (0, "[PROGRESS] 99 percent", 99),
         (1, " 45% done - 11 rays/pixel", 45),
-        (2, "R90000   24%", 24)
-        (3, "V-Ray: 55%", 55)
-        (4, "V-Ray: 30 %", 30),
+        (2, "R90000   24%", 24),
+        (3, "V-Ray: 55%", 55),
+        (4, "V-Ray: 30 %", 30)
     ]
 
     @pytest.mark.parametrize("regex_index, stdout, expected_progress", handle_progress_params)

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -727,7 +727,9 @@ class TestMayaAdaptor_on_cleanup:
     handle_progress_params = [
         (0, "[PROGRESS] 99 percent", 99),
         (1, " 45% done - 11 rays/pixel", 45),
-        (2, "R90000   24%", 24),
+        (2, "R90000   24%", 24)
+        (3, "V-Ray: 55%", 55)
+        (4, "V-Ray: 30 %", 30),
     ]
 
     @pytest.mark.parametrize("regex_index, stdout, expected_progress", handle_progress_params)
@@ -844,7 +846,19 @@ class TestMayaAdaptor_on_cleanup:
         # GIVEN
         init_data["strict_error_checking"] = strict_error_checking
         adaptor = MayaAdaptor(init_data)
-        error_regexes = [re.compile(".*Exception:.*|.*Error:.*|.*Warning.*|.*SEVERE.*")]
+        error_regexes = [
+            re.compile( r"Frame rendering aborted.", re.IGNORECASE),
+            re.compile( r"Rendering was internally aborted", re.IGNORECASE),
+            re.compile( r'Cannot find procedure "rsPreference"', re.IGNORECASE),
+            re.compile( r"\[mtoa\] Failed batch render", re.IGNORECASE),
+            re.compile( r"Plug-in, \"mtoa\", was not found on MAYA_PLUG_IN_PATH", re.IGNORECASE),
+            re.compile( r".*V-Ray error: .*", re.IGNORECASE),
+            re.compile( r".*The system does not support the required CUDA compute capabilities.*", re.IGNORECASE),
+            re.compile( r".*Failed to init the CUDA driver API.*", re.IGNORECASE),
+            re.compile( r".*CUDA_ERROR_UNKNOWN.*", re.IGNORECASE),
+            re.compile( r"Render failed", re.IGNORECASE),
+            re.compile( r".*Exception:.*|.*Error:.*|.*Warning.*|.*SEVERE.*"),
+            ]
 
         # WHEN
         callbacks = adaptor._get_regex_callbacks()


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
Maya adaptor fails the job but doesn't handle the regex from Maya application to cancel the error at the correct time. Also progress for V-Ray print in a specific regex which was missing in the adaptor. 

### What was the solution? (How)
Modified the regex pattern so that Maya fails only for specific regexes. These regexes have been used in Deadline 10 for a long time and have been proven to be robust.

### What is the impact of this change?
Adaptor will not fail jobs on non-fatal error and warnings in its STDOUT.

### How was this change tested?
Run the Unit test with `hatch run test` and 95 test passed.
```
Required test coverage of 41.0% reached. Total coverage: 44.43%
=============================================================================== slowest 5 durations ================================================================================
0.23s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.12s call     test/test_copyright_headers.py::test_copyright_headers
0.11s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test__wait_for_socket
0.10s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[vray-False]
0.10s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
=============================================================================== 95 passed in 11.19s ================================================================================
```
- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Nothing changed in the submitter so it doesn't require Job Bundle Output tests. 

### Was this change documented?
No 
### Is this a breaking change?

No