### PR TITLE
Better job attachments handling to include cache files

### DIFF
--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -47,6 +47,7 @@ _MAYA_INIT_KEYS = {
     "output_file_prefix",
     "render_layer",
     "render_setup_include_lights",
+    "cache_pathmapping",
     "error_on_arnold_license_fail",
 }
 

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -47,6 +47,7 @@ class DefaultMayaHandler:
             "project_path": self.set_project_path,
             "render_layer": self.set_render_layer,
             "render_setup_include_lights": self.set_render_setup_include_lights,
+            "cache_pathmapping": self.set_cache_pathmapping,
             "scene_file": self.set_scene_file,
         }
         self.image_width = None
@@ -206,6 +207,21 @@ class DefaultMayaHandler:
         DirectoryMapping.set_activated(True)
         for source, dest in rules.items():
             DirectoryMapping.mappings[source] = dest
+
+    def set_cache_pathmapping(self, data: dict) -> None:
+        """
+        Applies pathmapping to some cache files. Some nodes convert their cache file paths into absolute paths and store them in an attribute named 'absoluteCachePath'. This attribute is only updated when the UI does a refresh, which means when we render headlessly, the attribute doesn't get changed properly. This function searches for nodes with the 'absoluteCacheName' attribute and manually changes it to the correct value.
+
+        Args:
+            data (dict): The data given from the Adaptor. Keys expected: []
+        """
+        if not DirectoryMapping.get_activated():
+            return
+        for node in maya.cmds.ls():
+            if maya.cmds.attributeQuery("absoluteCacheName", node=node, exists=True):
+                attrName: str = "%s.absoluteCacheName" % node
+                new_cache_path: str = DirectoryMapping.convert(maya.cmds.getAttr(attrName))
+                maya.cmds.setAttr(attrName, new_cache_path)
 
     def set_project_path(self, data: dict) -> None:
         """

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -210,7 +210,9 @@ class DefaultMayaHandler:
 
     def set_cache_pathmapping(self, data: dict) -> None:
         """
-        Applies pathmapping to some cache files. Some nodes convert their cache file paths into absolute paths and store them in an attribute named 'absoluteCachePath'. This attribute is only updated when the UI does a refresh, which means when we render headlessly, the attribute doesn't get changed properly. This function searches for nodes with the 'absoluteCacheName' attribute and manually changes it to the correct value.
+        Applies pathmapping to some cache files. Some nodes convert their cache file paths into absolute paths and store them in an attribute named 'absoluteCachePath'.
+        This attribute is only updated when the UI does a refresh, which means when we render headlessly, the attribute doesn't get changed properly.
+        This function searches for nodes with the 'absoluteCacheName' attribute and manually changes it to the correct value.
 
         Args:
             data (dict): The data given from the Adaptor. Keys expected: []
@@ -221,7 +223,7 @@ class DefaultMayaHandler:
             if maya.cmds.attributeQuery("absoluteCacheName", node=node, exists=True):
                 attrName: str = "%s.absoluteCacheName" % node
                 new_cache_path: str = DirectoryMapping.convert(maya.cmds.getAttr(attrName))
