### PR TITLE
fix: move mod file to a user folder to prevent permission issue

### DIFF
--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -92,11 +92,11 @@
                     "</programArguments>
                 </runProgram>
                 <createDirectory>
-                    <path>/Users/Shared/Autodesk/modules/maya</path>
+                    <path>${user_home_directory}/Library/Preferences/Autodesk/maya/modules</path>
                 </createDirectory>
                 <copyFile>
                     <origin>${installdir}/DeadlineCloudForMaya.mod</origin>
-                    <destination>/Users/Shared/Autodesk/modules/maya/DeadlineCloudForMaya.mod</destination>
+                    <destination>${user_home_directory}/Library/Preferences/Autodesk/maya/modules/DeadlineCloudForMaya.mod</destination>
                 </copyFile>
             </actionList>
         </if>

--- a/installer/DeadlineCloudForMayaSubmitter.xml
+++ b/installer/DeadlineCloudForMayaSubmitter.xml
@@ -244,7 +244,7 @@
                 <platformTest type="osx" />
             </conditionRuleList>
             <actionList>
-                <deleteFile path="/Users/Shared/Autodesk/modules/maya/DeadlineCloudForMaya.mod"/>
+                <deleteFile path="${user_home_directory}/Library/Preferences/Autodesk/maya/modules/DeadlineCloudForMaya.mod"/>
             </actionList>
         </if>
     </preUninstallationActionList>


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
- Current installer move mod file to a shared folder. This could create permission issue in some rare case where we do not have write access.
- Also move it here make it accessible by other user, which is not what an user install intend to be
### What was the solution? (How)
Move the mod file to user default folder that Maya search for
### What is the impact of this change?
Installer will now behaved as we expected on MacOS
### How was this change tested?
#### Manually build the installer and install it on local for Maya 2024 and 2025
- Make sure we can load the submitter
- Make sure we can submit a job

### Have you run the unit tests?
```
====================================================================================================================================== tests coverage =======================================================================================================================================
_____________________________________________________________________________________________________________________ coverage: platform darwin, python 3.12.3-final-0 ______________________________________________________________________________________________________________________

Name                                                                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------------------------------------
src/deadline/maya_adaptor/MayaAdaptor/__init__.py                                  3      0      0      0   100%
src/deadline/maya_adaptor/MayaAdaptor/adaptor.py                                 235      5     58      4    97%   61->exit, 302, 318-320, 528->531, 600, 607->616
src/deadline/maya_adaptor/MayaClient/__init__.py                                   3      0      0      0   100%
src/deadline/maya_adaptor/MayaClient/dir_map.py                                   42     19      2      0    52%   21-24, 27, 30, 33, 39-40, 46, 52, 55-58, 61, 71, 75, 79
src/deadline/maya_adaptor/MayaClient/maya_client.py                               40      4      4      0    91%   16-19, 56-58
src/deadline/maya_adaptor/MayaClient/render_handlers/__init__.py                  13      3      6      3    68%   22, 24, 26
src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py            46     36     16      0    16%   29-81, 92-93, 105-107
src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py     103     65     34      0    31%   15, 45-58, 61-80, 93-127, 139, 166-168, 177, 201-205, 217-219, 229-230, 241-251
src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py         42     26     14      1    30%   28-30, 68-108
src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py              65     51     30      2    17%   27-39, 57-120, 129-131, 143-145
src/deadline/maya_adaptor/__init__.py                                              0      0      0      0   100%
src/deadline/maya_submitter/__init__.py                                            6      0      0      0   100%
src/deadline/maya_submitter/assets.py                                             79     36     40      4    48%   26-51, 59-65, 91->89, 98-99, 111-122, 131-133, 160, 165, 168->167
src/deadline/maya_submitter/cameras.py                                            10      4      0      0    60%   19-22, 33
src/deadline/maya_submitter/data_classes.py                                       46     19      8      0    50%   44-71, 74-83
src/deadline/maya_submitter/file_path_editor.py                                   33     17     10      0    37%   37-38, 45-84
src/deadline/maya_submitter/job_bundle_output_test_runner.py                     145    118     42      0    14%   38-47, 53-54, 61-69, 74, 79-111, 116, 123, 131-206, 210-304
src/deadline/maya_submitter/logging.py                                            48     26     10      0    38%   26, 32-38, 43-79
src/deadline/maya_submitter/maya_render_submitter.py                             252    210    108      0    12%   71-311, 320-444, 450-687
src/deadline/maya_submitter/mel_commands.py                                       36      4     10      3    85%   36->exit, 48-54, 59, 88
src/deadline/maya_submitter/render_layers.py                                      33     16      0      0    52%   26-41, 45, 49, 53, 60, 68-71, 79-81
src/deadline/maya_submitter/renderers.py                                          24     13      6      0    37%   16, 23, 34-37, 44-57
src/deadline/maya_submitter/scene.py                                             105     39     18      0    59%   38, 45, 52, 59, 66, 73-76, 86-96, 109, 116, 123-126, 152-156, 163-167, 175-179, 183-189
src/deadline/maya_submitter/utils.py                                              28      0      4      2    94%   62->73, 63->66
--------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                           1437    711    420     19    44%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml
Required test coverage of 41.0% reached. Total coverage: 44.32%
==================================================================================================================================== slowest 5 durations ====================================================================================================================================
0.15s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.06s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_fail
0.05s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[arnold-True]
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[renderman-False]
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
==================================================================================================================================== 96 passed in 3.37s =====================================================================================================================================
```

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below

```
==================================================================================================================================== test session starts ====================================================================================================================================
platform darwin -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0 -- /Users/xuananh/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/U9zh9YGK/deadline-cloud-for-maya/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: cov-6.1.1, xdist-3.6.1
10 workers [13 items]     
scheduling tests via LoadScheduling

test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw5] [  7%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw3] [ 15%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw9] [ 23%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestUserInstall::test_install 
[gw4] [ 30%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw8] [ 38%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw1] [ 46%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw1] [ 53%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw2] [ 76%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw2] [ 84%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw6] [ 92%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

==================================================================================================================================== slowest 5 durations ====================================================================================================================================
12.22s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
12.09s setup    test/installer/test_installer.py::TestUserInstall::test_install
11.52s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
3.09s call     test/installer/test_installer.py::test_default_location
2.87s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
=============================================================================================================================== 4 passed, 9 skipped in 15.90s ===============================================================================================================================
```

### Was this change documented?

Yes

### Is this a breaking change?

No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
