### PR TITLE
chore(deps): bump deadline to 0.51.*

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -140,18 +140,41 @@ or modifying functionality, then you will want to be writing one or more integ t
 logic behaves as expected and that future changes do not accidentally break your change.
 
 To run the integ tests, you need to:
-1. Add `mayapy` executable to the PATH:
+1. Install Maya 2025
+2. Install Redshift for Maya 2025
+3. Add `mayapy` executable to the PATH:
    
    For example, default path of mayapy on OSX is 
 
    ```
-   /Applications/Autodesk/maya<version>/Maya.app/Contents/MacOS
+   /Applications/Autodesk/maya2025/Maya.app/Contents/MacOS
    ```
-2. Use hatch to run submitter tests:
+
+   So you can run:
+   ```
+   export PATH="/Applications/Autodesk/maya2025/Maya.app/Contents/MacOS:$PATH"
+   ```
+4. Navigate to your local checkout of this repository:
+   ```
+   cd </path/to/deadline-cloud-for-maya>
+   ```
+5. Install your local `deadline-cloud-for-maya` repository into Maya's Python environment:
+   ```
+   mayapy -m pip install -e . --force-reinstall
+   ```
+6. Install the testing dependencies into Maya's Python environment:
+   ```
+   mayapy -m pip install -r requirements-testing.txt
+   ```
+7. Install the integration testing dependencies into Maya's Python environment:
+   ```
+   mayapy -m pip install -r requirements-integ-testing.txt
+   ```
+8. Use hatch to run submitter tests:
    ```bash
    hatch run integ:test_submitters
    ```
-3. (Optional) Use hatch to run all integ tests:
+9. (Optional) Use hatch to run all integ tests:
    ```bash
    hatch run integ:test
    ```
@@ -311,6 +334,10 @@ To run the integ tests, you need to:
    ```
 
 ### Submitter Installer Development Workflow
+
+#### Prerequisites
+- Install [InstallBuilder](https://installbuilder.com/)
+
 #### Build the package
 
 ```bash
@@ -320,12 +347,10 @@ hatch run build
 #### Build the installer
 
 ```bash
-hatch run installer:build-installer --local-dev-build --platform <PLATFORM> [--install-builder-location <LOCATION> --output-dir <DIR>]
+hatch run installer:build-installer --local-dev --platform <PLATFORM> [--install-builder-location <LOCATION> --output-dir <DIR>]
 ```
 
 Run `hatch run installer:build-installer -h` to see the full list of arguments.
-
-
 
 #### Test a local installer
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.49.*",
+    "deadline == 0.51.*",
     "openjd-adaptor-runtime == 0.8.*",
-    # TODO we should remove this when migrating deadline-cloud from 0.49.* to >=0.49.*, <0.51.*
-    "psutil == 7.0.*",
 ]
 
 [project.urls]

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 import yaml  # type: ignore[import]
 from copy import deepcopy
 from dataclasses import dataclass
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 import maya.cmds  # pylint: disable=import-error
 
 from deadline.client.api import get_deadline_cloud_library_telemetry_client
+from deadline.client.job_bundle.parameters import JobParameter
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint: disable=import-error
     SubmitJobToDeadlineDialog,
@@ -517,7 +518,7 @@ def on_create_job_bundle_callback(
     widget: SubmitJobToDeadlineDialog,
     job_bundle_dir: str,
     settings: RenderSubmitterUISettings,
-    queue_parameters: list[dict[str, Any]],
+    queue_parameters: list[JobParameter],
     asset_references: AssetReferences,
     host_requirements: Optional[dict[str, Any]] = None,
     purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
@@ -621,7 +622,7 @@ def on_create_job_bundle_callback(
         current_layer_selectable_cameras=current_layer_selectable_cameras,
     )
     parameter_values = _get_parameter_values(
-        settings, renderers, submit_render_layers, queue_parameters
+        settings, renderers, submit_render_layers, cast(list[dict[str, Any]], queue_parameters)
     )
 
     # If "HostRequirements" is provided, inject it into each of the "Step"

--- a/test/integ/test_maya_submitters.py
+++ b/test/integ/test_maya_submitters.py
@@ -79,6 +79,7 @@ class TestSubmitters:
                 file_prefix="redshift_test",
             ),
         ],
