### PR TITLE
fix: Fix submitter integration test for Windows

### DIFF
--- a/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
@@ -133,6 +133,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -142,6 +143,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData

--- a/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
@@ -269,6 +269,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -278,6 +279,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData
@@ -342,6 +344,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -351,6 +354,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData
@@ -416,6 +420,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -425,6 +430,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData
@@ -491,6 +497,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -500,6 +507,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData
@@ -564,6 +572,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -573,6 +582,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData

--- a/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
@@ -145,6 +145,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -154,6 +155,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData
@@ -218,6 +220,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -227,6 +230,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData
@@ -291,6 +295,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -300,6 +305,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData

--- a/job_bundle_output_tests/referenced_layers/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/referenced_layers/expected_job_bundle/template.yaml
@@ -145,6 +145,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -154,6 +155,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData

--- a/job_bundle_output_tests/renderman/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/renderman/expected_job_bundle/template.yaml
@@ -133,6 +133,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -142,6 +143,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData

--- a/test/integ/helpers/output_comparison.py
+++ b/test/integ/helpers/output_comparison.py
@@ -51,6 +51,7 @@ def are_parameter_values_similar(job_history_dir: Path, expected_parameter_value
     """
     with open(job_history_dir / PARAMETER_VALUES) as actual:
         actual_parameter_values = yaml.safe_load(actual)
+
         # Compare the lengths so that we can cover the case of duplicate parameters.
         assert len(actual_parameter_values["parameterValues"]) == len(
             expected_parameter_values["parameterValues"]
@@ -58,7 +59,14 @@ def are_parameter_values_similar(job_history_dir: Path, expected_parameter_value
 
         # The order of the list of parameter values doesn't matter,
         for parameter_value in expected_parameter_values["parameterValues"]:
-            assert parameter_value in actual_parameter_values["parameterValues"]
+            name = parameter_value["name"]
+            value = parameter_value["value"]
+
+            # Convert to help with Windows path format
+            if not isinstance(value, int):
+                value = value.replace("\\", "/")
+
+            assert value == extract_parameter_value(actual_parameter_values, name)
 
 
 def are_asset_references_similar(
@@ -77,4 +85,8 @@ def are_asset_references_similar(
         actual_asset_reference["assetReferences"]["inputs"]["filenames"] = set(
             actual_asset_reference["assetReferences"]["inputs"]["filenames"]
         )
+        directories = expected_asset_references["assetReferences"]["outputs"]["directories"]
+        expected_asset_references["assetReferences"]["outputs"]["directories"] = [
+            d.replace("\\", "/") for d in directories
+        ]
         assert actual_asset_reference == expected_asset_references

--- a/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
@@ -134,6 +134,7 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -143,6 +144,7 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
   script:
     embeddedFiles:
     - name: runData


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The submitter integration test fails due to a couple of unrelated issues.
1. The test fails on Windows because of issues with directory paths format.
2. The default job template was modified to introduce timeouts, but some of the expected test job templates weren't. 

### What was the solution? (How)
1. Handle Windows path format in the submitter test.
2. Update the expected test job templates to include the timeouts.

### What is the impact of this change?
Fix submitter integration test.

### How was this change tested?
Ran submitter integ test on Windows.
```
test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
[gw0] [ 50%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
===Flaky Test Report===

test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!

===End Flaky Test Report===

=================================================================================================================================================== slowest 5 durations ====================================================================================================================================================
35.23s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
5.11s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
1.49s call     test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.12s teardown test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s setup    test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
==================================================================================================================================================== 2 passed in 45.12s ====================================================================================================================================================
```

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
Yes.
```

Timestamp: 2025-05-20T20:29:34.410259+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\cube

cube
Test succeeded

Timestamp: 2025-05-20T20:29:34.635992+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\layers

layers
Test succeeded

Timestamp: 2025-05-20T20:29:35.116330+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\layers_no_variation

layers_no_variation
Test succeeded

Timestamp: 2025-05-20T20:29:35.403927+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\referenced_layers

referenced_layers
Test succeeded

Timestamp: 2025-05-20T20:29:35.758347+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\renderman
Skipping test renderman because Renderman for Maya is not installed.
All tests passed, ran 4 total.
Timestamp: 2025-05-20T20:29:47.428719+00:00
```

### Was this change documented?
N/A

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
