### PR TITLE
feat: Add ignore version environment variable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ $ maya -help
 
 For more information on the commands the OpenJD adaptor runtime provides, see [here][openjd-adaptor-runtime-lifecycle].
 
+Maya Adaptor by default will skip version checking when opening scene. If you want to change this, set the `MAYA_IGNORE_VERSION` enviroment variable accordingly.
+
+For example, to enable version checking:
+```
+export MAYA_IGNORE_VERSION=false
+```
+
 ### Maya Software Availability in AWS Deadline Cloud Service Managed Fleets
 
 You will need to ensure that the version of Maya that you want to run is available on the worker host when you are using

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -15,6 +15,22 @@ def _get_render_layer_display_name(render_layer_name: str) -> str:
     return maya.mel.eval(f'renderLayerDisplayName "{render_layer_name}"')
 
 
+def _get_ignore_version_flag() -> bool:
+    raw_val = os.environ.get("MAYA_IGNORE_VERSION", "True")
+    normalized_val = raw_val.strip().lower()
+
+    if normalized_val == "false":
+        return False
+    elif normalized_val == "true":
+        return True
+    else:
+        print(
+            f"Warning: Unrecognized value for 'MAYA_IGNORE_VERSION': '{raw_val}'. "
+            "Expected 'False' to disable. Defaulting to True (ignoring version)."
+        )
+        return True
+
+
 class DefaultMayaHandler:
     cameras: Optional[List[str]] = None
     render_kwargs: Dict[str, Any]
