### PR TITLE
feat: add support for auto-populating maya-vray conda package in submitter

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -740,6 +740,9 @@ def show_maya_render_submitter(
         rez_packages += " mtoa"
         conda_packages += " maya-mtoa"
 
+    if "vray" in all_renderers:
+        conda_packages += " maya-vray"
+
     # Close the progress dialog before creating the submission dialog
     progress_dialog.close()
     print("Progress dialog closed, creating submission dialog")

--- a/test/integ/test_scripts/redshift_test/scene/test.ma
+++ b/test/integ/test_scripts/redshift_test/scene/test.ma
@@ -353,7 +353,6 @@ createNode VRaySettingsNode -s -n "vraySettings";
 		 1600613993 1768186226 893002351 1679961142 1735746149 1684105299 1600613993 1667590243 577004907 1818322490 573334899 1919251571
 		 1867345765 1918854500 1869177953 943143458 1953702444 1868919397 1701080909 1701339999 1684368227 1634089506 2103800684 125 ;
 	setAttr ".vfbSyncM" yes;
-	setAttr ".mSceneName" -type "string" "/Users/larbe/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma";
 	setAttr ".rt_cpuRayBundleSize" 4;
 	setAttr ".rt_gpuRayBundleSize" 256;
 	setAttr ".rt_gpuRaysPerPixel" 2;


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
* We will want to auto-detect the renderer and auto-populate the maya-vray conda package for job submission

### What was the solution? (How)
* Add the maya-vray package to the set of required conda packages. Anchored at 2025.*

### What is the impact of this change?
* Customers won't need to manually set this field when submitting VRay for Maya jobs.

### How was this change tested?
* Installed submitter into local version of Maya and verified the maya-vray package was added to the submitter.

#### Unit test result
```
================================================================================================================================================= tests coverage ==================================================================================================================================================
_________________________________________________________________________________________________________________________________ coverage: platform darwin, python 3.9.6-final-0 _________________________________________________________________________________________________________________________________

Name                                                                           Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------------------------------------
src/deadline/maya_adaptor/MayaAdaptor/__init__.py                                  3      0      0      0   100%
src/deadline/maya_adaptor/MayaAdaptor/adaptor.py                                 235      5     58      4    97%   61->exit, 302, 318-320, 528->531, 600, 607->616
src/deadline/maya_adaptor/MayaClient/__init__.py                                   3      0      0      0   100%
src/deadline/maya_adaptor/MayaClient/dir_map.py                                   42     19      2      0    52%   21-24, 27, 30, 33, 39-40, 46, 52, 55-58, 61, 71, 75, 79
src/deadline/maya_adaptor/MayaClient/maya_client.py                               40      4      4      0    91%   16-19, 56-58
src/deadline/maya_adaptor/MayaClient/render_handlers/__init__.py                  16      4      8      4    67%   23, 25, 27, 29
src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py            46     36     16      0    16%   29-81, 92-93, 105-107
src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py     113     57     38      0    45%   15, 61-74, 77-96, 109-143, 155, 182-184, 193, 217-221, 233-235, 245-246, 267-268
src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py          32     22     10      0    24%   35-61, 73-75
src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py         42     26     14      1    30%   28-30, 68-108
src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py              65     51     30      2    17%   27-39, 57-120, 129-131, 143-145
src/deadline/maya_adaptor/__init__.py                                              0      0      0      0   100%
src/deadline/maya_submitter/__init__.py                                            6      0      0      0   100%
src/deadline/maya_submitter/assets.py                                             79     36     40      4    48%   26-51, 59-65, 91->89, 98-99, 111-122, 131-133, 160, 165, 168->167
src/deadline/maya_submitter/cameras.py                                             9      4      0      0    56%   19-22, 33
src/deadline/maya_submitter/data_classes.py                                       46     19      8      0    50%   44-71, 74-83
src/deadline/maya_submitter/file_path_editor.py                                   32     17     10      0    36%   37-38, 45-84
src/deadline/maya_submitter/job_bundle_output_test_runner.py                     152    124     42      0    14%   39-48, 54-55, 62-70, 75, 80-112, 117, 124, 132-207, 211-311
src/deadline/maya_submitter/logging.py                                            48     26     10      0    38%   26, 32-38, 43-79
src/deadline/maya_submitter/maya_render_submitter.py                             263    218    110      0    12%   71-311, 320-444, 448-460, 465-508, 520-645, 654-712
src/deadline/maya_submitter/mel_commands.py                                       36      4     10      3    85%   36->exit, 48-54, 59, 88
src/deadline/maya_submitter/render_layers.py                                      33     16      0      0    52%   26-41, 45, 49, 53, 60, 68-71, 79-81
src/deadline/maya_submitter/renderers.py                                          24     13      6      0    37%   16, 23, 34-37, 44-57
src/deadline/maya_submitter/scene.py                                             105     39     18      0    59%   39, 46, 53, 60, 67, 74-77, 87-97, 110, 117, 124-127, 153-157, 164-168, 176-180, 184-190
src/deadline/maya_submitter/utils.py                                              28      0      4      2    94%   62->73, 63->66
--------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                           1498    740    438     20    45%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml
Required test coverage of 41.0% reached. Total coverage: 44.63%
=============================================================================================================================================== slowest 5 durations ===============================================================================================================================================
0.11s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.05s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_server_init_fail
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[arnold-True]
0.04s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_populate_action_queue_test_mapping
=============================================================================================================================================== 104 passed in 3.77s ===============================================================================================================================================
```
#### Integ test result
```
========================================================== slowest 5 durations ===========================================================
40.59s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
2.62s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
1.24s call     test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.03s teardown test/integ/test_maya_submitters.py::TestSubmitters::test_minimal_scene_submitter
0.00s setup    test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
=========================================================== 2 passed in 47.88s ===========================================================
```

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
