### PR TITLE
fix: Maya scene with many asset files hangs without user feedback

### DIFF
--- a/src/deadline/maya_submitter/assets.py
+++ b/src/deadline/maya_submitter/assets.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import re
+import time
 from functools import lru_cache
 from pathlib import Path
 from typing import Generator, Iterable
@@ -15,9 +16,12 @@ _FRAME_RE = re.compile("#+")
 
 
 class AssetIntrospector:
-    def parse_scene_assets(self) -> set[Path]:
+    def parse_scene_assets(self, progress_callback=None) -> set[Path]:
         """
         Searches the scene for assets, and filters out assets that are not needed for Rendering.
+
+        Args:
+            progress_callback: Optional callback function that takes a string argument for progress updates
 
         Returns:
             set[Path]: A set containing filepaths of assets needed for Rendering
@@ -28,14 +32,26 @@ class AssetIntrospector:
         assets: set[Path] = set()
 
         # Grab any yeti files
-        assets.update(self._get_yeti_files())
+        if progress_callback:
+            progress_callback("Searching for Yeti cache files...")
+        assets.update(self._get_yeti_files(progress_callback))
 
         if Scene.renderer() == RendererNames.arnold.value:
-            assets.update(self._get_tx_files())
+            if progress_callback:
+                progress_callback("Searching for Arnold texture files...")
+            assets.update(self._get_tx_files(progress_callback))
         elif Scene.renderer() == RendererNames.renderman.value:
-            assets.update(self._get_tex_files())
+            if progress_callback:
+                progress_callback("Searching for Renderman texture files...")
+            assets.update(self._get_tex_files(progress_callback))
 
-        for ref in FilePathEditor.fileRefs():
+        file_refs = list(FilePathEditor.fileRefs())
+        total_refs = len(file_refs)
+        print(f"Processing {total_refs} file references")
+        if progress_callback:
+            progress_callback(f"Processing {total_refs} file references...")
+
+        for i, ref in enumerate(file_refs):
             normalized_path = os.path.normpath(ref.path)
             # Files without tokens may already have been checked, if so, skip
             if normalized_path in assets:
@@ -45,28 +61,61 @@ class AssetIntrospector:
             # these files since it returns the original generator which is exhausted.
             for path in self._expand_path(normalized_path):
                 assets.add(path)
+            # Only refresh UI every 100 elements to improve performance
+            if i % 100 == 0:
+                print(f"Processed {i+1}/{total_refs} file references at {time.time()}")
+                if progress_callback:
+                    progress_callback(f"Processed {i+1}/{total_refs} file references...")
 
         assets.add(Path(Scene.name()))
 
+        if progress_callback:
+            progress_callback(f"Found {len(assets)} assets in total")
+
         return assets
 
-    def _get_yeti_files(self) -> set[Path]:
+    def _get_yeti_files(self, progress_callback=None) -> set[Path]:
         """
         If Yeti plugin nodes are in the scene, searches for fur cache files
+
+        Args:
+            progress_callback: Optional callback function for progress updates
+
         Returns:
             set[Path]: A set of yeti files
         """
         yeti_files: set[Path] = set()
         cache_files = Scene.yeti_cache_files()
-        for cache_path in cache_files:
+        total_files = len(cache_files)
+
+        if total_files > 0:
+            print(f"Processing {total_files} Yeti cache files")
+            if progress_callback:
+                progress_callback(f"Processing {total_files} Yeti cache files...")
+
+        for i, cache_path in enumerate(cache_files):
             for expanded_path in self._expand_path(cache_path):
                 yeti_files.add(expanded_path)
 
+            # For every 100 yeti files, update progress
+            if i % 100 == 0 and i > 0:
+                print(f"Processed {i}/{total_files} Yeti cache files at {time.time()}")
+                if progress_callback:
+                    progress_callback(f"Processed {i}/{total_files} Yeti cache files...")
+
+        if total_files > 0:
+            print(f"Completed processing all {total_files} Yeti cache files at {time.time()}")
+            if progress_callback:
+                progress_callback(f"Completed processing all {total_files} Yeti cache files")
+
         return yeti_files
 
-    def _get_tex_files(self) -> set[Path]:
+    def _get_tex_files(self, progress_callback=None) -> set[Path]:
         """
         Searches for Renderman .tex files
