### PR TITLE
chore: Set timeouts for the adaptor in the job template

### DIFF
--- a/src/deadline/maya_submitter/default_maya_job_template.yaml
+++ b/src/deadline/maya_submitter/default_maya_job_template.yaml
@@ -102,6 +102,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -111,6 +112,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData

--- a/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
@@ -207,6 +207,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -216,6 +217,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
https://github.com/aws-deadline/deadline-cloud-for-maya/issues/239

### What was the solution? (How)
Set timeouts for the adaptor in the job template 

### What is the impact of this change?
Add guardrails for better performance.

### How was this change tested?
* `hatch build && hatch run test`
*  Ran test bundle.

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*