### PR TITLE
chore: change macos install method to using mod file

### DIFF
--- a/.github/actions/bump_precommit_hook/action.yaml
+++ b/.github/actions/bump_precommit_hook/action.yaml
@@ -10,6 +10,6 @@ runs:
   - name: Update plugin Version
     shell: bash
     run: |
-      echo "+ deadline-cloud-for-maya ${{inputs.semver}} ." > ./maya_submitter_plugin/DeadlineCloudForMaya.mod
+      echo "+ DeadlineCloudForMaya ${{inputs.semver}} ." > ./maya_submitter_plugin/DeadlineCloudForMaya.mod
       sed -i "s/^VERSION =.*/VERSION = \"${{inputs.semver}}\"/" ./maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py
       git add ./maya_submitter_plugin/DeadlineCloudForMaya.mod ./maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py

--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -43,14 +43,6 @@
     </folderList>
 	<initializationActionList>
 		<setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_maya"/>
-        <if>
-            <conditionRuleList>
-                <platformTest type="osx" />
-            </conditionRuleList>
-            <actionList>
-                <setInstallerVariable name="installdir" value="/Users/Shared/Autodesk/maya" />
-            </actionList>
-        </if>
 	</initializationActionList>
 	<readyToInstallActionList>
         <if>
@@ -74,7 +66,7 @@
 		</stringParameter>
 	</parameterList>
     <postInstallationActionList>
-		<fnAddPathEnvironmentVariable>
+        <fnAddPathEnvironmentVariable>
 			<progressText>Registering plug-in with Maya</progressText>
 			<name>MAYA_MODULE_PATH</name>
 			<value>${maya_installdir}</value>
@@ -88,5 +80,22 @@
         <deleteFile>
             <path>${installdir}/tmp/maya_deps</path>
         </deleteFile>
+        <if>
+            <conditionRuleList>
+                <platformTest type="osx" />
+            </conditionRuleList>
+            <actionList>
+                <runProgram>
+                    <program>bash</program>
+                    <programArguments>-c "
+                        sed -E -i '' 's#(\+ DeadlineCloudForMaya [^ ]*) \.#\1 '"${installdir}"'#' "${installdir}/DeadlineCloudForMaya.mod"
+                    "</programArguments>
+                </runProgram>
+                <copyFile>
+                    <origin>${installdir}/DeadlineCloudForMaya.mod</origin>
+                    <destination>/Users/Shared/Autodesk/modules/maya/DeadlineCloudForMaya.mod</destination>
+                </copyFile>
+            </actionList>
+        </if>
     </postInstallationActionList>
 </component>

--- a/installer/DeadlineCloudForMayaSubmitter.xml
+++ b/installer/DeadlineCloudForMayaSubmitter.xml
@@ -239,7 +239,14 @@
             </ruleList>
         </actionGroup>
         <deleteFile path="${installdir}/installer_version.txt"/>
-        <deleteFile path="Users/Shared/Autodesk/modules/maya/DeadlineCloudForMaya.mod"/>
+        <if>
+            <conditionRuleList>
+                <platformTest type="osx" />
+            </conditionRuleList>
+            <actionList>
+                <deleteFile path="/Users/Shared/Autodesk/modules/maya/DeadlineCloudForMaya.mod"/>
+            </actionList>
+        </if>
     </preUninstallationActionList>
     <width>550</width>
 </project>

--- a/installer/DeadlineCloudForMayaSubmitter.xml
+++ b/installer/DeadlineCloudForMayaSubmitter.xml
@@ -239,6 +239,7 @@
             </ruleList>
         </actionGroup>
         <deleteFile path="${installdir}/installer_version.txt"/>
+        <deleteFile path="Users/Shared/Autodesk/modules/maya/DeadlineCloudForMaya.mod"/>
     </preUninstallationActionList>
     <width>550</width>
 </project>

