### PR TITLE
chore(deps): bump openjd-adaptor-runtime to 0.9.*

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -308,18 +308,47 @@ or modifying functionality, then you will want to be writing one or more integ t
 logic behaves as expected and that future changes do not accidentally break your change.
 
 To run the integ tests, you need to:
-1. Add `mayapy` executable to the PATH:
+1. Install Maya 2025
+2. Install Redshift 2025
+3. Add `mayapy` executable to the PATH:
    
    For example, default path of mayapy on OSX is 
 
    ```
    /Applications/Autodesk/maya<version>/Maya.app/Contents/MacOS
    ```
-2. Use hatch to run all adaptor tests:
+4. Navigate to your local checkout of this repository:
+   ```
+   cd </path/to/deadline-cloud-for-maya>
+   ```
+5. Install your local `deadline-cloud-for-maya` repository into Maya's Python environment:
+   ```
+   mayapy -m pip install -e . --force-reinstall
+   ```
+6. Install the testing dependencies into Maya's Python environment:
+   ```
+   mayapy -m pip install -r requirements-testing.txt
+   ```
+7. Install the integration testing dependencies into Maya's Python environment:
+   ```
+   mayapy -m pip install -r requirements-integ-testing.txt
+   ```
+8. Add Maya's Python's `bin/` folder to your `PATH`:
+
+   For example, the default path on OSX is
+   ```
+   /Applications/Autodesk/maya2025/Maya.app/Contents/Frameworks/Python.framework/Versions/Current/bin/
+   ```
+
+   So you can run:
+   ```
+   export PATH="/Applications/Autodesk/maya2025/Maya.app/Contents/Frameworks/Python.framework/Versions/Current/bin/:$PATH"
+   ```
+9. Use hatch to run all adaptor tests:
    ```bash
    hatch run integ:test_adaptors_all
    ```
-3. Use hatch to run adaptor tests for a specific maya renderer plugin: 
+10. Use hatch to run adaptor tests for a specific maya renderer plugin:
    ```bash
    hatch run integ:test_adaptors_maya
    ```
@@ -328,7 +357,7 @@ To run the integ tests, you need to:
    hatch run integ:test_adaptors_redshift
    ```
 
-4. (Optional) Use hatch to run all integ tests:
+11. (Optional) Use hatch to run all integ tests:
    ```bash
    hatch run integ:test
    ```
@@ -341,7 +370,7 @@ To run the integ tests, you need to:
 #### Build the package
 
 ```bash
