### PR TITLE
chore: Fix installers and scripts for release

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -13,7 +13,7 @@ on:
         - MacOS
       ref_type:
         required: true
-        default: tags
+        default: heads
         type: choice
         options:
         - tags
@@ -39,4 +39,3 @@ jobs:
       ref_type: ${{inputs.ref_type}}
       ref: ${{inputs.ref}}
       oses: "['${{inputs.os}}']"
-      project_name: "deadline-cloud-for-maya"

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -17,7 +17,9 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: aws-deadline/.github/.github/workflows/reusable_publish.yml@mainline
+    uses: aws-deadline/.github/.github/workflows/reusable_publish_v2.yml@mainline
+    with:
+      installer_oses: "['Linux', 'Windows', 'MacOS']"
     secrets: inherit
   # PyPI does not support reusable workflows yet
   # # See https://github.com/pypi/warehouse/issues/11096
@@ -31,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: release
+          ref: ${{ needs.Publish.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/depsBundle.sh
+++ b/depsBundle.sh
@@ -7,12 +7,4 @@
 
 set -xeuo pipefail
 
-python depsBundle.py
-
-rm -f dependency_bundle/deadline_cloud_for_maya_submitter-deps-windows.zip
-rm -f dependency_bundle/deadline_cloud_for_maya_submitter-deps-linux.zip
-rm -f dependency_bundle/deadline_cloud_for_maya_submitter-deps-macos.zip
-
-cp dependency_bundle/deadline_cloud_for_maya_submitter-deps.zip dependency_bundle/deadline_cloud_for_maya_submitter-deps-windows.zip
-cp dependency_bundle/deadline_cloud_for_maya_submitter-deps.zip dependency_bundle/deadline_cloud_for_maya_submitter-deps-linux.zip
-cp dependency_bundle/deadline_cloud_for_maya_submitter-deps.zip dependency_bundle/deadline_cloud_for_maya_submitter-deps-macos.zip
+python3 scripts/deps_bundle.py

--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -55,30 +55,6 @@
                 <setInstallerVariable name="maya_installdir" value="${installdir}/Submitters/Maya"/>
             </elseActionList>
         </if>
-        <if>
-             <conditionRuleList>
-                 <platformTest type="windows"/>
-             </conditionRuleList>
-             <actionList>
-                 <setInstallerVariable name="maya_deps_platform" value="windows"/>
-             </actionList>
-         </if>
-         <if>
-             <conditionRuleList>
-                 <platformTest type="linux"/>
-             </conditionRuleList>
-             <actionList>
-                 <setInstallerVariable name="maya_deps_platform" value="linux"/>
-             </actionList>
-         </if>
-         <if>
-             <conditionRuleList>
-                 <platformTest type="osx"/>
-             </conditionRuleList>
-             <actionList>
-                 <setInstallerVariable name="maya_deps_platform" value="macos"/>
-             </actionList>
-         </if>
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_maya_summary" ask="0" cliOptionShow="0">
@@ -98,7 +74,7 @@
 		</fnAddPathEnvironmentVariable>
         <unzip>
             <destinationDirectory>${maya_installdir}/scripts</destinationDirectory>
-            <zipFile>${installdir}/tmp/maya_deps/dependency_bundle/deadline_cloud_for_maya_submitter-deps-${maya_deps_platform}.zip</zipFile>
+            <zipFile>${installdir}/tmp/maya_deps/dependency_bundle/deadline_cloud_for_maya_submitter-deps.zip</zipFile>
         </unzip>
         <deleteFile>
             <path>${installdir}/tmp/maya_deps</path>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.49.6",
+    "deadline == 0.49.*",
     "openjd-adaptor-runtime == 0.8.*",
 ]
 

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -2,8 +2,6 @@
 """Script to create platform-specific Deadline Client installers using InstallBuilder."""
 
 import os
-import platform
-import subprocess
 import sys
 import shutil
 import tempfile
@@ -12,7 +10,9 @@ from typing import Optional
 from pathlib import Path
 
 from common import EvaluationBuildError, run
-from find_installbuilder import InstallBuilderSelection
+from find_installbuilder import InstallBuilderSelection, get_builder_exe_name
+
+from deps_bundle import build_deps_bundle
 
 # This is derived from <installerFilename> in installer/DeadlineCloudClient.xml
 # See "Supported Platforms" table in https://releases.installbuilder.com/installbuilder/docs/installbuilder-userguide.html
@@ -50,17 +50,12 @@ def setup_install_builder(
 
     install_builder_path = selection.resolve_install_builder_installation(workdir)
 
-    if platform.system() == "Windows":
-        binary_name = "builder.exe"
-    else:
-        binary_name = "builder"
-
     if (
         not install_builder_path.is_dir()
-        or not (install_builder_path / "bin" / binary_name).is_file()
+        or not (install_builder_path / "bin" / get_builder_exe_name()).is_file()
     ):
         raise FileNotFoundError(
-            f"InstallBuilder path '{install_builder_path}' must be a directory containing 'bin/{binary_name}'."
+            f"InstallBuilder path '{install_builder_path}' must be a directory containing 'bin/{get_builder_exe_name()}'."
         )
 
     if license_file_path is not None:
@@ -98,20 +93,7 @@ def build_installer(
     else:
         raise ValueError(f"Unknown platform '{installer_platform}'")
 
-    try:
-        if platform.system() == "Windows":
-            # `shell=True` is necessary here to run on Windows.
-            # Please see the security considerations of this flag if editing the script or its invocation:
-            # https://docs.python.org/3/library/subprocess.html#security-considerations
-            deps_bundle_output = subprocess.run(
-                "depsBundle.sh", check=True, shell=True, capture_output=True
-            )
-        else:
-            deps_bundle_output = subprocess.run("./depsBundle.sh", check=True, capture_output=True)
-        print(deps_bundle_output.stdout.decode("utf-8"))
-    except subprocess.CalledProcessError as e:
-        print(f"Error when bundling dependencies: {e.stdout.decode('utf-8')}")
-        raise
+    build_deps_bundle()
 
     install_builder_cli = install_builder_location / "bin" / "builder"
     out_dir = workdir / "out"
@@ -192,7 +174,7 @@ def main(
                 f"Found:\n\t{os.linesep.join([str(i) for i in installer_dir.iterdir()])}"
             )
 
-        output_path = installer_filename
+        output_path = Path(installer_filename)
         if output_dir:
             output_dir.mkdir(exist_ok=True)
             output_path = output_dir / output_path

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -79,25 +79,20 @@ def _download_native_dependencies(working_directory: Path, base_env: Path) -> li
     ]
     native_dependency_paths = []
     for version in SUPPORTED_PYTHON_VERSIONS:
-        for platform in SUPPORTED_PLATFORMS:
-            native_dependency_path = (
-                working_directory / "native" / f"{version.replace('.', '_')}_{platform}"
-            )
-            native_dependency_paths.append(native_dependency_path)
-            native_dependency_path.mkdir(parents=True)
-            native_dependency_pip_args = [
-                "pip",
-                "install",
-                "--target",
-                str(native_dependency_path),
-                "--platform",
-                platform,
-                "--python-version",
-                version,
-                "--only-binary=:all:",
-                *versioned_native_dependencies,
-            ]
-            subprocess.run(native_dependency_pip_args, check=True)
+        native_dependency_path = working_directory / "native" / f"{version.replace('.', '_')}"
+        native_dependency_paths.append(native_dependency_path)
+        native_dependency_path.mkdir(parents=True)
+        native_dependency_pip_args = [
+            "pip",
+            "install",
+            "--target",
+            str(native_dependency_path),
+            "--python-version",
+            version,
+            "--only-binary=:all:",
+            *versioned_native_dependencies,
+        ]
+        subprocess.run(native_dependency_pip_args, check=True)
     return native_dependency_paths
 
 
@@ -127,13 +122,15 @@ def _zip_bundle(base_env: Path, zip_path: Path) -> None:
     shutil.make_archive(str(zip_path.with_suffix("")), "zip", str(base_env))
 
 
-def _copy_zip_to_destination(zip_path: Path) -> None:
+def _copy_zip_to_destination(zip_path: Path) -> Path:
     dependency_bundle_dir = Path.cwd() / "dependency_bundle"
     dependency_bundle_dir.mkdir(exist_ok=True)
-    zip_desntination = dependency_bundle_dir / zip_path.name
-    if zip_desntination.exists():
-        zip_desntination.unlink()
-    shutil.copy(str(zip_path), str(zip_desntination))
+    zip_destination = dependency_bundle_dir / zip_path.name
+    if zip_destination.exists():
+        zip_destination.unlink()
+    shutil.copy(str(zip_path), str(zip_destination))
+
+    return zip_destination
 
 
 def build_deps_bundle() -> None:

--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -15,6 +15,7 @@ from common import UnsupportedOSError
 _INSTALL_BUILDER_ARCHIVE_FILENAME = {
     "Windows": "VMware-InstallBuilder-Professional-windows.tar.gz",
     "Linux": "VMware-InstallBuilder-Professional-linux.tar.gz",
+    "MacOS": "VMware-InstallBuilder-Professional-macos.tar.gz",
 }
 
 
@@ -150,6 +151,12 @@ class _InstallBuilderInstallation:
         )
 
 
+def get_builder_exe_name() -> str:
+    if platform.system() == "Windows":
+        return "builder.exe"
+    return "builder"
+
+
 def _get_default_installbuilder_location() -> Path:
     """
     Returns the default location where InstallBuilder Professional will be installed depending on the platform.
@@ -161,7 +168,7 @@ def _get_default_installbuilder_location() -> Path:
     for install_dir in config.parent_path.iterdir():
         if install_dir.is_dir():
             match = config.get_install_directory_regex().match(install_dir.name)
-            if match and (install_dir / "bin" / "builder").is_file():
+            if match and (install_dir / "bin" / get_builder_exe_name()).is_file():
                 if platform.system() == "Linux":
                     version_offset = 0
                 else:

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -183,7 +183,7 @@ def test_default_location(installer_path: Path):
 
 
 @pytest.mark.skipif(
-    os.getenv("CODEBUILD_SRC_DIR") is None,
+    os.getenv("CODEBUILD_SRC_DIR") is None or os.getenv("IS_DEV_BUILD", "false").lower() == "true",
     reason="Only installers built with a license will not be evaluation mode",
 )
 @pytest.mark.skipif(
@@ -264,8 +264,11 @@ class TestLinuxAndMacOS:
     def _validate_posix_permissions(self, installation_path: Path):
         # assists mypy type checking to ignore this on Windows
         assert sys.platform != "win32"
+        # pwd is not available on Windows
+        import pwd
+
         # GIVEN
-        current_user = getpass.getuser()
+        current_user = pwd.getpwuid(os.getuid())[0]  # type: ignore
 
         # WHEN
         bad_perms: defaultdict[Path, list[str]] = defaultdict(list)
@@ -298,6 +301,23 @@ class TestWindows:
         # GIVEN / WHEN / THEN
         self._verify_windows_least_privilege(user_installation)
 
+    def _running_in_container(self) -> bool:
+        """
+        Check to see if the cexecsvc service exists and is running
+        to determine if we're running on a container.
+        """
+        # assists mypy type checking to ignore this on non-Windows
+        assert sys.platform == "win32"
+        import win32service
+        import win32serviceutil
+
+        try:
+            service_status = win32serviceutil.QueryServiceStatus("cexecsvc")
+            return service_status[1] == win32service.SERVICE_RUNNING
+        except win32service.error:
+            # Service doesn't exist, not on a container
+            return False
+
     @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
     def test_system_permissions(self, system_installation):
         # GIVEN / WHEN / THEN
@@ -313,7 +333,15 @@ class TestWindows:
 
         # GIVEN
         windows_user = getpass.getuser()
-        builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, "Administrators")
+
+        if self._running_in_container():
+            # The admin group is different wehen running
+            # in a container.
+            admin_group = "ContainerAdministrator"
+        else:
+            admin_group = "Administrators"
+
+        builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, admin_group)
         user_sid, _, _ = win32security.LookupAccountName(None, windows_user)
 
         # WHEN
@@ -329,7 +357,7 @@ class TestWindows:
             if _is_admin():
                 if builtin_admin_group_sid != owner_sid:
                     bad_perms[path].append(
-                        f"Expected to be owned by 'Administrators' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
+                        f"Expected to be owned by '{admin_group}' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
                     )
             elif user_sid != owner_sid:
                 bad_perms[path].append(
@@ -428,7 +456,7 @@ class TestSystemInstall:
 
 
 @pytest.mark.skipif(
-    os.getenv("CODEBUILD_SRC_DIR") is None,
+    os.getenv("CODEBUILD_SRC_DIR") is None or os.getenv("IS_DEV_BUILD", "false").lower() == "true",
     reason="Only installers built internally will be signed",
 )
 class TestVerifySigning:
@@ -453,7 +481,11 @@ class TestVerifySigning:
             Number of errors: 1
         """
         # GIVEN
-        signtool = next(glob.iglob("C:/Program Files*/Windows Kits/*/bin/*/x64/signtool.exe"), None)
+        signtool = shutil.which("signtool")
+        if not signtool:
+            signtool = next(
+                glob.iglob("C:/Program Files*/Windows Kits/*/bin/*/x64/signtool.exe"), None
+            )
         assert signtool, "signtool not found in expected location"
 
         # WHEN


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Individual installers need some tweaks to fit into our release process better.

### What was the solution? (How)
Many little things bundled up:
- Move everything in `depsBundle.sh` into the associated Python script
- Bundle dependencies only for the current platform
- Correct admin role for testing installers in Windows containers
- Correct how the current user is gotten for testing installers on macOS/Linux
- Add a check for signtool on `PATH` when testing signing on Windows
- Added a Pytest marker to skip prod-exclusive tests in local/development builds
- Change the Build Installers workflow to default to `heads` for `ref_type`
- Change the ref passed during the Release/Publish workflow to a ref
- Pass all OSes to build installers for in the Release/Publish workflow
- Reuse `release_publish_v2` instead of the old version
- Add a bundle identifier for the macOS installer

### What is the impact of this change?
We can build Maya submitter installers locally and for production.

### How was this change tested?

- Have you run the unit tests?
```
===================================================================================================================================================================================== test session starts ======================================================================================================================================================================================
platform darwin -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /Volumes/workplace/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: cov-6.1.1, xdist-3.6.1
10 workers [96 items]     
........................................................................................../Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported"../Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
.)
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported"/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
)
.../Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
/Volumes/workplace/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py:197: SyntaxWarning: invalid escape sequence '\s'
  _renderman_license_error = ".*{SEVERE}\s+License.*"
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
/Volumes/workplace/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py:197: SyntaxWarning: invalid escape sequence '\s'
  _renderman_license_error = ".*{SEVERE}\s+License.*"
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
/Volumes/workplace/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py:197: SyntaxWarning: invalid escape sequence '\s'
  _renderman_license_error = ".*{SEVERE}\s+License.*"
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
/Volumes/workplace/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py:197: SyntaxWarning: invalid escape sequence '\s'
  _renderman_license_error = ".*{SEVERE}\s+License.*"
                                                                                                                                                                                                                                                                                         [100%]
======================================================================================================================================================================================== tests coverage ========================================================================================================================================================================================
_______________________________________________________________________________________________________________________________________________________________________ coverage: platform darwin, python 3.12.3-final-0 _______________________________________________________________________________________________________________________________________________________________________

Name                                                                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------------------------------------
src/deadline/maya_adaptor/MayaAdaptor/__init__.py                                  3      0      0      0   100%
src/deadline/maya_adaptor/MayaAdaptor/adaptor.py                                 235      5     58      4    97%   61->exit, 302, 318-320, 528->531, 600, 607->616
src/deadline/maya_adaptor/MayaClient/__init__.py                                   3      0      0      0   100%
src/deadline/maya_adaptor/MayaClient/dir_map.py                                   42     19      2      0    52%   21-24, 27, 30, 33, 39-40, 46, 52, 55-58, 61, 71, 75, 79
src/deadline/maya_adaptor/MayaClient/maya_client.py                               40      4      4      0    91%   16-19, 56-58
src/deadline/maya_adaptor/MayaClient/render_handlers/__init__.py                  13      3      6      3    68%   22, 24, 26
src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py            46     36     16      0    16%   29-81, 92-93, 105-107
src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py     103     65     34      0    31%   15, 45-58, 61-80, 93-127, 139, 166-168, 177, 201-205, 217-219, 229-230, 241-251
src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py         42     26     14      1    30%   28-30, 68-108
src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py              65     51     30      2    17%   27-39, 57-120, 129-131, 143-145
src/deadline/maya_adaptor/__init__.py                                              0      0      0      0   100%
src/deadline/maya_submitter/__init__.py                                            6      0      0      0   100%
src/deadline/maya_submitter/assets.py                                             79     36     40      4    48%   26-51, 59-65, 91->89, 98-99, 111-122, 131-133, 160, 165, 168->167
src/deadline/maya_submitter/cameras.py                                            10      4      0      0    60%   19-22, 33
src/deadline/maya_submitter/data_classes.py                                       46     19      8      0    50%   44-71, 74-83
src/deadline/maya_submitter/file_path_editor.py                                   33     17     10      0    37%   37-38, 45-84
src/deadline/maya_submitter/job_bundle_output_test_runner.py                     145    118     42      0    14%   38-47, 53-54, 61-69, 74, 79-111, 116, 123, 131-206, 210-304
src/deadline/maya_submitter/logging.py                                            48     26     10      0    38%   26, 32-38, 43-79
src/deadline/maya_submitter/maya_render_submitter.py                             252    210    108      0    12%   71-311, 320-444, 450-687
src/deadline/maya_submitter/mel_commands.py                                       36      4     10      3    85%   36->exit, 48-54, 59, 88
src/deadline/maya_submitter/render_layers.py                                      33     16      0      0    52%   26-41, 45, 49, 53, 60, 68-71, 79-81
src/deadline/maya_submitter/renderers.py                                          24     13      6      0    37%   16, 23, 34-37, 44-57
src/deadline/maya_submitter/scene.py                                             105     39     18      0    59%   38, 45, 52, 59, 66, 73-76, 86-96, 109, 116, 123-126, 152-156, 163-167, 175-179, 183-189
src/deadline/maya_submitter/utils.py                                              28      0      4      2    94%   62->73, 63->66
--------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                           1437    711    420     19    44%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml
Required test coverage of 41.0% reached. Total coverage: 44.32%
===================================================================================================================================================================================== slowest 5 durations ======================================================================================================================================================================================
0.13s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_no_error
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_run_data_wrong_schema
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[renderman-False]
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
====================================================================================================================================================================================== 96 passed in 3.56s ======================================================================================================================================================================================
```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

```
===================================================================================================================================================================================== test session starts ======================================================================================================================================================================================
platform darwin -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0 -- /Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: cov-6.1.1, xdist-3.6.1
10 workers [13 items]     
scheduling tests via LoadScheduling

test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw9] [  7%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw8] [ 15%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw1] [ 23%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw3] [ 30%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw4] [ 38%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw5] [ 46%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw1] [ 53%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw6] [ 76%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 84%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw2] [ 92%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

======================================================================================================================================================================================= warnings summary =======================================================================================================================================================================================
test/installer/test_installer.py:465
  /Volumes/workplace/deadline-cloud-for-maya/test/installer/test_installer.py:465: SyntaxWarning: invalid escape sequence '\*'
    """Assumes that the Windows SDK is installed so we can find signtool:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================================================================================================== slowest 5 durations ======================================================================================================================================================================================
11.54s setup    test/installer/test_installer.py::TestUserInstall::test_install
11.40s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
10.85s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
3.03s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
3.00s call     test/installer/test_installer.py::test_default_location
=========================================================================================================================================================================== 4 passed, 9 skipped, 1 warning in 14.70s ===========================================================================================================================================================================
```


Additionally, I also built the installers locally and confirmed that they build and work correctly.

### Was this change documented?
Documentation added in the initial installer feat is still relevant.

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
