### PR TITLE
chore(submitter): improve error message for known MtoA bug with scene introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ ability to run Maya efficiently on your render farm.
 This library requires:
 
 1. Maya 2024 - 2025,
+1. MtoA 5.3.5 or higher,
 1. Python 3.9 or higher; and
 1. Linux, Windows, or a macOS operating system.
 

--- a/src/deadline/maya_submitter/assets.py
+++ b/src/deadline/maya_submitter/assets.py
@@ -233,7 +233,25 @@ class AssetIntrospector:
         """
         import mtoa.txManager.lib as mtoa  # type: ignore
 
-        return mtoa.get_scanned_files(mtoa.scene_default_texture_scan)
+        try:
+            return mtoa.get_scanned_files(mtoa.scene_default_texture_scan)
+        except re.error as e:
+            if "bad escape" in str(e):
+                try:
+                    import maya.cmds
+
+                    mtoa_version = maya.cmds.pluginInfo("mtoa", query=True, version=True)
+                except Exception:
+                    mtoa_version = "UNKNOWN - Please check 'Arnold' > 'About'"
+
+                # Handle a known MTOA bug where this function is broken when using UDIM textures (logged as MTOA-1424 at Autodesk)
+                # This is fixed in MTOA 5.3.5: https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_maya_535_html
+                raise Exception(
+                    "This error may be caused by a known bug in Arnold for Maya (MtoA) versions less than 5.3.5 (MTOA-1424). "
+                    "If the installed version of Arnold for Maya is less than 5.3.5, please upgrade to MtoA 5.3.5 or newer and try again. "
+                    f"Detected MtoA Version: {mtoa_version}"
+                ) from e
+            raise
 
     @lru_cache(maxsize=None)
     def _expand_path(self, path: str) -> Generator[Path, None, None]:


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/204

### What was the problem/requirement? (What/Why)
There is a known bug in MtoA versions older than 5.3.5 where its scene introspection functionality is broken for scenes that use UDIM texture file paths.

### What was the solution? (How)
- Update the README to indicate a minimum compatible version of MtoA 5.3.5
- Catch the known error thrown by MtoA and raise an exception with an improved error message suggesting the user to upgrade their MtoA version.

### What is the impact of this change?
Users have better error messaging for a known MtoA bug that prevents the submitter from opening, giving them a path to unblock themselves.

### How was this change tested?

Reproduce the error by modifying the submitter code to just throw an `re.error` with a similar error message and verified the improved exception message was thrown instead. This can be improved to a simple error message box without a stack trace in another revision if we would like.

<img width="553" height="699" alt="image" src="https://github.com/user-attachments/assets/d7544d90-3014-407a-9ccc-8947be777a97" />


#### Unit test result
All passed (also see the GitHub checks)

#### Integ test result

Tests result:
```
============================================================================================================================================== short test summary info ==============================================================================================================================================
FAILED test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor - assert 1 == 0
 +  where 1 = CompletedProcess(args=['mayapy', '-m', 'openjd', 'run', '/Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/expected_job_bundle/template.yaml', '--step', 'masterLayer', '--job-param', '{"MayaSceneFile": "/Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma", "OutputFilePrefix": "redshift_test", "Frames": "1", "ImageWidth": 960, "ImageHeight": 540, "OutputFilePath": "/private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/pytest-of-jericht/pytest-11/popen-gw0/test_redshift_scene_adaptor2/output", "ProjectPath": "/Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/", "RenderSetupIncludeLights": "false"}'], returncode=1, stdout=b'0:00:00.000931\tOpen Job Description CLI: Session start 2025-07-11T15:45:32.756873-07:00\n0:00:00.000957\tOpen Job Description CLI: Running job \'test.ma\'\n0:00:00.000990\tOpen Job Description CLI: Running step \'masterLayer\'\n0:00:00.001018\t\n0:00:00.001031\t==============================================\n0:00:00.001043\t--------- Entering Environment: Maya\n0:00:00.001053\t==============================================\n0:00:00.001735\t----------------------------------------------\n0:00:00.001756\tPhase: Setup\n0:00:00.001767\t----------------------------------------------\n0:00:00.001782\tWriting embedded files for Environment to disk.\n0:00:00.001824\tMapping: Env.File.initData -> /private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/OpenJD/CLI-session6rtv9tjm/embedded_files12hponu2/init-data.yaml\n0:00:00.002101\tWrote: initData -> /private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/OpenJD/CLI-session6rtv9tjm/embedded_files12hponu2/init-data.yaml\n0:00:00.002837\t----------------------------------------------\n0:00:00.002852\tPhase: Running action\n0:00:00.002863\t----------------------------------------------\n0:00:00.002954\tRunning command /private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/OpenJD/CLI-session6rtv9tjm/tmpku3ma9gs.sh\n0:00:00.004929\tCommand started as pid: 82791\n0:00:00.005022\tOutput:\n0:00:00.585247\tINFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json\n0:00:00.587486\tINFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/MayaAdaptor/MayaAdaptor.json\n0:00:00.587546\tINFO: Initializing backend process...\n0:00:00.590915\tINFO: Started backend process. PID: 82792\n0:00:00.590978\tINFO: Waiting for File \'/private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/OpenJD/CLI-session6rtv9tjm/connection.json\' to exist\n0:00:00.591019\tINFO: Retrying in 1s...\n0:00:02.598051\tINFO: Waiting for File \'/private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/OpenJD/CLI-session6rtv9tjm/connection.json\' to be openable\n0:00:02.598974\tINFO: Waiting for File \'/private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/OpenJD/CLI-session6rtv9tjm/connection.json\' to have valid ConnectionSettings\n0:00:02.600794\tINFO: ========== BEGIN BOOTSTRAP OUTPUT CONTENTS ==========\n0:00:02.600980\tINFO: <frozen runpy>:128: RuntimeWarning: \'deadline.maya_adaptor.MayaAdaptor.__main__\' found in sys.modules after import of package \'deadline.maya_adaptor.MayaAdaptor\', but prior to execution of \'deadline.maya_adaptor.MayaAdaptor.__main__\'; this may result in unpredictable behaviour\n0:00:02.601046\tINFO: INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json\n0:00:02.601097\tINFO: INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/MayaAdaptor/MayaAdaptor.json\n0:00:02.601143\tINFO: ========== END BOOTSTRAP OUTPUT CONTENTS ==========\n0:00:02.601188\tINFO: Checking for bootstrap logs at \'/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/adaptor-runtime-background-bootstrap-8e0594a0-2e0d-4d95-a501-caef6617dad7.log\'\n0:00:02.601617\tINFO: ========== BEGIN BOOTSTRAP LOG CONTENTS ==========\n0:00:02.601723\tINFO: [2025-07-11 15:45:33,770][INFO    ] Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json\n0:00:02.601788\tINFO: [2025-07-11 15:45:33,772][INFO    ] Applying user-level configuration: /Users/jericht/.openjd/adaptors/MayaAdaptor/MayaAdaptor.json\n0:00:02.601841\tINFO: [2025-07-11 15:45:33,773][INFO    ] Running in background daemon mode.\n0:00:02.601890\tINFO: ========== END BOOTSTRAP LOG CONTENTS ==========\n0:00:02.602232\tINFO: Verifying connection to backend...\n0:00:02.605559\tINFO: Connected successfully\n0:00:02.605640\topenjd_env: OPENJD_ADAPTOR_SOCKET=/private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/.openjd_adaptor_runtime/82792\n0:00:02.608660\tADAPTOR_OUTPUT: INFO: Running in background daemon mode.\n0:00:02.608715\tADAPTOR_OUTPUT: INFO: Loading \'init_data\' schema from /Volumes/workplace/github/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaAdaptor/schemas/init_data.schema.json\n0:00:02.608740\tADAPTOR_OUTPUT: INFO: Loading \'run_data\' schema from /Volumes/workplace/github/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaAdaptor/schemas/run_data.schema.json\n0:00:03.610932\tADAPTOR_OUTPUT: INFO: Running command: mayapy /Volumes/workplace/github/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaClient/maya_client.py\n0:00:04.613213\tADAPTOR_OUTPUT: STDERR: This plugin does not support createPlatformOpenGLContext!\n0:00:04.613268\tADAPTOR_OUTPUT: STDERR: This plugin does not support createPlatformOpenGLContext!\n0:00:05.615795\tADAPTOR_OUTPUT: STDOUT: MayaClient: Maya Version 2024\n0:00:05.615865\tADAPTOR_OUTPUT: STDOUT: Performing action: {"name": "renderer", "args": {"renderer": "redshift"}}\n0:00:05.615888\tADAPTOR_OUTPUT: STDOUT: Performing action: {"name": "path_mapping", "args": {"path_mapping_rules": {}}}\n0:00:05.615910\tADAPTOR_OUTPUT: STDOUT: Performing action: {"name": "scene_file", "args": {"scene_file": "/Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma"}}\n0:00:05.616031\tADAPTOR_OUTPUT: STDOUT: 00:00:00   437MB         | log started Fri Jul 11 15:45:38 2025\n0:00:05.616064\tADAPTOR_OUTPUT: STDOUT: 00:00:00   437MB         | Arnold 7.2.0.0 [3560d69f] darwin arm64 clang-10.0.1 oiio-2.4.1 osl-1.12.0 vdb-7.1.1 adlsdk-7.4.2.47 clmhub-3.1.1.43 rlm-14.2.5 2023/02/06 16:46:28\n0:00:05.616083\tADAPTOR_OUTPUT: STDOUT: 00:00:00   437MB         | running on 6c7e67d1b958, pid=82799\n0:00:05.616099\tADAPTOR_OUTPUT: STDOUT: 00:00:00   437MB         |  1 x Apple M2 Pro (12 cores, 12 logical) with 32768MB\n0:00:05.616116\tADAPTOR_OUTPUT: STDOUT: 00:00:00   437MB         |  Mac OS 15.5.0, Darwin kernel 24.5.0\n0:00:05.616130\tADAPTOR_OUTPUT: STDOUT: 00:00:00   437MB         |  soft limit for open files changed from 1048575 to 10238\n0:00:05.616144\tADAPTOR_OUTPUT: STDOUT: 00:00:00   437MB         |  \n0:00:05.616158\tADAPTOR_OUTPUT: STDOUT: 00:00:00   437MB         | [metadata] loading metadata file: /Applications/Autodesk/Arnold/mtoa/2024/bin/arnold.mtd\n0:00:05.616172\tADAPTOR_OUTPUT: STDOUT: 00:00:00   438MB         | [color_manager_ocio] default ocio.config found in /Applications/Autodesk/Arnold/mtoa/2024/bin/../ocio/configs/arnold/config.ocio\n0:00:05.616186\tADAPTOR_OUTPUT: STDOUT: 00:00:00   438MB         | loading plugins from /Applications/Autodesk/Arnold/mtoa/2024/bin/../plugins ...\n0:00:05.616201\tADAPTOR_OUTPUT: STDOUT: 00:00:00   439MB         |  cryptomatte.dylib: cryptomatte uses Arnold 7.2.0.0\n0:00:05.616216\tADAPTOR_OUTPUT: STDOUT: 00:00:00   439MB         |  cryptomatte.dylib: cryptomatte_filter uses Arnold 7.2.0.0\n0:00:05.616230\tADAPTOR_OUTPUT: STDOUT: 00:00:00   439MB         |  cryptomatte.dylib: cryptomatte_manifest_driver uses Arnold 7.2.0.0\n0:00:05.616246\tADAPTOR_OUTPUT: STDOUT: 00:00:00   439MB         |  [metadata] loading metadata file: /Applications/Autodesk/Arnold/mtoa/2024/bin/../plugins/cryptomatte.mtd\n0:00:05.616267\tADAPTOR_OUTPUT: STDOUT: 00:00:00   446MB         |  usd_proc.dylib: usd uses Arnold 7.2.0.0\n0:00:05.616280\tADAPTOR_OUTPUT: STDOUT: 00:00:00   446MB         |  alembic_proc.dylib: alembic uses Arnold 7.2.0.0\n0:00:05.616296\tADAPTOR_OUTPUT: STDOUT: 00:00:00   447MB         | loaded 5 plugins from 3 lib(s) in 0:00.02\n0:00:05.616310\tADAPTOR_OUTPUT: STDERR: Warning: file: /Users/jericht/Library/Preferences/Autodesk/maya/2024/prefs/filePathEditorRegistryPrefs.mel line 4: filePathEditor: Attribute \'aiImage.filename\' is invalid or is not designated \'usedAsFilename\'.\n0:00:05.616332\tADAPTOR_OUTPUT: STDERR: Warning: file: /Users/jericht/Library/Preferences/Autodesk/maya/2024/prefs/filePathEditorRegistryPrefs.mel line 5: filePathEditor: Attribute \'aiPhotometricLight.aiFilename\' is invalid or is not designated \'usedAsFilename\'.\n0:00:05.616346\tADAPTOR_OUTPUT: STDERR: Warning: file: /Users/jericht/Library/Preferences/Autodesk/maya/2024/prefs/filePathEditorRegistryPrefs.mel line 7: filePathEditor: Attribute \'aiVolume.filename\' is invalid or is not designated \'usedAsFilename\'.\n0:00:05.616360\tADAPTOR_OUTPUT: STDERR: Warning: line 1: filePathEditor: Attribute \'aiVolume.filename\' and label \'VDB\' have been saved already.\n0:00:05.616390\tADAPTOR_OUTPUT: STDOUT: 00:00:00   453MB WARNING |  unable to load dynamic library: dlopen(/Applications/Autodesk/Arnold/mtoa/2024/procedurals/xgenSpline_procedural.dylib, 0x0005): Library not loaded: @rpath/libAdskSeExpr.dylib\n0:00:05.616404\tADAPTOR_OUTPUT: STDOUT:   Referenced from: <0535277A-089F-3766-8F56-43D958CD7CEB> /Applications/Autodesk/Arnold/mtoa/2024/procedurals/xgenSpline_procedural.dylib\n0:00:05.616418\tADAPTOR_OUTPUT: STDOUT:   Reason: tried: \'/Applications/Autodesk/maya2024/Maya.app/Contents/MacOS/./libAdskSeExpr.dylib\' (no such file), \'/Applications/Autodesk/Arnold/mtoa/2024/bin/./libAdskSeExpr.dylib\' (no such file), \'/Applications/Autodesk/maya2024/Maya.app/Contents/MacOS/libAdskSeExpr.dylib\' (no such file), \'/usr/local/lib/libAdskSeExpr.dylib\' (no such file), \'/usr/lib/libAdskSeExpr.dylib\' (no such file, not in dyld cache)\n0:00:05.616433\tADAPTOR_OUTPUT: STDOUT: 00:00:00   453MB WARNING |  unable to load dynamic library: dlopen(/Applications/Autodesk/Arnold/mtoa/2024/procedurals/xgen_procedural.dylib, 0x0005): Library not loaded: @rpath/libAdskSeExpr.dylib\n0:00:05.616448\tADAPTOR_OUTPUT: STDOUT:   Referenced from: <4F62FEAD-EC92-3CA3-B836-2CC57C3246F5> /Applications/Autodesk/Arnold/mtoa/2024/procedurals/xgen_procedural.dylib\n0:00:05.616462\tADAPTOR_OUTPUT: STDOUT:   Reason: tried: \'/Applications/Autodesk/maya2024/Maya.app/Contents/MacOS/./libAdskSeExpr.dylib\' (no such file), \'/Applications/Autodesk/Arnold/mtoa/2024/bin/./libAdskSeExpr.dylib\' (no such file), \'/Applications/Autodesk/maya2024/Maya.app/Contents/MacOS/libAdskSeExpr.dylib\' (no such file), \'/usr/local/lib/libAdskSeExpr.dylib\' (no such file), \'/usr/lib/libAdskSeExpr.dylib\' (no such file, not in dyld cache)\n0:00:06.622737\tADAPTOR_OUTPUT: STDERR: Warning: line 1: filePathEditor: Attribute \'aiImage.filename\' and label \'Image\' have been saved already.\n0:00:06.622884\tADAPTOR_OUTPUT: STDERR: Warning: line 1: filePathEditor: Attribute \'aiPhotometricLight.aiFilename\' and label \'IES\' have been saved already.\n0:00:07.628385\tADAPTOR_OUTPUT: STDERR: Warning: line 1: displayRGBColor is unavailable in batch mode\n0:00:08.634249\tADAPTOR_OUTPUT: STDERR: Warning: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 110: Unrecognized node type \'RedshiftPhysicalLight\'; preserving node information during this session.\n0:00:08.634314\tADAPTOR_OUTPUT: STDERR: Warning: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 128: Unrecognized node type \'RedshiftDomeLight\'; preserving node information during this session.\n0:00:08.634400\tADAPTOR_OUTPUT: STDERR: Warning: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 161: Unrecognized node type \'RedshiftOptions\'; preserving node information during this session.\n0:00:08.634449\tADAPTOR_OUTPUT: STDERR: Warning: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 188: Unrecognized node type \'RedshiftPostEffects\'; preserving node information during this session.\n0:00:08.634475\tADAPTOR_OUTPUT: STDERR: Warning: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 195: Unrecognized node type \'VRaySettingsNode\'; preserving node information during this session.\n0:00:08.634496\tADAPTOR_OUTPUT: STDERR: Warning: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 375: Unrecognized node type \'RedshiftStandardMaterial\'; preserving node information during this session.\n0:00:08.634514\tADAPTOR_OUTPUT: STDERR: Warning: Error could not read \'/Applications/Autodesk/maya2025/Maya.app/Contents/Resources/OCIO-configs/Maya2022-default/config.ocio\' OCIO profile.\n0:00:08.634533\tADAPTOR_OUTPUT: STDERR: Warning: Error could not read \'/Applications/Autodesk/maya2025/Maya.app/Contents/Resources/OCIO-configs/Maya2022-default/config.ocio\' OCIO profile.\n0:00:08.634551\tADAPTOR_OUTPUT: STDERR: Warning: Errors have occurred while reading this scene that may result in data loss.\n0:00:08.634569\tADAPTOR_OUTPUT: STDERR: File read in  3.3 seconds.\n0:00:08.634587\tADAPTOR_OUTPUT: STDERR: Error: Color management settings cannot be applied: Error could not read \'/Applications/Autodesk/maya2025/Maya.app/Contents/Resources/OCIO-configs/Maya2022-default/config.ocio\' OCIO profile..\n0:00:08.634604\tADAPTOR_OUTPUT: STDERR: If you are using remote PC software, such as Team Viewer, RealVNC, or Remote Desktop,\n0:00:08.634622\tADAPTOR_OUTPUT: STDERR: these application\'s display setting drivers are not compatible with Maya extensions.\n0:00:08.634641\tADAPTOR_OUTPUT: STDERR: See this article for more detail.\n0:00:08.634719\tADAPTOR_OUTPUT: STDERR: https://www.autodesk.com/maya-color-management-settings-error\n0:00:08.634748\tADAPTOR_OUTPUT: STDERR: Traceback (most recent call last):\n0:00:08.634763\tADAPTOR_OUTPUT: STDERR:   File "/Volumes/workplace/github/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaClient/maya_client.py", line 81, in <module>\n0:00:08.634781\tADAPTOR_OUTPUT: STDERR:     main()\n0:00:08.634795\tADAPTOR_OUTPUT: STDERR:   File "/Volumes/workplace/github/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaClient/maya_client.py", line 77, in main\n0:00:08.634808\tADAPTOR_OUTPUT: STDERR:     client.poll()\n0:00:08.634822\tADAPTOR_OUTPUT: STDERR:   File "/Users/jericht/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/vTaURC9A/integ/lib/python3.12/site-packages/openjd/adaptor_runtime_client/base_client_interface.py", line 212, in poll\n0:00:08.634838\tADAPTOR_OUTPUT: STDERR:     self._perform_action(action)\n0:00:08.634853\tADAPTOR_OUTPUT: STDERR:   File "/Users/jericht/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/vTaURC9A/integ/lib/python3.12/site-packages/openjd/adaptor_runtime_client/base_client_interface.py", line 233, in _perform_action\n0:00:08.634869\tADAPTOR_OUTPUT: STDERR:     action_func(a.args)\n0:00:08.634889\tADAPTOR_OUTPUT: STDERR:   File "/Volumes/workplace/github/deadline-cloud-for-maya/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py", line 261, in set_scene_file\n0:00:08.634904\tADAPTOR_OUTPUT: STDERR:     maya.cmds.file(file_path, open=True, force=True, ignoreVersion=ignore_version_flag)\n0:00:08.634916\tADAPTOR_OUTPUT: STDERR: RuntimeError: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 7: Plug-in, "redshift4maya", was not found on MAYA_PLUG_IN_PATH.\n0:00:08.634928\tADAPTOR_OUTPUT: STDERR: # Traceback (most recent call last):\n0:00:08.634941\tADAPTOR_OUTPUT: STDERR: #   File "<maya console>", line 1, in <module>\n0:00:08.634953\tADAPTOR_OUTPUT: STDERR: # RuntimeError: Plug-in, "redshift4maya", was not found on MAYA_PLUG_IN_PATH.\n0:00:08.635099\tADAPTOR_OUTPUT: STDERR: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 9: Plug-in, "vrayformaya", was not found on MAYA_PLUG_IN_PATH.\n0:00:08.635116\tADAPTOR_OUTPUT: STDERR: # Traceback (most recent call last):\n0:00:08.635129\tADAPTOR_OUTPUT: STDERR: #   File "<maya console>", line 1, in <module>\n0:00:08.635142\tADAPTOR_OUTPUT: STDERR: # RuntimeError: Plug-in, "vrayformaya", was not found on MAYA_PLUG_IN_PATH.\n0:00:08.635154\tADAPTOR_OUTPUT: STDERR: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 113: setAttr: Too much data was provided. The last 1 elements were not used.\n0:00:08.635169\tADAPTOR_OUTPUT: STDERR: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 114: setAttr: Too much data was provided. The last 1 elements were not used.\n0:00:08.635184\tADAPTOR_OUTPUT: STDERR: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 131: setAttr: Too much data was provided. The last 1 elements were not used.\n0:00:08.635212\tADAPTOR_OUTPUT: STDERR: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 132: setAttr: Too much data was provided. The last 1 elements were not used.\n0:00:08.635227\tADAPTOR_OUTPUT: STDERR: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 489: The mayaUsdLayerManager \'mayaUsdLayerManager1\' has no \'.sst\' attribute.\n0:00:08.635240\tADAPTOR_OUTPUT: STDERR: file: /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma line 489: setAttr: No object matches name: .sst\n0:00:08.635255\tADAPTOR_OUTPUT: STDERR: Error reading file.\n0:00:08.635273\tADAPTOR_OUTPUT: STDERR: Error reading file.\n0:00:08.635287\tADAPTOR_OUTPUT: STDERR: Color management settings cannot be applied: Error could not read \'/Applications/Autodesk/maya2025/Maya.app/Contents/Resources/OCIO-configs/Maya2022-default/config.ocio\' OCIO profile..\n0:00:08.635303\tADAPTOR_OUTPUT: STDERR: If you are using remote PC software, such as Team Viewer, RealVNC, or Remote Desktop,\n0:00:08.635322\tADAPTOR_OUTPUT: STDERR: these application\'s display setting drivers are not compatible with Maya extensions.\n0:00:08.635338\tADAPTOR_OUTPUT: STDERR: See this article for more detail.\n0:00:08.635354\tADAPTOR_OUTPUT: STDERR: https://www.autodesk.com/maya-color-management-settings-error\n0:00:08.635369\tADAPTOR_OUTPUT: STDERR: \n0:00:09.637816\tADAPTOR_OUTPUT: INFO: Deadline Cloud telemetry is enabled.\n0:00:09.637941\topenjd_fail: Error encountered while starting adaptor: Maya encountered an error and was not able to complete initialization actions.\n0:00:09.638378\tERROR: Entrypoint failed: INFO: Deadline Cloud telemetry is enabled.\n0:00:09.638442\topenjd_fail: Error encountered while starting adaptor: Maya encountered an error and was not able to complete initialization actions.\n0:00:09.666378\tProcess pid 82791 exited with code: 1 (unsigned) / 0x1 (hex)\n0:00:09.666630\t\n0:00:09.666658\t==============================================\n0:00:09.666671\t--------- Exiting Environment: Maya\n0:00:09.666681\t==============================================\n0:00:09.668035\t----------------------------------------------\n0:00:09.668066\tPhase: Setup\n0:00:09.668080\t----------------------------------------------\n0:00:09.668099\tWriting embedded files for Environment to disk.\n0:00:09.668136\tMapping: Env.File.initData -> /private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/OpenJD/CLI-session6rtv9tjm/embedded_files12hponu2/init-data.yaml\n0:00:09.668826\tWrote: initData -> /private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/OpenJD/CLI-session6rtv9tjm/embedded_files12hponu2/init-data.yaml\n0:00:09.669643\t----------------------------------------------\n0:00:09.669660\tPhase: Running action\n0:00:09.669671\t----------------------------------------------\n0:00:09.669748\tRunning command /private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/OpenJD/CLI-session6rtv9tjm/tmp9jtk5ya1.sh\n0:00:09.671690\tCommand started as pid: 82925\n0:00:09.671769\tOutput:\n0:00:10.286554\tINFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json\n0:00:10.289257\tINFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/MayaAdaptor/MayaAdaptor.json\n0:00:10.303399\tADAPTOR_OUTPUT: \n0:00:10.303471\tADAPTOR_OUTPUT: INFO: Daemon background process stopped.\n0:00:11.311290\tINFO: Done MayaAdaptor main\n0:00:11.345053\tProcess pid 82925 exited with code: 0 (unsigned) / 0x0 (hex)\n0:00:11.345283\t\n0:00:11.345332\tOpen Job Description CLI: ERROR executing action: \'Enter Environment \'Maya\'\' (see Task logs for details)\n0:00:11.345345\tOpen Job Description CLI: Local Session ended! Now cleaning up Session resources.\n\n--- Results of local session ---\n\nSession ended with errors; see Task logs for details\n\nJob: test.ma\nStep: masterLayer\nDuration: 11.3645313330926 seconds\nChunks run: 0\n\n', stderr=b'').returncode
ERROR test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[job_configuration0] - ImportError: cannot import name 'on_create_job_bundle_callback' from 'deadline.maya_submitter.maya_render_submitter' (/Applications/Autodesk/maya2024/Maya.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.10/site-packages/deadline/maya_submitter/maya_render_submitter.py)
ERROR test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[job_configuration1] - ImportError: cannot import name 'on_create_job_bundle_callback' from 'deadline.maya_submitter.maya_render_submitter' (/Applications/Autodesk/maya2024/Maya.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.10/site-packages/deadline/maya_submitter/maya_render_submitter.py)
=========================================================================================================================== 1 failed, 1 passed, 2 warnings, 2 errors in 68.11s (0:01:08) ============================================================================================================================
```

#### Installer test result
N/A

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

All 4 tests failed but it looks like it's because the expected template is JSON but actual templates were YAML:

```

Timestamp: 2025-07-11T15:37:35.455193-07:00
Running job bundle output test: /Volumes/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test failed, found differences
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -1,120 +1,59 @@
-{
- "parameterValues": [
-  {
-   "name": "MayaSceneFile",
-   "value": "/normalized/job/bundle/dir/layers.ma"
-  },
-  {
-   "name": "layerDefaultFramesFrames",
-   "value": "1-10"
-  },
-  {
-   "name": "layerFrameRange1Frames",
-   "value": "1-10"
-  },
-  {
-   "name": "masterLayerFrames",
-   "value": "1-10"
-  },
-  {
-   "name": "renderSetupLayer2Frames",
-   "value": "20-30"
-  },
-  {
-   "name": "renderSetupLayer4Frames",
-   "value": "1-20"
-  },
-  {
-   "name": "layerDefaultFramesOutputFilePrefix",
-   "value": "<Layer>/layer_specific_file_prefix_"
-  },
-  {
-   "name": "layerFrameRange1OutputFilePrefix",
-   "value": "<Layer>/<Camera>/<Scene>"
-  },
-  {
-   "name": "masterLayerOutputFilePrefix",
-   "value": "<Layer>/<Camera>/<Scene>"
-  },
-  {
-   "name": "renderSetupLayer2OutputFilePrefix",
-   "value": "<Layer>/<Camera>/<Scene>"
-  },
-  {
-   "name": "renderSetupLayer4OutputFilePrefix",
-   "value": "<Layer>/<Camera>/<Scene>"
-  },
-  {
-   "name": "layerDefaultFramesImageWidth",
-   "value": 960
-  },
-  {
-   "name": "layerDefaultFramesImageHeight",
-   "value": 540
-  },
-  {
-   "name": "layerFrameRange1ImageWidth",
-   "value": 960
-  },
-  {
-   "name": "layerFrameRange1ImageHeight",
-   "value": 540
-  },
-  {
-   "name": "masterLayerImageWidth",
-   "value": 960
-  },
-  {
-   "name": "masterLayerImageHeight",
-   "value": 540
-  },
-  {
-   "name": "renderSetupLayer2ImageWidth",
-   "value": 960
-  },
-  {
-   "name": "renderSetupLayer2ImageHeight",
-   "value": 540
-  },
-  {
-   "name": "renderSetupLayer4ImageWidth",
-   "value": 1920
-  },
-  {
-   "name": "renderSetupLayer4ImageHeight",
-   "value": 1080
-  },
-  {
-   "name": "ProjectPath",
-   "value": "/normalized/job/bundle/dir/"
-  },
-  {
-   "name": "OutputFilePath",
-   "value": "/normalized/job/bundle/dir/images"
-  },
-  {
-   "name": "RenderSetupIncludeLights",
-   "value": "true"
-  },
-  {
-   "name": "ArnoldErrorOnLicenseFailure",
-   "value": "false"
-  },
-  {
-   "name": "deadline:targetTaskRunStatus",
-   "value": "READY"
-  },
-  {
-   "name": "deadline:maxFailedTasksCount",
-   "value": 20
-  },
-  {
-   "name": "deadline:maxRetriesPerTask",
-   "value": 5
-  },
-  {
-   "name": "deadline:priority",
-   "value": 50
-  }
- ]
-}+parameterValues:
+- name: MayaSceneFile
+  value: /normalized/job/bundle/dir/layers.ma
+- name: layerDefaultFramesFrames
+  value: 1-10
+- name: layerFrameRange1Frames
+  value: 1-10
+- name: masterLayerFrames
+  value: 1-10
+- name: renderSetupLayer2Frames
+  value: 20-30
+- name: renderSetupLayer4Frames
+  value: 1-20
+- name: layerDefaultFramesOutputFilePrefix
+  value: <Layer>/layer_specific_file_prefix_
+- name: layerFrameRange1OutputFilePrefix
+  value: <Layer>/<Camera>/<Scene>
+- name: masterLayerOutputFilePrefix
+  value: <Layer>/<Camera>/<Scene>
+- name: renderSetupLayer2OutputFilePrefix
+  value: <Layer>/<Camera>/<Scene>
+- name: renderSetupLayer4OutputFilePrefix
+  value: <Layer>/<Camera>/<Scene>
+- name: layerDefaultFramesImageWidth
+  value: 960
+- name: layerDefaultFramesImageHeight
+  value: 540
+- name: layerFrameRange1ImageWidth
+  value: 960
+- name: layerFrameRange1ImageHeight
+  value: 540
+- name: masterLayerImageWidth
+  value: 960
+- name: masterLayerImageHeight
+  value: 540
+- name: renderSetupLayer2ImageWidth
+  value: 960
+- name: renderSetupLayer2ImageHeight
+  value: 540
+- name: renderSetupLayer4ImageWidth
+  value: 1920
+- name: renderSetupLayer4ImageHeight
+  value: 1080
+- name: ProjectPath
+  value: /normalized/job/bundle/dir/
+- name: OutputFilePath
+  value: /normalized/job/bundle/dir/images
+- name: RenderSetupIncludeLights
+  value: 'true'
+- name: ArnoldErrorOnLicenseFailure
+  value: 'false'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

Timestamp: 2025-07-11T15:37:38.121960-07:00
Running job bundle output test: /Volumes/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test failed, found differences
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -1,56 +1,27 @@
-{
- "parameterValues": [
-  {
-   "name": "MayaSceneFile",
-   "value": "/normalized/job/bundle/dir/referenced_layers.ma"
-  },
-  {
-   "name": "Frames",
-   "value": "1"
-  },
-  {
-   "name": "OutputFilePrefix",
-   "value": "<Scene>"
-  },
-  {
-   "name": "ImageWidth",
-   "value": 960
-  },
-  {
-   "name": "ImageHeight",
-   "value": 540
-  },
-  {
-   "name": "ProjectPath",
-   "value": "/normalized/job/bundle/dir/"
-  },
-  {
-   "name": "OutputFilePath",
-   "value": "/normalized/job/bundle/dir/images"
-  },
-  {
-   "name": "RenderSetupIncludeLights",
-   "value": "true"
-  },
-  {
-   "name": "ArnoldErrorOnLicenseFailure",
-   "value": "true"
-  },
-  {
-   "name": "deadline:targetTaskRunStatus",
-   "value": "READY"
-  },
-  {
-   "name": "deadline:maxFailedTasksCount",
-   "value": 20
-  },
-  {
-   "name": "deadline:maxRetriesPerTask",
-   "value": 5
-  },
-  {
-   "name": "deadline:priority",
-   "value": 50
-  }
- ]
-}+parameterValues:
+- name: MayaSceneFile
+  value: /normalized/job/bundle/dir/referenced_layers.ma
+- name: Frames
+  value: '1'
+- name: OutputFilePrefix
+  value: <Scene>
+- name: ImageWidth
+  value: 960
+- name: ImageHeight
+  value: 540
+- name: ProjectPath
+  value: /normalized/job/bundle/dir/
+- name: OutputFilePath
+  value: /normalized/job/bundle/dir/images
+- name: RenderSetupIncludeLights
+  value: 'true'
+- name: ArnoldErrorOnLicenseFailure
+  value: 'true'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

Timestamp: 2025-07-11T15:37:39.873608-07:00
Running job bundle output test: /Volumes/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2025-07-11T15:37:39.873693-07:00
Running job bundle output test: /Volumes/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test failed, found differences
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -1,52 +1,25 @@
-{
- "parameterValues": [
-  {
-   "name": "MayaSceneFile",
-   "value": "/normalized/job/bundle/dir/cube.ma"
-  },
-  {
-   "name": "Frames",
-   "value": "537"
-  },
-  {
-   "name": "OutputFilePrefix",
-   "value": "<Scene>"
-  },
-  {
-   "name": "ImageWidth",
-   "value": 960
-  },
-  {
-   "name": "ImageHeight",
-   "value": 540
-  },
-  {
-   "name": "ProjectPath",
-   "value": "/normalized/job/bundle/dir/"
-  },
-  {
-   "name": "OutputFilePath",
-   "value": "/normalized/job/bundle/dir/images"
-  },
-  {
-   "name": "RenderSetupIncludeLights",
-   "value": "true"
-  },
-  {
-   "name": "deadline:targetTaskRunStatus",
-   "value": "READY"
-  },
-  {
-   "name": "deadline:maxFailedTasksCount",
-   "value": 20
-  },
-  {
-   "name": "deadline:maxRetriesPerTask",
-   "value": 5
-  },
-  {
-   "name": "deadline:priority",
-   "value": 50
-  }
- ]
-}+parameterValues:
+- name: MayaSceneFile
+  value: /normalized/job/bundle/dir/cube.ma
+- name: Frames
+  value: '537'
+- name: OutputFilePrefix
+  value: <Scene>
+- name: ImageWidth
+  value: 960
+- name: ImageHeight
+  value: 540
+- name: ProjectPath
+  value: /normalized/job/bundle/dir/
+- name: OutputFilePath
+  value: /normalized/job/bundle/dir/images
+- name: RenderSetupIncludeLights
+  value: 'true'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

Timestamp: 2025-07-11T15:37:41.539559-07:00
Running job bundle output test: /Volumes/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test failed, found differences
--- expected/parameter_values.yaml
+++ test/parameter_values.yaml
@@ -1,56 +1,27 @@
-{
- "parameterValues": [
-  {
-   "name": "MayaSceneFile",
-   "value": "/normalized/job/bundle/dir/layers_no_variation.ma"
-  },
-  {
-   "name": "Frames",
-   "value": "1-10"
-  },
-  {
-   "name": "OutputFilePrefix",
-   "value": "<Layer>/<Scene>"
-  },
-  {
-   "name": "ImageWidth",
-   "value": 960
-  },
-  {
-   "name": "ImageHeight",
-   "value": 540
-  },
-  {
-   "name": "ProjectPath",
-   "value": "/normalized/job/bundle/dir/"
-  },
-  {
-   "name": "OutputFilePath",
-   "value": "/normalized/job/bundle/dir/images"
-  },
-  {
-   "name": "RenderSetupIncludeLights",
-   "value": "true"
-  },
-  {
-   "name": "ArnoldErrorOnLicenseFailure",
-   "value": "true"
-  },
-  {
-   "name": "deadline:targetTaskRunStatus",
-   "value": "READY"
-  },
-  {
-   "name": "deadline:maxFailedTasksCount",
-   "value": 20
-  },
-  {
-   "name": "deadline:maxRetriesPerTask",
-   "value": 5
-  },
-  {
-   "name": "deadline:priority",
-   "value": 50
-  }
- ]
-}+parameterValues:
+- name: MayaSceneFile
+  value: /normalized/job/bundle/dir/layers_no_variation.ma
+- name: Frames
+  value: 1-10
+- name: OutputFilePrefix
+  value: <Layer>/<Scene>
+- name: ImageWidth
+  value: 960
+- name: ImageHeight
+  value: 540
+- name: ProjectPath
+  value: /normalized/job/bundle/dir/
+- name: OutputFilePath
+  value: /normalized/job/bundle/dir/images
+- name: RenderSetupIncludeLights
+  value: 'true'
+- name: ArnoldErrorOnLicenseFailure
+  value: 'true'
+- name: deadline:targetTaskRunStatus
+  value: READY
+- name: deadline:maxFailedTasksCount
+  value: 20
+- name: deadline:maxRetriesPerTask
+  value: 5
+- name: deadline:priority
+  value: 50

Failed 4 tests, succeeded 0.
Timestamp: 2025-07-11T15:37:47.430718-07:00

```

### Was this change documented?

Yes, updated README

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