-                maya.cmds.setAttr(attrName, new_cache_path)
+                maya.cmds.setAttr(attrName, new_cache_path, type="string")
 
     def set_project_path(self, data: dict) -> None:
         """

--- a/src/deadline/maya_submitter/assets.py
+++ b/src/deadline/maya_submitter/assets.py
@@ -77,12 +77,8 @@ class AssetIntrospector:
             frame_re_matches = _FRAME_RE.findall(normalized_path)
             if frame_re_matches or "<f>" in normalized_path or "<frame>" in normalized_path:
                 for expanded_path in self._expand_path(normalized_path):
-                    if not os.path.exists(expanded_path):
-                        continue
-                    if expanded_path in assets:
-                        continue
                     assets.add(expanded_path)
-            elif os.path.exists(normalized_path) and normalized_path not in assets:
+            else:
                 assets.add(Path(normalized_path))
 
         assets.add(Path(Scene.name()))

--- a/src/deadline/maya_submitter/assets.py
+++ b/src/deadline/maya_submitter/assets.py
@@ -12,6 +12,8 @@ from .file_path_editor import FilePathEditor
 from .scene import Animation, RendererNames, Scene
 from .utils import findAllFilesForPattern
 
+import maya.cmds
+
 _FRAME_RE = re.compile("#+")
 
 
@@ -66,6 +68,22 @@ class AssetIntrospector:
                 print(f"Processed {i+1}/{total_refs} file references at {time.time()}")
                 if progress_callback:
                     progress_callback(f"Processed {i+1}/{total_refs} file references...")
+
+        # Iterate through every node and list all attributes that are filenames
+        # Then replace all tokens and check if it's a real path
+        # If it's not already in assets, add it to assets
+        for path in self._get_node_attr_paths(expand_tokens=True):
+            normalized_path = os.path.normpath(path)
+            frame_re_matches = _FRAME_RE.findall(normalized_path)
+            if frame_re_matches or "<f>" in normalized_path or "<frame>" in normalized_path:
+                for expanded_path in self._expand_path(normalized_path):
+                    if not os.path.exists(expanded_path):
+                        continue
+                    if expanded_path in assets:
+                        continue
+                    assets.add(expanded_path)
+            elif os.path.exists(normalized_path) and normalized_path not in assets:
+                assets.add(Path(normalized_path))
 
         assets.add(Path(Scene.name()))
 
@@ -253,6 +271,35 @@ class AssetIntrospector:
                 ) from e
             raise
 
+    def _get_node_attr_paths(self, expand_tokens=False):
+        """
+        FilePathEditor by default leaves out many file types like caches.
+        This function iterates through nodes in the scene and filters for filepath attributes
+
+        Returns:
+            [str]: A list of all the paths found
+        """
+        paths: list[str] = []
+        for node in maya.cmds.ls():
+            attrs: list[str] = maya.cmds.listAttr(
+                node, usedAsFilename=True, fullNodeName=True, multi=True
+            )
+            # We need to make sure we're including Bifrost caches, but listAttr won't find them
+            # Bifrost simulation caches use the "absoluteCacheName" attribute, which is not marked with "usedAsFilename"
+            if maya.cmds.attributeQuery("absoluteCacheName", node=node, exists=True):
+                if attrs is None:
+                    attrs = []
+                attrs.append("%s.absoluteCacheName" % node)
+            if attrs is not None:
+                new_paths: list[str] = list(
+                    filter(None, map(maya.cmds.getAttr, attrs))
+                )  # Map attribute to their value, then filter out empty attributes
+                if expand_tokens:
+                    new_paths = [self._expand_tokens(path, object_name=node) for path in new_paths]
+                paths.extend(new_paths)
+
+        return paths
+
     @lru_cache(maxsize=None)
     def _expand_path(self, path: str) -> Generator[Path, None, None]:
         """
@@ -263,7 +310,7 @@ class AssetIntrospector:
         This function expands these tokens and characters to find all the assets which will be
         required at render time.
 
-        This function gets called for a varierty of file groupings (ie. Arnold's txmanager, Maya's FilePathEditor)
+        This function gets called for a variety of file groupings (ie. Arnold's txmanager, Maya's FilePathEditor)
         Since this func has an lru cache and returns a generator, it'll actually skip rechecking these files since
         it returns the original generator which is exhausted. You can, however, force it to recheck
         these files by performing asset_introspector._expand_path.cache_clear() call.
@@ -277,7 +324,7 @@ class AssetIntrospector:
         frame_re_matches = _FRAME_RE.findall(path)
 
         frame_list: Iterable[int] = [0]
-        if frame_re_matches or "<f>" in path:
+        if frame_re_matches or "<f>" in path or "<frame>" in path:
             frame_list = Animation.frame_list()
 
         for frame in frame_list:
@@ -288,3 +335,14 @@ class AssetIntrospector:
             for p in paths:
                 if not p.endswith(":Zone.Identifier"):  # Metadata files that erroneously match
                     yield Path(p)
