### PR TITLE
fix: fixed Maya submitter to pull the correct image resolution from scene

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -368,13 +368,13 @@ def _get_parameter_values(
         parameter_values.append(
             {
                 "name": "ImageWidth",
-                "value": render_layers[0].image_resolution[0],
+                "value": get_width(),
             }
         )
         parameter_values.append(
             {
                 "name": "ImageHeight",
-                "value": render_layers[0].image_resolution[1],
+                "value": get_height(),
             }
         )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Maya submitter doesn't take the changed ImageResolution from the scene, the parameters_values.yaml file from the template shows the wrong ImageWidth and ImageHeight after been changed

### What was the solution? (How)

Change the code under the maya_render_submitter.py file to pull the Width and Height from Maya scene using the "defaultResolution.height" and "defaultResolution.width". It returned the correct value after this. 

### What is the impact of this change?

Enables the customers to submit the correct Image Resolution to Deadline for Maya. 

### How was this change tested?

Replaced the maya_render_submitter.py in the local installation and re-run the Maya application. Exporting the scene template from the submitter revealed the correct Image Width and Height in the parameter_values.yaml: 
```
- name: ImageWidth
  value: 320
- name: ImageHeight
  value: 240
```
### Was this change documented?

No.

### Is this a breaking change?

No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