@@ -238,10 +254,11 @@ class DefaultMayaHandler:
         Raises:
             FileNotFoundError: If the file provided in the data dictionary does not exist.
         """
+        ignore_version_flag = _get_ignore_version_flag()
         file_path = data.get("scene_file", "")
         if not os.path.isfile(file_path):
             raise FileNotFoundError(f"The scene file '{file_path}' does not exist")
-        maya.cmds.file(file_path, open=True, force=True, ignoreVersion=True)
+        maya.cmds.file(file_path, open=True, force=True, ignoreVersion=ignore_version_flag)
 
         pre_render_mel = maya.cmds.getAttr("defaultRenderGlobals.preMel")
         if pre_render_mel:

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
+from io import StringIO
+import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -97,47 +99,6 @@ class TestDefaultMayaHandler:
         "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.getAttr"
     )
     @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval")
-    def test_set_scene_file(
-        self,
-        mock_mel_eval: Mock,
-        mock_get_attr: Mock,
-        mock_file: Mock,
-        mock_isfile: Mock,
-        mayahandlerbase: DefaultMayaHandler,
-        args: dict,
-        file_exists: bool,
-    ):
-        """
-        Test that set_scene_file calls maya.cmds.file with the correct arguments
-        and handles pre-render MEL scripts if they exist.
-        """
-        # GIVEN
-        mock_isfile.return_value = file_exists
-        mock_get_attr.return_value = "some_mel_script"
-
-        # WHEN
-        mayahandlerbase.set_scene_file(args)
-
-        # THEN
-        mock_isfile.assert_called_once_with(args["scene_file"])
-        mock_file.assert_called_once_with(
-            args["scene_file"], open=True, force=True, ignoreVersion=True
-        )
-        mock_get_attr.assert_called_once_with("defaultRenderGlobals.preMel")
-        mock_mel_eval.assert_called_once_with(mock_get_attr.return_value)
-
-    @pytest.mark.parametrize(
-        "args,file_exists",
-        [
-            ({"scene_file": "/path/to/scene.ma"}, True),
-        ],
-    )
-    @patch("os.path.isfile")
-    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.file")
-    @patch(
-        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.getAttr"
-    )
-    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval")
     def test_set_scene_file_no_pre_mel(
         self,
         mock_mel_eval: Mock,
@@ -190,3 +151,131 @@ class TestDefaultMayaHandler:
             FileNotFoundError, match=f"The scene file '{args['scene_file']}' does not exist"
         ):
             mayahandlerbase.set_scene_file(args)
+
+    @pytest.mark.parametrize(
+        "args,file_exists",
+        [
+            ({"scene_file": "/path/to/scene.ma"}, True),
+        ],
+    )
+    @patch("os.path.isfile")
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.file")
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.getAttr"
+    )
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval")
+    @patch.dict(os.environ, {"MAYA_IGNORE_VERSION": "true"})
+    def test_set_scene_file_check_version_true(
+        self,
+        mock_mel_eval: Mock,
+        mock_get_attr: Mock,
+        mock_file: Mock,
+        mock_isfile: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+        args: dict,
+        file_exists: bool,
+    ):
+        """
+        Test that set_scene_file calls maya.cmds.file with the correct arguments
+        and handles pre-render MEL scripts if they exist.
+        """
+        # GIVEN
+        mock_isfile.return_value = file_exists
+        mock_get_attr.return_value = "some_mel_script"
+
+        # WHEN
+        mayahandlerbase.set_scene_file(args)
+
+        # THEN
+        mock_isfile.assert_called_once_with(args["scene_file"])
+        mock_file.assert_called_once_with(
+            args["scene_file"], open=True, force=True, ignoreVersion=True
+        )
+        mock_get_attr.assert_called_once_with("defaultRenderGlobals.preMel")
+        mock_mel_eval.assert_called_once_with(mock_get_attr.return_value)
+
+    @pytest.mark.parametrize(
+        "args,file_exists",
+        [
+            ({"scene_file": "/path/to/scene.ma"}, True),
+        ],
+    )
+    @patch("os.path.isfile")
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.file")
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.getAttr"
+    )
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval")
+    @patch.dict(os.environ, {"MAYA_IGNORE_VERSION": "false"})
+    def test_set_scene_file_check_version_false(
+        self,
+        mock_mel_eval: Mock,
+        mock_get_attr: Mock,
+        mock_file: Mock,
+        mock_isfile: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+        args: dict,
+        file_exists: bool,
+    ):
+        """
+        Test that set_scene_file calls maya.cmds.file with the correct arguments
+        and handles pre-render MEL scripts if they exist.
+        """
+        # GIVEN
+        mock_isfile.return_value = file_exists
+        mock_get_attr.return_value = "some_mel_script"
+
+        # WHEN
+        mayahandlerbase.set_scene_file(args)
+
+        # THEN
+        mock_isfile.assert_called_once_with(args["scene_file"])
+        mock_file.assert_called_once_with(
+            args["scene_file"], open=True, force=True, ignoreVersion=False
+        )
+        mock_get_attr.assert_called_once_with("defaultRenderGlobals.preMel")
+        mock_mel_eval.assert_called_once_with(mock_get_attr.return_value)
+
+    @pytest.mark.parametrize(
+        "args,file_exists",
+        [
+            ({"scene_file": "/path/to/scene.ma"}, True),
+        ],
+    )
+    @patch("os.path.isfile")
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.file")
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.getAttr"
+    )
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval")
+    @patch.dict(os.environ, {"MAYA_IGNORE_VERSION": "banana"})
+    def test_set_scene_file_check_version_random(
+        self,
+        mock_mel_eval: Mock,
+        mock_get_attr: Mock,
+        mock_file: Mock,
+        mock_isfile: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+        args: dict,
+        file_exists: bool,
+    ):
+        """
+        Test that set_scene_file calls maya.cmds.file with the correct arguments
+        and handles pre-render MEL scripts if they exist.
+        """
+        # GIVEN
+        mock_isfile.return_value = file_exists
+        mock_get_attr.return_value = "some_mel_script"
+
+        # WHEN
+        with patch("sys.stdout", new=StringIO()) as output:
+            mayahandlerbase.set_scene_file(args)
+
+            # THEN
+            mock_isfile.assert_called_once_with(args["scene_file"])
+            mock_file.assert_called_once_with(
+                args["scene_file"], open=True, force=True, ignoreVersion=True
+            )
+            mock_get_attr.assert_called_once_with("defaultRenderGlobals.preMel")
+            mock_mel_eval.assert_called_once_with(mock_get_attr.return_value)
+            assert "Unrecognized value" in output.getvalue()


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
We introduce a ignore version flag in #273. But there is no way to toggle it on or off based on customers need
### What was the solution? (How)
Add an environment flag to make this version check feature toggleable

### What is the impact of this change?
Customers can now also have strict version checking if needed

### How was this change tested?

#### Unit test result
```
=================================================================================================================================== tests coverage ===================================================================================================================================
__________________________________________________________________________________________________________________ coverage: platform darwin, python 3.12.3-final-0 __________________________________________________________________________________________________________________

Name                                                                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------------------------------------
src/deadline/maya_adaptor/MayaAdaptor/__init__.py                                  3      0      0      0   100%
src/deadline/maya_adaptor/MayaAdaptor/adaptor.py                                 235      5     58      4    97%   61->exit, 302, 318-320, 528->531, 600, 607->616
src/deadline/maya_adaptor/MayaClient/__init__.py                                   3      0      0      0   100%
src/deadline/maya_adaptor/MayaClient/dir_map.py                                   42     19      2      0    52%   21-24, 27, 30, 33, 39-40, 46, 52, 55-58, 61, 71, 75, 79
src/deadline/maya_adaptor/MayaClient/maya_client.py                               40      4      4      0    91%   16-19, 56-58
src/deadline/maya_adaptor/MayaClient/render_handlers/__init__.py                  16      4      8      4    67%   23, 25, 27, 29
src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py            46     36     16      0    16%   29-81, 92-93, 105-107
src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py     115     57     40      0    46%   15, 64-77, 80-99, 112-146, 158, 185-187, 196, 220-224, 236-238, 248-249, 273-274
src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py          32     22     10      0    24%   35-61, 73-75
src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py         42     26     14      1    30%   28-30, 68-108
src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py              65     51     30      2    17%   27-39, 57-120, 129-131, 143-145
src/deadline/maya_adaptor/__init__.py                                              0      0      0      0   100%
src/deadline/maya_submitter/__init__.py                                            6      0      0      0   100%
src/deadline/maya_submitter/assets.py                                             79     36     40      4    48%   26-51, 59-65, 91->89, 98-99, 111-122, 131-133, 160, 165, 168->167
src/deadline/maya_submitter/cameras.py                                            10      4      0      0    60%   19-22, 33
src/deadline/maya_submitter/data_classes.py                                       46     19      8      0    50%   44-71, 74-83
src/deadline/maya_submitter/file_path_editor.py                                   33     17     10      0    37%   37-38, 45-84
src/deadline/maya_submitter/job_bundle_output_test_runner.py                     145    118     42      0    14%   38-47, 53-54, 61-69, 74, 79-111, 116, 123, 131-206, 210-304
src/deadline/maya_submitter/logging.py                                            48     26     10      0    38%   26, 32-38, 43-79
src/deadline/maya_submitter/maya_render_submitter.py                             260    215    108      0    12%   71-311, 320-444, 448-460, 465-508, 520-643, 650-705
src/deadline/maya_submitter/mel_commands.py                                       36      4     10      3    85%   36->exit, 48-54, 59, 88
src/deadline/maya_submitter/render_layers.py                                      33     16      0      0    52%   26-41, 45, 49, 53, 60, 68-71, 79-81
src/deadline/maya_submitter/renderers.py                                          24     13      6      0    37%   16, 23, 34-37, 44-57
src/deadline/maya_submitter/scene.py                                             106     39     18      0    59%   39, 46, 53, 60, 67, 74-77, 87-97, 110, 117, 124-127, 153-157, 164-168, 176-180, 184-190
src/deadline/maya_submitter/utils.py                                              28      0      4      2    94%   62->73, 63->66
--------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                           1493    731    438     20    45%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml
Required test coverage of 41.0% reached. Total coverage: 45.05%
================================================================================================================================ slowest 5 durations =================================================================================================================================
0.13s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.05s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
0.05s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_fail
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_run_data_wrong_schema
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[renderman-False]
================================================================================================================================ 105 passed in 3.44s =================================================================================================================================
```
#### Integ test result
```
================================================================================================================================ test session starts =================================================================================================================================
platform darwin -- Python 3.11.4, pytest-8.3.5, pluggy-1.5.0 -- /Applications/Autodesk/maya2025/Maya.app/Contents/MacOS/mayapy
cachedir: .pytest_cache
rootdir: /Volumes/workplace/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: flaky-3.8.1, cov-6.1.1, xdist-3.6.1
1 worker [2 items]     
scheduling tests via LoadScheduling

test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 50%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter 
===Flaky Test Report===

test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!

===End Flaky Test Report===

================================================================================================================================ slowest 5 durations =================================================================================================================================
29.86s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
2.08s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
1.10s call     test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.04s teardown test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s setup    test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
================================================================================================================================= 2 passed in 35.12s =================================================================================================================================
```
#### Installer test result
Not Applicable


### Was this change documented?

Yes
### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
