### PR TITLE
feat: allow adaptor to ignore version when open scene

### DIFF
--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -241,7 +241,7 @@ class DefaultMayaHandler:
         file_path = data.get("scene_file", "")
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"The scene file '{file_path}' does not exist")
-        maya.cmds.file(file_path, open=True, force=True)
+        maya.cmds.file(file_path, open=True, force=True, ignoreVersion=True)
 
         pre_render_mel = maya.cmds.getAttr("defaultRenderGlobals.preMel")
         if pre_render_mel:

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
@@ -84,3 +84,109 @@ class TestDefaultMayaHandler:
         # THEN
         mock_mapping_activated.assert_called_once_with(True)
         assert mock_set_mappings.call_count == len(args["path_mapping_rules"])
+
+    @pytest.mark.parametrize(
+        "args,file_exists",
+        [
+            ({"scene_file": "/path/to/scene.ma"}, True),
+        ],
+    )
+    @patch("os.path.isfile")
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.file")
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.getAttr"
+    )
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval")
+    def test_set_scene_file(
+        self,
+        mock_mel_eval: Mock,
+        mock_get_attr: Mock,
+        mock_file: Mock,
+        mock_isfile: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+        args: dict,
+        file_exists: bool,
+    ):
+        """
+        Test that set_scene_file calls maya.cmds.file with the correct arguments
+        and handles pre-render MEL scripts if they exist.
+        """
+        # GIVEN
+        mock_isfile.return_value = file_exists
+        mock_get_attr.return_value = "some_mel_script"
+
+        # WHEN
+        mayahandlerbase.set_scene_file(args)
+
+        # THEN
+        mock_isfile.assert_called_once_with(args["scene_file"])
+        mock_file.assert_called_once_with(
+            args["scene_file"], open=True, force=True, ignoreVersion=True
+        )
+        mock_get_attr.assert_called_once_with("defaultRenderGlobals.preMel")
+        mock_mel_eval.assert_called_once_with(mock_get_attr.return_value)
+
+    @pytest.mark.parametrize(
+        "args,file_exists",
+        [
+            ({"scene_file": "/path/to/scene.ma"}, True),
+        ],
+    )
+    @patch("os.path.isfile")
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.file")
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.getAttr"
+    )
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval")
+    def test_set_scene_file_no_pre_mel(
+        self,
+        mock_mel_eval: Mock,
+        mock_get_attr: Mock,
+        mock_file: Mock,
+        mock_isfile: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+        args: dict,
+        file_exists: bool,
+    ):
+        """
+        Test that set_scene_file doesn't call maya.mel.eval when there's no pre-render MEL script.
+        """
+        # GIVEN
+        mock_isfile.return_value = file_exists
+        mock_get_attr.return_value = ""  # No pre-render MEL script
+
+        # WHEN
+        mayahandlerbase.set_scene_file(args)
+
+        # THEN
+        mock_isfile.assert_called_once_with(args["scene_file"])
+        mock_file.assert_called_once_with(
+            args["scene_file"], open=True, force=True, ignoreVersion=True
+        )
+        mock_get_attr.assert_called_once_with("defaultRenderGlobals.preMel")
+        mock_mel_eval.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ({"scene_file": "/path/to/nonexistent.ma"}),
+        ],
+    )
+    @patch("os.path.isfile")
+    def test_set_scene_file_not_found(
+        self,
+        mock_isfile: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+        args: dict,
+    ):
+        """
+        Test that set_scene_file raises FileNotFoundError when the scene file doesn't exist.
+        """
+        # GIVEN
+        mock_isfile.return_value = False
+
+        # WHEN/THEN
+        with pytest.raises(
+            FileNotFoundError, match=f"The scene file '{args['scene_file']}' does not exist"
+        ):
+            mayahandlerbase.set_scene_file(args)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Maya adaptor can't open a file that was created with higher version of Maya than what they have access to.