-hatch run build
+hatch build
 ```
 
 #### Build the installer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies = [
     "deadline == 0.51.*",
-    "openjd-adaptor-runtime == 0.8.*",
+    "openjd-adaptor-runtime == 0.9.*",
 ]
 
 [project.urls]

--- a/src/deadline/maya_adaptor/MayaClient/maya_client.py
+++ b/src/deadline/maya_adaptor/MayaClient/maya_client.py
@@ -9,14 +9,9 @@ from typing import Optional
 # The Maya Adaptor adds the `openjd` namespace directory to PYTHONPATH,
 # so that importing just the adaptor_runtime_client should work.
 try:
-    from adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
+    from adaptor_runtime_client import ClientInterface  # type: ignore[import]
 except (ImportError, ModuleNotFoundError):
-    try:
-        from openjd.adaptor_runtime_client import HTTPClientInterface  # type: ignore[import]
-    except (ImportError, ModuleNotFoundError):
-        # TODO: Remove this try/except once we bump to openjd.adaptor_runtime_client 0.9+
-        # On Windows, HTTPClientInterface is not available, only ClientInterface
-        from openjd.adaptor_runtime_client import ClientInterface as HTTPClientInterface  # type: ignore[import]
+    from openjd.adaptor_runtime_client import ClientInterface  # type: ignore[import]
 
 
 try:
@@ -29,7 +24,7 @@ except (ImportError, ModuleNotFoundError):
     )
 
 
-class MayaClient(HTTPClientInterface):
+class MayaClient(ClientInterface):
     def __init__(self, server_path: str) -> None:
         super().__init__(server_path=server_path)
         self.actions.update(

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/test_client.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/test_client.py
@@ -9,7 +9,7 @@ from deadline.maya_adaptor.MayaClient.maya_client import MayaClient, main
 
 
 class TestMayaClient:
-    @patch("deadline.maya_adaptor.MayaClient.maya_client.HTTPClientInterface")
+    @patch("deadline.maya_adaptor.MayaClient.maya_client.ClientInterface")
     def test_mayaclient(self, mock_httpclient: Mock) -> None:
         """Tests that the maya client can initialize, set a renderer and close"""
         client = MayaClient(server_path=str(9999))
@@ -19,7 +19,7 @@ class TestMayaClient:
     @patch("deadline.maya_adaptor.MayaClient.maya_client.os.path.exists")
     @patch.dict(os.environ, {"MAYA_ADAPTOR_SERVER_PATH": "server_path"})
     @patch("deadline.maya_adaptor.MayaClient.MayaClient.poll")
-    @patch("deadline.maya_adaptor.MayaClient.maya_client.HTTPClientInterface")
+    @patch("deadline.maya_adaptor.MayaClient.maya_client.ClientInterface")
     def test_main(self, mock_httpclient: Mock, mock_poll: Mock, mock_exists: Mock) -> None:
         """Tests that the main method starts the maya client polling method"""
         # GIVEN


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We should upgrade `openjd-adaptor-runtime` to the latest released version to get all the latest fixes and improvements.

### What was the solution? (How)
Upgrade `openjd-adaptor-runtime` to 0.9.*

### What is the impact of this change?
We have the latest adaptor runtime changes

### How was this change tested?

#### Manual testing
- Submitted a Maya job with the developer override adaptor option enabled, verified the job succeed, downloaded the output and ensured it looked correct. Used the "Sophie" scene from https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_for_maya_tutorials_am_Learning_Scenes_html

#### Integ test result

I only ran the Maya render scene, could not get the Redshift one to work even after installing Redshift and V-Ray for Maya 2025

```
$ hatch run integ:test_adaptors_maya
================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.11.4, pytest-8.4.1, pluggy-1.6.0 -- /Applications/Autodesk/maya2025/Maya.app/Contents/bin/mayapy
cachedir: .pytest_cache
rootdir: /Volumes/workplace/github/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: flaky-3.8.1, xdist-3.8.0, cov-6.2.1
1 worker [1 item]      
scheduling tests via LoadScheduling

test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [100%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 

==================================================================================== warnings summary ====================================================================================
test/integ/test_maya_adaptors.py:27
  /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:27: PytestUnknownMarkWarning: Unknown pytest.mark.maya_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.maya_renderer

test/integ/test_maya_adaptors.py:51
  /Volumes/workplace/github/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:51: PytestUnknownMarkWarning: Unknown pytest.mark.redshift_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.redshift_renderer

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===Flaky Test Report===

test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
================================================================================== slowest 5 durations ===================================================================================
33.77s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
0.00s setup    test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
0.00s teardown test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
============================================================================= 1 passed, 2 warnings in 35.34s =============================================================================
```

#### Installer test result

```
$ hatch run test-installer
================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.9.6, pytest-8.4.1, pluggy-1.6.0 -- /Users/jericht/Library/Application Support/hatch/env/virtual/deadline-cloud-for-maya/vTaURC9A/deadline-cloud-for-maya/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/github/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: xdist-3.8.0, cov-6.2.1
12 workers [13 items]     
scheduling tests via LoadScheduling

test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw9] [  7%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw5] [ 15%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw3] [ 23%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw10] [ 30%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw11] [ 38%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
[gw1] [ 46%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw4] [ 53%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw8] [ 61%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw0] [ 69%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw0] [ 76%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw6] [ 84%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 92%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

================================================================================== slowest 5 durations ===================================================================================
11.82s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
11.77s setup    test/installer/test_installer.py::TestUserInstall::test_install
11.03s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
3.12s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
2.64s call     test/installer/test_installer.py::test_default_location
============================================================================= 4 passed, 9 skipped in 16.21s ==============================================================================
```

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No, the adaptor runtime is not used by the submitter.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