+        ids=["Minimal Maya Test", "Redshift Test"],
     )
     def test_scene_submitter(
         self,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to upgrade our dependency on `deadline` to the latest version

### What was the solution? (How)
- Upgrade the dependency to 0.51.*
    - There was a breaking change in 0.51.0 (https://github.com/aws-deadline/deadline-cloud/releases/tag/0.51.0) that required some typing changes
- Also improved the testing documentation since it was missing a few steps that I had to do to get the tests to run

### What is the impact of this change?
The Maya integration is using the latest `deadline` version

### How was this change tested?

#### Manual testing
Performed on Mac with Maya 2025
- Installed the submitter into my local Maya
- Downloaded the "Sophie" test scene from https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_maya_tutorials_am_Learning_Scenes_html
- Submitted a job with the developer override adaptor wheels option enabled, verified the render succeed and output looks as expected



#### Unit test result
See "Checks" tab.

#### Integ test result

```
$ hatch run integ:test_submitters
======================================================================== test session starts ========================================================================
platform darwin -- Python 3.11.4, pytest-8.4.1, pluggy-1.6.0 -- /Applications/Autodesk/maya2025/Maya.app/Contents/bin/mayapy
cachedir: .pytest_cache
rootdir: /Volumes/workplace/github/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: flaky-3.8.1, xdist-3.8.0, cov-6.2.1
1 worker [2 items]     
scheduling tests via LoadScheduling

test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
[gw0] [ 50%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 

========================================================================= warnings summary ==========================================================================
test/integ/test_maya_adaptors.py:27
  /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:27: PytestUnknownMarkWarning: Unknown pytest.mark.maya_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.maya_renderer

test/integ/test_maya_adaptors.py:51
  /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:51: PytestUnknownMarkWarning: Unknown pytest.mark.redshift_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.redshift_renderer

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== slowest 5 durations ========================================================================
30.68s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
9.10s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
1.55s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
0.05s teardown test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
0.00s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
================================================================== 2 passed, 2 warnings in 48.51s ===================================================================
```

#### Installer test result

```
$ hatch run test-installer
======================================================================================================================================== test session starts =========================================================================================================================================
platform darwin -- Python 3.13.2, pytest-8.4.1, pluggy-1.6.0 -- /Users/jericht/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/vTaURC9A/deadline-cloud-for-maya/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/github/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: xdist-3.8.0, cov-6.2.1
12 workers [13 items]     
scheduling tests via LoadScheduling

test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw1] [  7%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw9] [ 15%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw11] [ 23%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw10] [ 30%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw4] [ 38%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw3] [ 46%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw8] [ 53%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw5] [ 61%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw0] [ 69%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw0] [ 76%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw6] [ 84%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 92%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

========================================================================================================================================== warnings summary ==========================================================================================================================================
test/installer/test_installer.py:466
  /Volumes/workplace/github/deadline-cloud-for-maya/test/installer/test_installer.py:466: SyntaxWarning: invalid escape sequence '\*'
    """Assumes that the Windows SDK is installed so we can find signtool:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================================================== slowest 5 durations =========================================================================================================================================
11.62s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
11.47s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
11.38s setup    test/installer/test_installer.py::TestUserInstall::test_install
2.84s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
2.75s call     test/installer/test_installer.py::test_default_location
============================================================================================================================== 4 passed, 9 skipped, 1 warning in 15.73s ==============================================================================================================================
```

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Yes, all passed

```
Timestamp: 2025-08-18T11:33:56.797515-07:00
Running job bundle output test: /Users/jericht/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2025-08-18T11:33:59.409830-07:00
Running job bundle output test: /Users/jericht/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2025-08-18T11:34:01.188585-07:00
Running job bundle output test: /Users/jericht/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2025-08-18T11:34:01.188744-07:00
Running job bundle output test: /Users/jericht/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2025-08-18T11:34:02.935832-07:00
Running job bundle output test: /Users/jericht/workplace/github/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2025-08-18T11:34:06.603609-07:00
```


### Was this change documented?

No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