For example, Maya adaptor call Maya 2025.1 to render image, then scene create with Maya version higher than 2025.1 will not able to be open
### What was the solution? (How)
We add an ignore version flag when opening scene to make sure scene can always be open
### What is the impact of this change?
This will unblock customer and make sure the version mismatch did not affect the workflow
### How was this change tested?
#### Unit test result
```
========================================================================================================== tests coverage ===========================================================================================================
_________________________________________________________________________________________ coverage: platform darwin, python 3.12.3-final-0 __________________________________________________________________________________________

Name                                                                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------------------------------------
src/deadline/maya_adaptor/MayaAdaptor/__init__.py                                  3      0      0      0   100%
src/deadline/maya_adaptor/MayaAdaptor/adaptor.py                                 235      5     58      4    97%   61->exit, 302, 318-320, 528->531, 600, 607->616
src/deadline/maya_adaptor/MayaClient/__init__.py                                   3      0      0      0   100%
src/deadline/maya_adaptor/MayaClient/dir_map.py                                   42     19      2      0    52%   21-24, 27, 30, 33, 39-40, 46, 52, 55-58, 61, 71, 75, 79
src/deadline/maya_adaptor/MayaClient/maya_client.py                               40      4      4      0    91%   16-19, 56-58
src/deadline/maya_adaptor/MayaClient/render_handlers/__init__.py                  13      3      6      3    68%   22, 24, 26
src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py            46     36     16      0    16%   29-81, 92-93, 105-107
src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py     103     57     34      0    39%   15, 45-58, 61-80, 93-127, 139, 166-168, 177, 201-205, 217-219, 229-230, 250-251
src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py         42     26     14      1    30%   28-30, 68-108
src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py              65     51     30      2    17%   27-39, 57-120, 129-131, 143-145
src/deadline/maya_adaptor/__init__.py                                              0      0      0      0   100%
src/deadline/maya_submitter/__init__.py                                            6      0      0      0   100%
src/deadline/maya_submitter/assets.py                                             79     36     40      4    48%   26-51, 59-65, 91->89, 98-99, 111-122, 131-133, 160, 165, 168->167
src/deadline/maya_submitter/cameras.py                                            10      4      0      0    60%   19-22, 33
src/deadline/maya_submitter/data_classes.py                                       46     19      8      0    50%   44-71, 74-83
src/deadline/maya_submitter/file_path_editor.py                                   33     17     10      0    37%   37-38, 45-84
src/deadline/maya_submitter/job_bundle_output_test_runner.py                     145    118     42      0    14%   38-47, 53-54, 61-69, 74, 79-111, 116, 123, 131-206, 210-304
src/deadline/maya_submitter/logging.py                                            48     26     10      0    38%   26, 32-38, 43-79
src/deadline/maya_submitter/maya_render_submitter.py                             260    215    108      0    12%   71-311, 320-444, 448-460, 465-508, 520-643, 650-705
src/deadline/maya_submitter/mel_commands.py                                       36      4     10      3    85%   36->exit, 48-54, 59, 88
src/deadline/maya_submitter/render_layers.py                                      33     16      0      0    52%   26-41, 45, 49, 53, 60, 68-71, 79-81
src/deadline/maya_submitter/renderers.py                                          24     13      6      0    37%   16, 23, 34-37, 44-57
src/deadline/maya_submitter/scene.py                                             105     39     18      0    59%   38, 45, 52, 59, 66, 73-76, 86-96, 109, 116, 123-126, 152-156, 163-167, 175-179, 183-189
src/deadline/maya_submitter/utils.py                                              28      0      4      2    94%   62->73, 63->66
--------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                           1445    708    420     19    45%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml
Required test coverage of 41.0% reached. Total coverage: 44.93%
======================================================================================================== slowest 5 durations ========================================================================================================
0.13s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.05s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
0.05s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_populate_action_queue_test_mapping
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_run_data_wrong_schema
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_no_error
======================================================================================================== 99 passed in 3.52s =========================================================================================================
```
#### Integ test result
```
======================================================================================================== test session starts ========================================================================================================
platform darwin -- Python 3.11.4, pytest-8.3.5, pluggy-1.5.0 -- /Applications/Autodesk/maya2025/Maya.app/Contents/MacOS/mayapy
cachedir: .pytest_cache
rootdir: /Volumes/workplace/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: flaky-3.8.1, cov-6.1.1, xdist-3.6.1
1 worker [2 items]     
scheduling tests via LoadScheduling

test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 50%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter 
===Flaky Test Report===

test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!

===End Flaky Test Report===

======================================================================================================== slowest 5 durations ========================================================================================================
30.44s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
2.02s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
1.21s call     test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.04s teardown test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s setup    test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
======================================================================================================== 2 passed in 36.67s =========================================================================================================
```

#### Manual test
- Create custom adaptor wheels
- Submit a job with a scene that was create on Maya 2025 to a queue with Maya 2024 conda package
- Have 2 version, one with current adaptor and 1 with changed adaptor injected in
- Download output for comparision
- Confirm that scene that was error out before work after `ignore version` flag is added in
### Was this change documented?

Yes

### Is this a breaking change?

No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
