### PR TITLE
test: add unit tests for cache file scene introspection

### DIFF
--- a/test/unit/deadline_submitter_for_maya/scripts/test_assets.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_assets.py
@@ -137,6 +137,43 @@ class TestParseSceneAssets:
             any_order=True,
         )
 
+    @patch.object(assets_module.AssetIntrospector, "_get_node_attr_paths")
+    def test_gets_node_attr_paths(
+        self,
+        mock_get_node_attr_paths: MagicMock,
+        mock_expand_path: MagicMock,
+        scene_name: str,
+    ) -> None:
+        # GIVEN
+        node_attr_paths = [
+            "/path/to/project/test_scene/object1/cacheFile",
+            "/path/to/project/test_scene/object1/input1_####.png",
+            "/path/to/project/test_scene/object1/input2_<f>.png",
+            "/path/to/project/test_scene/object1/input3_<frame>.png",
+        ]
+        mock_get_node_attr_paths.return_value = node_attr_paths
+        progress_callback = MagicMock()
+
+        # WHEN
+        results = assets_module.AssetIntrospector().parse_scene_assets(progress_callback)
+
+        # THEN
+        expected_results = {
+            Path("/path/to/project/test_scene/object1/cacheFile"),
+            Path("/path/to/project/test_scene/object1/input1_####.png"),
+            Path("/path/to/project/test_scene/object1/input2_<f>.png"),
+            Path("/path/to/project/test_scene/object1/input3_<frame>.png"),
+            Path(scene_name),
+        }
+        assert expected_results.issubset(results)
+        mock_expand_path.assert_has_calls(
+            [
+                call("/path/to/project/test_scene/object1/input1_####.png"),
+                call("/path/to/project/test_scene/object1/input2_<f>.png"),
+                call("/path/to/project/test_scene/object1/input3_<frame>.png"),
+            ],
+        )
+
 
 @patch.object(assets_module.AssetIntrospector, "_expand_path")
 @patch.object(assets_module.Scene, "yeti_cache_files")
@@ -456,3 +493,72 @@ class TestExpandPath:
         # THEN
         assert next(third_result) == path
         assert mock_findAllFilesForPattern.call_count == 2
+
+
+@patch.object(assets_module, "maya")
+def test_expand_tokens(mock_maya: MagicMock) -> None:
+    # GIVEN
+    object_name = "test_object"
+    mock_maya.cmds.internalVar.return_value = "/path/to/project"
+    mock_maya.cmds.file.return_value = "/path/to/project/folder1/test_scene.ma"
+    input_path = "<project>/folder1/<scene>/folder2/<object>/cache_texture1"
+
+    # WHEN
+    result_path = assets_module.AssetIntrospector()._expand_tokens(input_path, object_name)
+
+    # THEN
+    assert result_path == "/path/to/project/folder1/test_scene/folder2/test_object/cache_texture1"
+
+
+@pytest.mark.parametrize("expand_tokens", [True, False])
+@patch.object(assets_module.AssetIntrospector, "_expand_tokens")
+@patch.object(assets_module, "maya")
+def test_get_node_attr_paths(
+    mock_maya: MagicMock,
+    mock_expand_tokens: MagicMock,
+    expand_tokens: bool,
+) -> None:
+    # GIVEN
+    file_node = MagicMock()
+    file_node_attrs = [f"{file_node}.texture1", f"{file_node}.texture2"]
+
+    bifrost_node = MagicMock()
+    bifrost_node_attrs = [f"{bifrost_node}.texture1", f"{bifrost_node}.texture2"]
+
+    mock_maya.cmds.ls.return_value = [file_node, bifrost_node]
+    mock_maya.cmds.listAttr.side_effect = [file_node_attrs, bifrost_node_attrs]
+    mock_maya.cmds.attributeQuery.side_effect = [False, True]
+
+    mock_expand_tokens.side_effect = (
+        lambda path, object_name: path.replace("<object>", str(object_name))
+        .replace("<scene>", "test_scene")
+        .replace("<project>", "/path/to/project")
+    )
+
+    attr_map = {
+        f"{file_node}.texture1": "<project>/<scene>/<object>/happy",
+        f"{file_node}.texture2": "<project>/<scene>/<object>/sad",
+        f"{bifrost_node}.texture1": "<project>/<scene>/<object>/water",
+        f"{bifrost_node}.texture2": None,
+        f"{bifrost_node}.absoluteCacheName": "<project>/<scene>/<object>/cacheFile",
+    }
+    mock_maya.cmds.getAttr.side_effect = lambda attr: attr_map[attr]
+
+    # WHEN
+    result = assets_module.AssetIntrospector()._get_node_attr_paths(expand_tokens)
+
+    # THEN
+    if expand_tokens:
+        assert result == [
+            f"/path/to/project/test_scene/{file_node}/happy",
+            f"/path/to/project/test_scene/{file_node}/sad",
+            f"/path/to/project/test_scene/{bifrost_node}/water",
+            f"/path/to/project/test_scene/{bifrost_node}/cacheFile",
+        ]
+    else:
+        assert result == [
+            "<project>/<scene>/<object>/happy",
+            "<project>/<scene>/<object>/sad",
+            "<project>/<scene>/<object>/water",
+            "<project>/<scene>/<object>/cacheFile",
+        ]

--- a/test/unit/deadline_submitter_for_maya/scripts/test_utils.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_utils.py
@@ -64,6 +64,7 @@ def test_join_paths(first_path: str, second_path: str, expected_output: str):
     assert join_paths(first_path, second_path) == expected_output
 
 
+@pytest.mark.parametrize("frame_symbol", ["<f>", "<frame>"])
 @patch.object(utils_module.os.path, "isfile", return_value=True)
 @patch.object(utils_module.os, "listdir")
 @patch.object(utils_module.os.path, "isdir", return_value=True)
@@ -73,9 +74,10 @@ def test_findAllFilesForPattern(
     mock_isdir: MagicMock,
     mock_listdir: MagicMock,
     mock_isfile: MagicMock,
+    frame_symbol: str,
 ) -> None:
     # GIVEN
-    pattern = "/test/file/path.<f>.png"
+    pattern = f"/test/file/path.{frame_symbol}.png"
     frame_number = 2
     mock_listdir.return_value = [
         "/test/file/path.0001.png",
@@ -85,7 +87,9 @@ def test_findAllFilesForPattern(
         "/test/file/path.2.png",
     ]
     # TODO: Figure out what patternToRegex actually does
-    mock_patternToRegex.return_value = pattern.replace("<f>", f"0*{frame_number}")
+    mock_patternToRegex.return_value = pattern.replace("<f>", f"0*{frame_number}").replace(
+        "<frame>", f"0*{frame_number}"
+    )
 
     # WHEN
     result = utils_module.findAllFilesForPattern(pattern, frame_number)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In https://github.com/aws-deadline/deadline-cloud-for-maya/pull/259, we improved the scene introspection to include  files that are referenced via attributes on nodes (e.g. Bifrost cache files), however we decided to go ahead and merge and backfill unit tests for this functionality later. We should backfill the unit tests for these changes.

### What was the solution? (How)
Add the unit tests for https://github.com/aws-deadline/deadline-cloud-for-maya/pull/259

### What is the impact of this change?
We have unit tests for https://github.com/aws-deadline/deadline-cloud-for-maya/pull/259

### How was this change tested?
`hatch run test`

#### Integ test result

N/A

#### Installer test result
N/A

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, this only adds unit tests


### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