--- a/maya_submitter_plugin/DeadlineCloudForMaya.mod
+++ b/maya_submitter_plugin/DeadlineCloudForMaya.mod
@@ -1,1 +1,1 @@
-+ deadline-cloud-for-maya 0.13.2 .
++ DeadlineCloudForMaya 0.15.3 .


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Need a solution to install this plug in to Maya on MacOS, the old solution have some potential to delete unwanted file and only work in default mode
### What was the solution? (How)
Remove the old solution.
Make some change to the mod file and move it to the default module path of Maya
### What is the impact of this change?
Installer now work on MacOS, and uninstall only delete file that we want to delete
### How was this change tested?
- Have you run the unit tests?
```
===================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /Volumes/workplace/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: cov-6.1.1, xdist-3.6.1
10 workers [96 items]     
............................................................................................./Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-import/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
ed")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
.../Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_adaptor was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module deadline/maya_submitter was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
/Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/lib/python3.12/site-packages/coverage/inorout.py:509: CoverageWarning: Module maya_submitter_plugin/plugins was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
/Volumes/workplace/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py:197: SyntaxWarning: invalid escape sequence '\s'
  _renderman_license_error = ".*{SEVERE}\s+License.*"
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
/Volumes/workplace/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py:197: SyntaxWarning: invalid escape sequence '\s'
  _renderman_license_error = ".*{SEVERE}\s+License.*"
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
<unknown>:197: SyntaxWarning: invalid escape sequence '\s'
/Volumes/workplace/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py:197: SyntaxWarning: invalid escape sequence '\s'
  _renderman_license_error = ".*{SEVERE}\s+License.*"
                                                                                         [100%]
======================================================================================== tests coverage ========================================================================================
_______________________________________________________________________ coverage: platform darwin, python 3.12.3-final-0 _______________________________________________________________________

Name                                                                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------------------------------------
src/deadline/maya_adaptor/MayaAdaptor/__init__.py                                  3      0      0      0   100%
src/deadline/maya_adaptor/MayaAdaptor/adaptor.py                                 235      5     58      4    97%   61->exit, 302, 318-320, 528->531, 600, 607->616
src/deadline/maya_adaptor/MayaClient/__init__.py                                   3      0      0      0   100%
src/deadline/maya_adaptor/MayaClient/dir_map.py                                   42     19      2      0    52%   21-24, 27, 30, 33, 39-40, 46, 52, 55-58, 61, 71, 75, 79
src/deadline/maya_adaptor/MayaClient/maya_client.py                               40      4      4      0    91%   16-19, 56-58
src/deadline/maya_adaptor/MayaClient/render_handlers/__init__.py                  13      3      6      3    68%   22, 24, 26
src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py            46     36     16      0    16%   29-81, 92-93, 105-107
src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py     103     65     34      0    31%   15, 45-58, 61-80, 93-127, 139, 166-168, 177, 201-205, 217-219, 229-230, 241-251
src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py         42     26     14      1    30%   28-30, 68-108
src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py              65     51     30      2    17%   27-39, 57-120, 129-131, 143-145
src/deadline/maya_adaptor/__init__.py                                              0      0      0      0   100%
src/deadline/maya_submitter/__init__.py                                            6      0      0      0   100%
src/deadline/maya_submitter/assets.py                                             79     36     40      4    48%   26-51, 59-65, 91->89, 98-99, 111-122, 131-133, 160, 165, 168->167
src/deadline/maya_submitter/cameras.py                                            10      4      0      0    60%   19-22, 33
src/deadline/maya_submitter/data_classes.py                                       46     19      8      0    50%   44-71, 74-83
src/deadline/maya_submitter/file_path_editor.py                                   33     17     10      0    37%   37-38, 45-84
src/deadline/maya_submitter/job_bundle_output_test_runner.py                     145    118     42      0    14%   38-47, 53-54, 61-69, 74, 79-111, 116, 123, 131-206, 210-304
src/deadline/maya_submitter/logging.py                                            48     26     10      0    38%   26, 32-38, 43-79
src/deadline/maya_submitter/maya_render_submitter.py                             252    210    108      0    12%   71-311, 320-444, 450-687
src/deadline/maya_submitter/mel_commands.py                                       36      4     10      3    85%   36->exit, 48-54, 59, 88
src/deadline/maya_submitter/render_layers.py                                      33     16      0      0    52%   26-41, 45, 49, 53, 60, 68-71, 79-81
src/deadline/maya_submitter/renderers.py                                          24     13      6      0    37%   16, 23, 34-37, 44-57
src/deadline/maya_submitter/scene.py                                             105     39     18      0    59%   38, 45, 52, 59, 66, 73-76, 86-96, 109, 116, 123-126, 152-156, 163-167, 175-179, 183-189
src/deadline/maya_submitter/utils.py                                              28      0      4      2    94%   62->73, 63->66
--------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                           1437    711    420     19    44%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml
Required test coverage of 41.0% reached. Total coverage: 44.32%
===================================================================================== slowest 5 durations ======================================================================================
0.14s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[arnold-True]
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_no_error
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_fail
====================================================================================== 96 passed in 3.30s ======================================================================================
```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
```
===================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0 -- /Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: cov-6.1.1, xdist-3.6.1
10 workers [13 items]     
scheduling tests via LoadScheduling

test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw9] [  7%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw3] [ 15%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw4] [ 23%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw8] [ 30%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw5] [ 38%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw2] [ 46%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw2] [ 53%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw6] [ 76%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw1] [ 84%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw1] [ 92%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

===================================================================================== slowest 5 durations ======================================================================================
12.68s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
12.47s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
11.79s setup    test/installer/test_installer.py::TestUserInstall::test_install
3.41s call     test/installer/test_installer.py::test_default_location
2.95s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
================================================================================ 4 passed, 9 skipped in 16.31s =================================================================================
```


### Was this change documented?
Yes
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