+
+        Args:
+            progress_callback: Optional callback function for progress updates
 
         Returns:
             set[Path]: A set of tex files associated to scene textures
@@ -81,9 +130,21 @@ class AssetIntrospector:
         filename_tex_set: set[Path] = set()
         directories = filePathEditor(listDirectories="", query=True)
 
+        total_files = 0
+        processed = 0
+
+        # First count total files for better progress reporting
         for directory in directories:
             files = filePathEditor(listFiles=directory, withAttribute=True, query=True)
-            for filename, attribute in zip(files[0::2], files[1::2]):
+            total_files += len(files) // 2  # files come in pairs (filename, attribute)
+
+        print(f"Processing {total_files} Renderman texture files")
+        if progress_callback:
+            progress_callback(f"Processing {total_files} Renderman texture files...")
+
+        for directory in directories:
+            files = filePathEditor(listFiles=directory, withAttribute=True, query=True)
+            for i, (filename, attribute) in enumerate(zip(files[0::2], files[1::2])):
                 full_path = os.path.join(directory, filename)
                 # Expand tags if any are present
                 for expanded_path in self._expand_path(full_path):
@@ -98,11 +159,33 @@ class AssetIntrospector:
                         except KeyError:
                             pass
 
+                processed += 1
+                # For every 100 texture files, update progress
+                if processed % 100 == 0:
+                    print(
+                        f"Processed {processed}/{total_files} Renderman texture files at {time.time()}"
+                    )
+                    if progress_callback:
+                        progress_callback(
+                            f"Processed {processed}/{total_files} Renderman texture files..."
+                        )
+
+        # Final count
+        if total_files > 0:
+            print(
+                f"Completed processing all {total_files} Renderman texture files at {time.time()}"
+            )
+            if progress_callback:
+                progress_callback(f"Completed processing all {total_files} Renderman texture files")
+
         return filename_tex_set
 