+
+    def _expand_tokens(self, path: str, object_name="<object>") -> str:
+        path = path.replace("<project>", os.path.normpath(maya.cmds.internalVar(uwd=True)))
+        path = path.replace("<object>", object_name)
+
+        filepath = maya.cmds.file(q=True, sn=True)
+        filename = os.path.basename(filepath)
+        scene_name, _ = os.path.splitext(filename)
+        path = path.replace("<scene>", scene_name)
+
+        return path

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -686,6 +686,13 @@ def show_maya_render_submitter(
     introspector = AssetIntrospector()
     print(f"Asset introspector initialized at {time.time()}")
 
+    normalized_paths = [os.path.normpath(path) for path in introspector.parse_scene_assets()]
+    for path in normalized_paths:
+        if os.path.exists(path) and os.path.isdir(path):
+            auto_detected_attachments.input_directories.add(path)
+        else:
+            auto_detected_attachments.input_filenames.add(path)
+
     update_progress("Analyzing scene assets...")
     scene_assets = list(introspector.parse_scene_assets(progress_callback=update_progress))
     total_assets = len(scene_assets)

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -240,6 +240,7 @@ def _get_job_template(
             + "image_height: {{Param."
             + (layer_data.image_height_parameter_name or "ImageHeight")
             + "}}\n"
+            + "cache_pathmapping: true\n"
         )
         # If a specific camera is selected, link to the Camera parameter
         if settings.camera_selection != ALL_CAMERAS:

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -702,7 +702,7 @@ def show_maya_render_submitter(
         progress_dialog.setValue(i)
         normalized = os.path.normpath(asset_path)
         if not os.path.exists(normalized):
-            continue;
+            continue
         if os.path.isdir(normalized):
             processed_directories.add(normalized)
         else:

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -685,14 +685,6 @@ def show_maya_render_submitter(
     auto_detected_attachments = AssetReferences()
     introspector = AssetIntrospector()
     print(f"Asset introspector initialized at {time.time()}")
-
-    normalized_paths = [os.path.normpath(path) for path in introspector.parse_scene_assets()]
-    for path in normalized_paths:
-        if os.path.exists(path) and os.path.isdir(path):
-            auto_detected_attachments.input_directories.add(path)
-        else:
-            auto_detected_attachments.input_filenames.add(path)
-
     update_progress("Analyzing scene assets...")
     scene_assets = list(introspector.parse_scene_assets(progress_callback=update_progress))
     total_assets = len(scene_assets)
@@ -702,19 +694,27 @@ def show_maya_render_submitter(
     progress_dialog.setValue(0)
 
     # Process assets with progress updates
-    processed_assets = set()
+    processed_files = set()
+    processed_directories = set()
     print(f"Starting to process {total_assets} scene assets...")
 
     for i, asset_path in enumerate(scene_assets):
         progress_dialog.setValue(i)
-        processed_assets.add(os.path.normpath(asset_path))
+        normalized = os.path.normpath(asset_path)
+        if not os.path.exists(normalized):
+            continue;
+        if os.path.isdir(normalized):
+            processed_directories.add(normalized)
+        else:
+            processed_files.add(normalized)
         # Process in larger batches to improve performance - refresh UI every 100 assets
         if i % 100 == 0 and i > 0:
             print(f"Processed {i+1}/{total_assets} assets at {time.time()}")
             update_progress(f"Processed {i+1}/{total_assets} assets")
 
     progress_dialog.setValue(total_assets)
-    auto_detected_attachments.input_filenames = processed_assets
+    auto_detected_attachments.input_filenames = processed_files
+    auto_detected_attachments.input_directories = processed_directories
     print(f"All {total_assets} assets processed at {time.time()}")
     update_progress(f"All {total_assets} assets processed")
 

--- a/src/deadline/maya_submitter/utils.py
+++ b/src/deadline/maya_submitter/utils.py
@@ -63,6 +63,7 @@ def findAllFilesForPattern(pattern: str, frameNumber: int) -> list[str]:
         if frameNumber is not None:
             # _patternToRegex handles frame tokens, but this is for only finding files for a specific frame
             basename = basename.replace("<f>", "0*" + str(frameNumber))
+            basename = basename.replace("<frame>", "0*" + str(frameNumber))
         regex = _patternToRegex(basename)
         result = [
             os.path.join(dirname, f)


### PR DESCRIPTION

Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/256

### What was the problem/requirement? (What/Why)
Caching files is required for any scene with a simulation.

### What was the solution? (How)
My solution checks every node and adds any attributes that are file paths to the job attachments list

### What is the impact of this change?
Any file references get added to the job attachments list

### How was this change tested?
Repeatedly running render tests on my CMF and SMF fleets. Also I ran `hatch run test` and didn't get any failures

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

It said it successfully ran 4 tests.


### Was this change documented?

No

### Is this a breaking change?

Not that I know of.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
