### PR TITLE
feat: Arnold licensing error handling for mtoa5.4.7.1

### DIFF
--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -214,7 +214,7 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
                 RegexCallback(
                     [
                         re.compile(
-                            "(aborting render because the abort_on_license_fail option was enabled)"
+                            "(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled))"
                         )
                     ],
                     self._handle_error,

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import ANY, Mock, PropertyMock, patch
+from typing import List
 
 import pytest
 import jsonschema  # type: ignore
@@ -866,7 +867,9 @@ class TestMayaAdaptor_on_cleanup:
         init_data["error_on_arnold_license_fail"] = error_on_arnold_license_fail
         adaptor = MayaAdaptor(init_data)
         expected_regex_list = [
-            re.compile("(aborting render because the abort_on_license_fail option was enabled)")
+            re.compile(
+                "(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled))"
+            )
         ]
 
         # WHEN
@@ -877,6 +880,35 @@ class TestMayaAdaptor_on_cleanup:
             any(expected_regex_list == regex_callback.regex_list for regex_callback in callbacks)
             == error_on_arnold_license_fail
         )
+
+    @pytest.mark.parametrize(
+        "message, should_match",
+        [
+            ("aborting render because the abort_on_license_fail option was enabled", True),
+            (
+                "aborting render because this is a batch render and abort_on_license_fail option is enabled",
+                True,
+            ),
+            ("aborting render because ", False),
+            ("aborting render because something else happened", False),
+        ],
+    )
+    def test_regex_for_error_on_arnold_license_fail(self, message: str, should_match: bool) -> None:
+        """
+        Tests that the regexes used to catch arnold license errors work as expected.
+        """
+        # GIVEN
+        regex_list = [
+            re.compile(
+                "(aborting render because (?:the abort_on_license_fail option was enabled|this is a batch render and abort_on_license_fail option is enabled))"
+            )
+        ]
+
+        # WHEN
+        results: List[bool] = [bool(regex.match(message)) for regex in regex_list]
+
+        # THEN
+        assert any(results) == should_match
 
     @pytest.mark.parametrize("adaptor_exc_info", [RuntimeError("Something Bad Happened!"), None])
     def test_has_exception(self, init_data: dict, adaptor_exc_info: Exception | None) -> None:


### PR DESCRIPTION
Fixes: *NA*

### What was the problem/requirement? (What/Why)
A customer reported an issue where their Maya job succeeds even when abort_on_license_fail option is enabled and license checkout for Arnold fails. This is happening because the string which we are trying to match in adaptor.py line#217 is different from what is actually printing in the log. What was the solution? (How)
I changed the string to catch both the error messages:
- aborting render because the abort_on_license_fail option was enabled
- borting render because this is a batch render and abort_on_license_fail option is enabled

### What is the impact of this change?
It will catch Arnold license error an fail the job.

### How was this change tested?
I ran the unit test by running `hatch run all:test`, I got `Required test coverage of 41.0% reached. Total coverage: 44.05%`

- Have you run the unit tests?
Yes. The result is here: 
[MayaUnitTest.txt](https://github.com/user-attachments/files/18714996/MayaUnitTest.txt)

I added the test as suggested.
[test.txt](https://github.com/user-attachments/files/19171892/test.txt)


### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, I ran the adaptor locally and tested it with real scene file. I did not have any licenses for Arnold so my job failed on the error message. 
![MayaAdaptor](https://github.com/user-attachments/assets/876a3bc1-4dfa-4f5c-a664-0a74b537a0ea)
Check the logs: 
[MayaAdaptorLocalRun.txt](https://github.com/user-attachments/files/18714999/MayaAdaptorLocalRun.txt)

### Was this change documented?
NA

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

