### PR TITLE
fix: sdist failed to install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ destinations = [
 
 [tool.hatch.build.targets.sdist]
 include = [
-    "src/*",
+    "src/deadline",
+    "maya_submitter_plugin",
     "hatch_custom_hook.py",
 ]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running `pip install` with an sdist (compressed or uncompressed) you get:
```
FileNotFoundError: Forced include not found: /private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pip-req-build-g5_xlihl/maya_submitter_plugin
```

### What was the solution? (How)

Instead of packaging only the package for sdist, we also now include the custom script

### What is the impact of this change?

buildable/installable sdist

### How was this change tested?

```
hatch clean && hatch build && pip install --force-reinstall dist/*.tar.gz
```

### Was this change documented?

N/A

### Is this a breaking change?
N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*