### PR TITLE
chore: remove unit test result section from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,16 +16,15 @@ Fixes: *<insert link to GitHub issue here>*
 See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/DEVELOPMENT.md) for information on running tests.
 *delete text ending here*
 
-#### Unit test result
-*delete text starting here*
-If `src/` was modified or a file was added/removed, then update the unit tests and post the test results below
-*delete text ending here*
 #### Integ test result
+
 *delete text starting here*
 If `src/` was modified or a file was added/removed, then update the integ tests and post the test results below. See
 DEVELOPMENT.md on additional instructions on running some, or all integ tests.
 *delete text ending here*
+
 #### Installer test result
+
 *delete text starting here*
 If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
 *delete text ending here*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The PR template included a section for `Unit test result`, but that's redundant because the checks that run on each PR run unit tests (on multiple platforms and Python versions).

### What was the solution? (How)
Remove the unit test result section, also put spacing in the test result sections so it is easier to read.

### What is the impact of this change?
Cleaner PR template

### How was this change tested?
N/A 

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, this change has no effect on the Maya integration

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
