### PR TITLE
chore: clean up redshift test scene unneeded references

### DIFF
--- a/test/integ/test_scripts/redshift_test/scene/test.ma
+++ b/test/integ/test_scripts/redshift_test/scene/test.ma
@@ -353,7 +353,6 @@ createNode VRaySettingsNode -s -n "vraySettings";
 		 1600613993 1768186226 893002351 1679961142 1735746149 1684105299 1600613993 1667590243 577004907 1818322490 573334899 1919251571
 		 1867345765 1918854500 1869177953 943143458 1953702444 1868919397 1701080909 1701339999 1684368227 1634089506 2103800684 125 ;
 	setAttr ".vfbSyncM" yes;
-	setAttr ".mSceneName" -type "string" "/Users/larbe/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma";
 	setAttr ".rt_cpuRayBundleSize" 4;
 	setAttr ".rt_gpuRayBundleSize" 256;
 	setAttr ".rt_gpuRaysPerPixel" 2;


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
* Want to clean up unneeded references in test scene for redshift.
*
#### Unit test result
N/A
#### Integ test result
```
test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 25%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
[gw0] [ 50%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[job_configuration0] 
[gw0] [ 75%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[job_configuration0] 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[job_configuration1] 
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[job_configuration1] 
```
#### Installer test result
N/A

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

N/A


### Was this change documented?
N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
