### PR TITLE
test: adding additional input validation tests for frame and camera s…

### DIFF
--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_redshift_handler.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_redshift_handler.py
@@ -44,3 +44,27 @@ class TestRedshiftHandler:
 
         # THEN
         assert handler.image_width == args["image_width"]
+
+    def test_start_render_throws_runtime_error_when_camera_not_set(self) -> None:
+        """Tests that a runtime error is raised when there is no camera"""
+        # GIVEN
+        handler = RedshiftHandler()
+
+        # WHEN
+        start_render_data = {"frame": 1}
+
+        # THEN
+        with pytest.raises(RuntimeError):
+            handler.start_render(start_render_data)
+
+    def test_start_render_throws_runtime_error_when_frama_not_set(self) -> None:
+        """Tests that a runtime error is raised when there is no frame"""
+        # GIVEN
+        handler = RedshiftHandler()
+
+        # WHEN
+        start_render_data = {"camera": "persp"}
+
+        # THEN
+        with pytest.raises(RuntimeError):
+            handler.start_render(start_render_data)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
* We want to have extra testing around how the redshift handler handles missing camera and frame settings in its "start_render" method.

### What was the solution? (How)
* Add the additional basic tests

### What is the impact of this change?
* Increased unit test coverage

### How was this change tested?

#### Unit test result
```
                                                                                          [100%]
============================================================================================= tests coverage ==============================================================================================
_____________________________________________________________________________ coverage: platform darwin, python 3.9.6-final-0 _____________________________________________________________________________

Name                                                                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------------------------------------
src/deadline/maya_adaptor/MayaAdaptor/__init__.py                                  3      0      0      0   100%
src/deadline/maya_adaptor/MayaAdaptor/adaptor.py                                 235      5     58      4    97%   61->exit, 302, 318-320, 528->531, 600, 607->616
src/deadline/maya_adaptor/MayaClient/__init__.py                                   3      0      0      0   100%
src/deadline/maya_adaptor/MayaClient/dir_map.py                                   42     19      2      0    52%   21-24, 27, 30, 33, 39-40, 46, 52, 55-58, 61, 71, 75, 79
src/deadline/maya_adaptor/MayaClient/maya_client.py                               40      4      4      0    91%   16-19, 56-58
src/deadline/maya_adaptor/MayaClient/render_handlers/__init__.py                  16      4      8      4    67%   23, 25, 27, 29
src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py            46     36     16      0    16%   29-81, 92-93, 105-107
src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py     113     50     38      1    52%   15, 69-70, 74, 77-96, 109-143, 155, 182-184, 193, 217-221, 233-235, 245-246, 267-268
src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py          32     21     10      0    26%   37-61, 73-75
src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py         42     26     14      1    30%   28-30, 68-108
src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py              65     51     30      2    17%   27-39, 57-120, 129-131, 143-145
src/deadline/maya_adaptor/__init__.py                                              0      0      0      0   100%
src/deadline/maya_submitter/__init__.py                                            6      0      0      0   100%
src/deadline/maya_submitter/assets.py                                             79     36     40      4    48%   26-51, 59-65, 91->89, 98-99, 111-122, 131-133, 160, 165, 168->167
src/deadline/maya_submitter/cameras.py                                             9      4      0      0    56%   19-22, 33
src/deadline/maya_submitter/data_classes.py                                       46     19      8      0    50%   44-71, 74-83
src/deadline/maya_submitter/file_path_editor.py                                   32     17     10      0    36%   37-38, 45-84
src/deadline/maya_submitter/job_bundle_output_test_runner.py                     152    124     42      0    14%   39-48, 54-55, 62-70, 75, 80-112, 117, 124, 132-207, 211-311
src/deadline/maya_submitter/logging.py                                            48     26     10      0    38%   26, 32-38, 43-79
src/deadline/maya_submitter/maya_render_submitter.py                             261    216    108      0    12%   71-311, 320-444, 448-460, 465-508, 520-645, 654-709
src/deadline/maya_submitter/mel_commands.py                                       36      4     10      3    85%   36->exit, 48-54, 59, 88
src/deadline/maya_submitter/render_layers.py                                      33     16      0      0    52%   26-41, 45, 49, 53, 60, 68-71, 79-81
src/deadline/maya_submitter/renderers.py                                          24     13      6      0    37%   16, 23, 34-37, 44-57
src/deadline/maya_submitter/scene.py                                             105     39     18      0    59%   39, 46, 53, 60, 67, 74-77, 87-97, 110, 117, 124-127, 153-157, 164-168, 176-180, 184-190
src/deadline/maya_submitter/utils.py                                              28      0      4      2    94%   62->73, 63->66
--------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                           1496    730    436     21    45%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml
Required test coverage of 41.0% reached. Total coverage: 45.29%
=========================================================================================== slowest 5 durations ===========================================================================================
0.12s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.05s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_server_init_fail
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[arnold-True]
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[renderman-False]
=========================================================================================== 106 passed in 4.42s ===========================================================================================
```

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
* No, this PR only contains updates to unit testing


### Was this change documented?

N/A

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
