### PR TITLE
chore: pinned version of deadline to 0.49.6 for now until next release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.49.*",
+    "deadline == 0.49.6",
     "openjd-adaptor-runtime == 0.8.*",
 ]
 


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
Most recent changes in Maya need to be released. However, we don't want to tie it to the next probable deadline cloud release and release it confidently while testing with current deadline cloud latest version ``0.49.6``

### What was the solution? (How)
We want to pin the version of deadline cloud in deadline cloud for Maya to be current latest version 0.49.6 and change it later to 0.49.* post release. 

### What is the impact of this change?
N/A. No effect because the current latest version is the pinned version

### How was this change tested?
N/A. We'll perform the testing as a part of release

- Have you run the unit tests?
Yes

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
N/A

### Was this change documented?
N/A

### Is this a breaking change?

N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
