### PR TITLE
chore: fix install builder MacOS key name

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -39,3 +39,4 @@ jobs:
       ref_type: ${{inputs.ref_type}}
       ref: ${{inputs.ref}}
       oses: "['${{inputs.os}}']"
+      project_name: "deadline-cloud-for-maya"

--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -15,7 +15,7 @@ from common import UnsupportedOSError
 _INSTALL_BUILDER_ARCHIVE_FILENAME = {
     "Windows": "VMware-InstallBuilder-Professional-windows.tar.gz",
     "Linux": "VMware-InstallBuilder-Professional-linux.tar.gz",
-    "MacOS": "VMware-InstallBuilder-Professional-macos.tar.gz",
+    "Darwin": "VMware-InstallBuilder-Professional-macos.tar.gz",
 }
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Same as https://github.com/aws-deadline/deadline-cloud-for-houdini/pull/247
```
- platform.system() returns Darwin not MacOS so the check for the install builder archive was failing
- The workflow to build installers requires a project_name as input
```
### What was the solution? (How)
Same as https://github.com/aws-deadline/deadline-cloud-for-houdini/pull/247
### What is the impact of this change?
Installer builds work again
### How was this change tested?

Tested against my own backend and verified the installer could be built with these changes

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results 
N/A
#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
N/A


### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
