### PR TITLE
feat: Added validation for frame range field in submitter ui

### DIFF
--- a/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import os
 
-from qtpy.QtCore import QSize, Qt  # type: ignore
+from qtpy.QtCore import QSize, Qt, QRegularExpression  # type: ignore
 from qtpy.QtWidgets import (  # type: ignore
     QCheckBox,
     QComboBox,
@@ -15,6 +15,7 @@ from qtpy.QtWidgets import (  # type: ignore
     QSpacerItem,
     QWidget,
 )
+from qtpy.QtGui import QRegularExpressionValidator  # type: ignore
 from deadline.client.ui import block_signals
 
 from ...render_layers import LayerSelection
@@ -125,6 +126,9 @@ class SceneSettingsWidget(QWidget):
 
         self.frame_override_chck = QCheckBox("Override Frame Range", self)
         self.frame_override_txt = QLineEdit(self)
+        # Only allow numbers, colons, dashes, commas, and whitespace for frame ranges
+        frame_pattern = QRegularExpression(r"^[0-9:\-,\s]*$")
+        self.frame_override_txt.setValidator(QRegularExpressionValidator(frame_pattern))
         lyt.addWidget(self.frame_override_chck, 4, 0)
         lyt.addWidget(self.frame_override_txt, 4, 1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)

--- a/test/unit/deadline_submitter_for_maya/scripts/test_submitter.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_submitter.py
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+from unittest.mock import Mock
+
+
+def test_frame_override_has_text_validation():
+    try:
+        # Create new mocks. We need to use a real class for QWidget instead of a Mock() so that the
+        # SceneSettingsWidget which is a subclass of QWidget actually runs its methods (instead its
+        # methods being mocked out).
+        class MockQWidget:
+            setEnabled = Mock()
+
+            def __init__(self, parent):
+                pass
+
+        mock_q_widgets = Mock()
+        mock_line_edit = Mock()
+
+        sys.modules["qtpy.QtWidgets"] = mock_q_widgets
+        mock_q_widgets.QWidget = MockQWidget
+        mock_q_widgets.QLineEdit = mock_line_edit
+
+        # Reload SceneSettingsWidget with the new mocks in place.
+        del sys.modules["deadline.maya_submitter.ui.components.scene_settings_tab"]
+        from deadline.maya_submitter.ui.components.scene_settings_tab import SceneSettingsWidget
+
+        # Stub out a method
+        SceneSettingsWidget._configure_settings = Mock()  # type: ignore
+        SceneSettingsWidget._fill_cameras_box = Mock()  # type: ignore
+
+        # Create the scene widget
+        SceneSettingsWidget(initial_settings=Mock())
+
+        # Verify that the validator was set on the frame override line edit
+        assert mock_line_edit.return_value.setValidator.call_count == 1
+        # Make sure the mock is working and there's at least 1 call (because there's at least 1 line edit element)
+        assert mock_line_edit.call_count > 0
+
+    finally:
+        # Reset QtWidgets mock
+        sys.modules["qtpy.QtWidgets"] = Mock()


### PR DESCRIPTION
Fixes: Added validation for the override frame range value field in submitter UI

### What was the problem/requirement? (What/Why)
The Override frame range field in the submitter accepts all characters, but only numbers, whitespace, and other characters to create a range should be allowed ("-" "," ":")

### What was the solution? (How)
Created a regex validation for the text box so characters other than the ones specified cannot be entered.

### What is the impact of this change?
Invalid characters cannot be entered in the text box. Invalid frame ranges can still be created with just these characters, and the job will still fail.

### How was this change tested?
Manually tested, made sure the regex works and only the specified characters are allowed. Also created a test case to verify that the validator is set. Used similar test case to [here](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/e7d62dcb6c0226c4f056ac84835fbef406691683/test/unit/deadline_submitter_for_cinema4d/test_submitter.py#L34)

#### Unit test result
```
================================================================================== slowest 5 durations ==================================================================================
0.12s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_run_data_wrong_schema
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_no_error
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_populate_action_queue_test_mapping
================================================================================== 107 passed in 2.88s ==================================================================================
```


### Was this change documented?
No

### Is this a breaking change?

No