-    def _get_tx_files(self) -> set[Path]:
+    def _get_tx_files(self, progress_callback=None) -> set[Path]:
         """
         Searches for both source and tx files for Arnold
+
+        Args:
+            progress_callback: Optional callback function for progress updates
 
         Returns:
             set[Path]: A set of original asset paths and their associated tx files.
@@ -112,12 +195,32 @@ class AssetIntrospector:
         if not Scene.autotx() and not Scene.use_existing_tiled_textures():
             return arnold_textures_files
 
-        for img_path in self._get_arnold_texture_files():
+        texture_files = list(self._get_arnold_texture_files())
+        total_textures = len(texture_files)
+        print(f"Processing {total_textures} Arnold texture files")
+        if progress_callback:
+            progress_callback(f"Processing {total_textures} Arnold texture files...")
+
+        for i, img_path in enumerate(texture_files):
             for expanded_path in self._expand_path(img_path):
                 arnold_textures_files.add(expanded_path)
                 # expanded files are guaranteed to exist, but we haven't checked the associated .tx file yet
                 if os.path.isfile(expanded_path.with_suffix(".tx")):
                     arnold_textures_files.add(expanded_path.with_suffix(".tx"))
+
+            # For every 100 texture files, update progress
+            if i % 100 == 0 and i > 0:
+                print(f"Processed {i}/{total_textures} Arnold texture files at {time.time()}")
+                if progress_callback:
+                    progress_callback(f"Processed {i}/{total_textures} Arnold texture files...")
+
+        # Final count
+        if total_textures > 0:
+            print(
+                f"Completed processing all {total_textures} Arnold texture files at {time.time()}"
+            )
+            if progress_callback:
+                progress_callback(f"Completed processing all {total_textures} Arnold texture files")
 
         return arnold_textures_files
 

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -39,6 +39,7 @@ from .cameras import get_renderable_camera_names, ALL_CAMERAS
 from ._version import version, version_tuple as adaptor_version_tuple
 from .ui.components.scene_settings_tab import SceneSettingsWidget
 from deadline.client.job_bundle.submission import AssetReferences
+import time
 
 logger = getLogger(__name__)
 
@@ -462,18 +463,20 @@ def _set_render_setting(load_sticky_setting: bool = False) -> RenderSubmitterUIS
 
 def _set_render_layer_data() -> list[RenderLayerData]:
     # Create a dictionary for the layers, and accumulate data about each layer
+    print(f"_set_render_layer_data - get_all_renderable_render_layer_names {time.time()}")
     render_layer_names = get_all_renderable_render_layer_names()
     if not render_layer_names:
         raise DeadlineOperationError(
             "No render layer is set as renderable. At least one must be renderable to submit a job."
         )
-
+    print(f"_set_render_layer_data processing layers {time.time()}")
     render_layers: list[RenderLayerData] = []
     with saved_current_render_layer():
         for render_layer_name in render_layer_names:
             set_current_render_layer(render_layer_name)
 
             display_name = get_render_layer_display_name(render_layer_name)
+            print(f"_set_render_layer_data processing layer {display_name} {time.time()}")
             renderer_name = Scene.renderer()
             renderable_camera_names = get_renderable_camera_names()
             output_directories: set[str] = set()
@@ -501,6 +504,7 @@ def _set_render_layer_data() -> list[RenderLayerData]:
                     image_resolution=image_resolution,
                 )
             )
+            print(f"_set_render_layer_data done processing layer {time.time()}")
 
     # Sort the layers by name
     render_layers.sort(key=lambda layer: layer.display_name)
@@ -650,21 +654,67 @@ def on_create_job_bundle_callback(
 def show_maya_render_submitter(
     parent, f=Qt.WindowFlags(), load_sticky_setting: bool = False
 ) -> Optional[SubmitJobToDeadlineDialog]:
+    print("Starting Maya render submitter")
 
-    render_settings = _set_render_setting()
+    # Create and show a progress dialog
+    from qtpy.QtWidgets import QProgressDialog
+    from qtpy.QtCore import Qt  # type: ignore
 
+    progress_dialog = QProgressDialog("Initializing...", "", 0, 1, parent)
+    progress_dialog.setWindowTitle("Asset Detection")
+    progress_dialog.setWindowModality(Qt.WindowModal)
+    progress_dialog.setCancelButton(None)  # Remove cancel button
+    progress_dialog.setMinimumDuration(0)  # Show immediately
+    progress_dialog.setValue(0)
+
+    # Create a callback function to update the progress dialog
+    def update_progress(message):
+        progress_dialog.setLabelText(message)
+        maya.cmds.refresh(force=True)
+        time.sleep(0.05)  # Add a small sleep to ensure the UI has time to update
+
+    # Initialize with first message
+    update_progress("Loading render settings...")
+    render_settings = _set_render_setting(load_sticky_setting)
+
+    update_progress("Processing render layers...")
     render_layers: list[RenderLayerData] = _set_render_layer_data()
-
+    print(f"Render layers processed at {time.time()}")
     all_renderers: set[str] = {layer_data.renderer_name for layer_data in render_layers}
 
     auto_detected_attachments = AssetReferences()
     introspector = AssetIntrospector()
-    auto_detected_attachments.input_filenames = set(
-        os.path.normpath(path) for path in introspector.parse_scene_assets()
-    )
+    print(f"Asset introspector initialized at {time.time()}")
 
+    update_progress("Analyzing scene assets...")
+    scene_assets = list(introspector.parse_scene_assets(progress_callback=update_progress))
+    total_assets = len(scene_assets)
+
+    # Update progress dialog with total assets
+    progress_dialog.setMaximum(total_assets)
+    progress_dialog.setValue(0)
+
+    # Process assets with progress updates
+    processed_assets = set()
+    print(f"Starting to process {total_assets} scene assets...")
+
+    for i, asset_path in enumerate(scene_assets):
+        progress_dialog.setValue(i)
+        processed_assets.add(os.path.normpath(asset_path))
+        # Process in larger batches to improve performance - refresh UI every 100 assets
+        if i % 100 == 0 and i > 0:
+            print(f"Processed {i+1}/{total_assets} assets at {time.time()}")
+            update_progress(f"Processed {i+1}/{total_assets} assets")
+
+    progress_dialog.setValue(total_assets)
+    auto_detected_attachments.input_filenames = processed_assets
+    print(f"All {total_assets} assets processed at {time.time()}")
+    update_progress(f"All {total_assets} assets processed")
+
+    update_progress("Adding output directories...")
     for layer_data in render_layers:
         auto_detected_attachments.output_directories.update(layer_data.output_directories)
+    print(f"Output directories added at {time.time()}")
 
     attachments = AssetReferences(
         input_filenames=set(render_settings.input_filenames),
@@ -672,9 +722,9 @@ def show_maya_render_submitter(
         output_directories=set(render_settings.output_directories),
     )
 
+    update_progress("Preparing submission parameters...")
     maya_version = maya.cmds.about(version=True)
     adaptor_version = ".".join(str(v) for v in adaptor_version_tuple[:2])
-
     # Need Maya and the Maya OpenJD application interface adaptor
     rez_packages = f"mayaIO-{maya_version} deadline_cloud_for_maya"
     conda_packages = f"maya={maya_version}.* maya-openjd={adaptor_version}.*"
@@ -690,6 +740,10 @@ def show_maya_render_submitter(
         rez_packages += " mtoa"
         conda_packages += " maya-mtoa"
 
+    # Close the progress dialog before creating the submission dialog
+    progress_dialog.close()
+    print("Progress dialog closed, creating submission dialog")
+
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,
         initial_job_settings=render_settings,
@@ -704,6 +758,5 @@ def show_maya_render_submitter(
         f=f,
         show_host_requirements_tab=True,
     )
-
     submitter_dialog.show()
     return submitter_dialog

--- a/test/unit/deadline_submitter_for_maya/scripts/test_assets.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_assets.py
@@ -146,10 +146,8 @@ def test_get_tex_files(
 
     # python 3.9 3.10 requires to mock the import of maya.cmds
     sys.modules["maya.cmds"] = mock_cmds
-    mock_cmds.filePathEditor.side_effect = [
-        [path],
-        [basename, "skydome_light.map"],
-    ]
+    # Set up the mock to return the expected values for each call
+    mock_cmds.filePathEditor.return_value = [basename, "skydome_light.map"]
 
     # mock the import of a non existent library (renderman for maya)
     mock_txmanager = MagicMock()


### PR DESCRIPTION
Fixes: Customer reported issue. Maya submitter "hangs" when launching with thousands of assets. The 

### What was the problem/requirement? (What/Why)
- Customers have thousands of assets in Maya, and customers need to submit jobs using Maya to Deadline Cloud
- The problem happens because the dialog is harvesting all assets in the scene. It is done in a tight for loop that blocks Maya with no signal to the user.

### What was the solution? (How)
- Allow time for the Qt event loop to run by adding appropriate sleeps and Maya UI refreshes.
- I selected to add interactivity rather than using threads because via research it seems Maya APIs are not very thread safe and needs to be run on the main thread.
- I added a progress dialog, along with signals to show the progress of scene introspection.

###
- Long term, I want to re-write this so the dialog is asynchronous from data harvesting. However, this needs us to re-write the dialog so it can fully support background operations and harvesting assets with the dialog open. On submission then it can block until the harvesting is fully done.

- However, that brings in a lot of other issues such as what to do with the Job Attachments tab while the harvesting is going on.

### What is the impact of this change?
- Make sure the app is still interactive, and users know the system is running.

### How was this change tested?
- hatch build && hatch run install
- Launch Maya, enable the deadline submitter.
- Loaded a scene with 14000 assets. Launch the submitter. See that we have a nice progress dialog now.



#### Unit test result
```
================================================================================================================================ slowest 5 durations =================================================================================================================================
0.12s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_server_init_fail
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_run_data_wrong_schema
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_cleanup::test_on_cleanup
================================================================================================================================ 106 passed in 3.01s =================================================================================================================================
```

#### Integ test result
- hatch run integ:test_adaptors_maya
- I did not run redshift because I don't have redshift.
```
[gw0] [ 50%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter 
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter 
===Flaky Test Report===
```
#### Installer test result
- Not Applicable.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
- Not Applicable

### Was this change documented?
- Not Applicable


### Is this a breaking change?
No, this is a submitter dialog gui change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
