### PR TITLE
fix: Fixed issues with job attachments caching change

### DIFF
--- a/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
@@ -119,6 +119,7 @@ steps:
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
+          cache_pathmapping: true
       actions:
         onEnter:
           command: MayaAdaptor

--- a/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
@@ -254,6 +254,7 @@ steps:
           output_file_prefix: '{{Param.layerDefaultFramesOutputFilePrefix}}'
           image_width: {{Param.layerDefaultFramesImageWidth}}
           image_height: {{Param.layerDefaultFramesImageHeight}}
+          cache_pathmapping: true
           error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
       actions:
         onEnter:
@@ -330,6 +331,7 @@ steps:
           output_file_prefix: '{{Param.layerFrameRange1OutputFilePrefix}}'
           image_width: {{Param.layerFrameRange1ImageWidth}}
           image_height: {{Param.layerFrameRange1ImageHeight}}
+          cache_pathmapping: true
       actions:
         onEnter:
           command: MayaAdaptor
@@ -405,6 +407,7 @@ steps:
           output_file_prefix: '{{Param.masterLayerOutputFilePrefix}}'
           image_width: {{Param.masterLayerImageWidth}}
           image_height: {{Param.masterLayerImageHeight}}
+          cache_pathmapping: true
           error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
       actions:
         onEnter:
@@ -482,6 +485,7 @@ steps:
           output_file_prefix: '{{Param.renderSetupLayer2OutputFilePrefix}}'
           image_width: {{Param.renderSetupLayer2ImageWidth}}
           image_height: {{Param.renderSetupLayer2ImageHeight}}
+          cache_pathmapping: true
           error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
       actions:
         onEnter:
@@ -558,6 +562,7 @@ steps:
           output_file_prefix: '{{Param.renderSetupLayer4OutputFilePrefix}}'
           image_width: {{Param.renderSetupLayer4ImageWidth}}
           image_height: {{Param.renderSetupLayer4ImageHeight}}
+          cache_pathmapping: true
       actions:
         onEnter:
           command: MayaAdaptor

--- a/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
@@ -130,6 +130,7 @@ steps:
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
+          cache_pathmapping: true
           error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
       actions:
         onEnter:
@@ -205,6 +206,7 @@ steps:
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
+          cache_pathmapping: true
           error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
       actions:
         onEnter:
@@ -280,6 +282,7 @@ steps:
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
+          cache_pathmapping: true
           error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
       actions:
         onEnter:

--- a/job_bundle_output_tests/referenced_layers/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/referenced_layers/expected_job_bundle/template.yaml
@@ -130,6 +130,7 @@ steps:
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
+          cache_pathmapping: true
           error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
       actions:
         onEnter:

--- a/src/deadline/maya_submitter/assets.py
+++ b/src/deadline/maya_submitter/assets.py
@@ -277,6 +277,10 @@ class AssetIntrospector:
         """
         paths: list[str] = []
         for node in maya.cmds.ls():
+            # Excluding vraySettings node because a referenced file path causes issues
+            # when auto-populating the attachment input directories
+            if str(node) == "vraySettings":
+                continue
             attrs: list[str] = maya.cmds.listAttr(
                 node, usedAsFilename=True, fullNodeName=True, multi=True
             )

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -697,7 +697,6 @@ def show_maya_render_submitter(
 
     # Process assets with progress updates
     processed_files = set()
-    processed_directories = set()
     print(f"Starting to process {total_assets} scene assets...")
 
     for i, asset_path in enumerate(scene_assets):
@@ -705,9 +704,7 @@ def show_maya_render_submitter(
         normalized = os.path.normpath(asset_path)
         if not os.path.exists(normalized):
             continue
-        if os.path.isdir(normalized):
-            processed_directories.add(normalized)
-        else:
+        if os.path.isfile(normalized):
             processed_files.add(normalized)
         # Process in larger batches to improve performance - refresh UI every 100 assets
         if i % 100 == 0 and i > 0:
@@ -716,7 +713,6 @@ def show_maya_render_submitter(
 
     progress_dialog.setValue(total_assets)
     auto_detected_attachments.input_filenames = processed_files
-    auto_detected_attachments.input_directories = processed_directories
     print(f"All {total_assets} assets processed at {time.time()}")
     update_progress(f"All {total_assets} assets processed")
 

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -697,6 +697,7 @@ def show_maya_render_submitter(
 
     # Process assets with progress updates
     processed_files = set()
+    processed_directories = set()
     print(f"Starting to process {total_assets} scene assets...")
 
     for i, asset_path in enumerate(scene_assets):
@@ -704,7 +705,9 @@ def show_maya_render_submitter(
         normalized = os.path.normpath(asset_path)
         if not os.path.exists(normalized):
             continue
-        if os.path.isfile(normalized):
+        if os.path.isdir(normalized):
+            processed_directories.add(normalized)
+        else:
             processed_files.add(normalized)
         # Process in larger batches to improve performance - refresh UI every 100 assets
         if i % 100 == 0 and i > 0:
@@ -713,6 +716,7 @@ def show_maya_render_submitter(
 
     progress_dialog.setValue(total_assets)
     auto_detected_attachments.input_filenames = processed_files
+    auto_detected_attachments.input_directories = processed_directories
     print(f"All {total_assets} assets processed at {time.time()}")
     update_progress(f"All {total_assets} assets processed")
 

--- a/test/integ/helpers/output_comparison.py
+++ b/test/integ/helpers/output_comparison.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Any
 import yaml
+import re
 
 import PIL.Image
 
@@ -70,21 +71,44 @@ def are_parameter_values_similar(job_history_dir: Path, expected_parameter_value
 
 
 def are_asset_references_similar(
-    job_history_dir: Path, expected_asset_references: dict[str, dict[str, Any]]
+    job_history_dir: Path, expected_asset_references: dict[str, dict[str, Any]], expected_scene_file_paths: list[str] = None
 ):
     """
     Helper function that asserts that asset reference values in the job bundle are what's expected.
     """
     with open(job_history_dir / ASSET_REFERENCES) as actual:
         actual_asset_reference = yaml.safe_load(actual)
+        actual_filenames = set(actual_asset_reference["assetReferences"]["inputs"]["filenames"])
+        expected_filenames = set(expected_asset_references["assetReferences"]["inputs"]["filenames"])
+        
+        actual_input_directories = set(actual_asset_reference["assetReferences"]["inputs"]["directories"])
+        expected_input_directories = set(expected_asset_references["assetReferences"]["inputs"]["directories"])
+        
+        # If we have expected file paths, find matching files in actual and add them to expected
+        if expected_scene_file_paths:
+            for pattern in expected_scene_file_paths:
+                matching_files = [f for f in actual_filenames if re.search(pattern, f)]
+                assert matching_files, f"Expected to find files matching pattern '{pattern}' in asset references, but found none. Actual filenames: {actual_filenames}"
+                expected_filenames.update(matching_files)
+            
+            # Verify job_history_dir is part of the actual input directories and add it to expected
+            job_history_str = str(job_history_dir)
+            for actual_dir in actual_input_directories:
+                if actual_dir in job_history_str:
+                    expected_input_directories.add(actual_dir)
+        
         # We don't care what order the filenames list is in, so turn it into a set for easier comparison.
         # Compare the lengths before we turn it into a set so that we can cover the case of duplicate assets.
-        assert len(actual_asset_reference["assetReferences"]["inputs"]["filenames"]) == len(
-            expected_asset_references["assetReferences"]["inputs"]["filenames"]
-        )
-        actual_asset_reference["assetReferences"]["inputs"]["filenames"] = set(
-            actual_asset_reference["assetReferences"]["inputs"]["filenames"]
-        )
+        assert len(actual_filenames) == len(expected_filenames)
+        assert len(actual_input_directories) == len(expected_input_directories)
+        
+        # Update the expected asset references with the matched files and directories
+        expected_asset_references["assetReferences"]["inputs"]["filenames"] = expected_filenames
+        actual_asset_reference["assetReferences"]["inputs"]["filenames"] = actual_filenames
+        
+        expected_asset_references["assetReferences"]["inputs"]["directories"] = list(expected_input_directories)
+        actual_asset_reference["assetReferences"]["inputs"]["directories"] = list(actual_input_directories)
+        
         directories = expected_asset_references["assetReferences"]["outputs"]["directories"]
         expected_asset_references["assetReferences"]["outputs"]["directories"] = [
             d.replace("\\", "/") for d in directories

--- a/test/integ/helpers/output_comparison.py
+++ b/test/integ/helpers/output_comparison.py
@@ -71,7 +71,9 @@ def are_parameter_values_similar(job_history_dir: Path, expected_parameter_value
 
 
 def are_asset_references_similar(
-    job_history_dir: Path, expected_asset_references: dict[str, dict[str, Any]], expected_scene_file_paths: list[str] = None
+    job_history_dir: Path,
+    expected_asset_references: dict[str, dict[str, Any]],
+    expected_scene_file_paths: list[str] = [],
 ):
     """
     Helper function that asserts that asset reference values in the job bundle are what's expected.
@@ -79,36 +81,48 @@ def are_asset_references_similar(
     with open(job_history_dir / ASSET_REFERENCES) as actual:
         actual_asset_reference = yaml.safe_load(actual)
         actual_filenames = set(actual_asset_reference["assetReferences"]["inputs"]["filenames"])
-        expected_filenames = set(expected_asset_references["assetReferences"]["inputs"]["filenames"])
-        
-        actual_input_directories = set(actual_asset_reference["assetReferences"]["inputs"]["directories"])
-        expected_input_directories = set(expected_asset_references["assetReferences"]["inputs"]["directories"])
-        
+        expected_filenames = set(
+            expected_asset_references["assetReferences"]["inputs"]["filenames"]
+        )
+
+        actual_input_directories = set(
+            actual_asset_reference["assetReferences"]["inputs"]["directories"]
+        )
+        expected_input_directories = set(
+            expected_asset_references["assetReferences"]["inputs"]["directories"]
+        )
+
         # If we have expected file paths, find matching files in actual and add them to expected
         if expected_scene_file_paths:
             for pattern in expected_scene_file_paths:
                 matching_files = [f for f in actual_filenames if re.search(pattern, f)]
-                assert matching_files, f"Expected to find files matching pattern '{pattern}' in asset references, but found none. Actual filenames: {actual_filenames}"
+                assert (
+                    matching_files
+                ), f"Expected to find files matching pattern '{pattern}' in asset references, but found none. Actual filenames: {actual_filenames}"
                 expected_filenames.update(matching_files)
-            
+
             # Verify job_history_dir is part of the actual input directories and add it to expected
             job_history_str = str(job_history_dir)
             for actual_dir in actual_input_directories:
                 if actual_dir in job_history_str:
                     expected_input_directories.add(actual_dir)
-        
+
         # We don't care what order the filenames list is in, so turn it into a set for easier comparison.
         # Compare the lengths before we turn it into a set so that we can cover the case of duplicate assets.
         assert len(actual_filenames) == len(expected_filenames)
         assert len(actual_input_directories) == len(expected_input_directories)
-        
+
         # Update the expected asset references with the matched files and directories
         expected_asset_references["assetReferences"]["inputs"]["filenames"] = expected_filenames
         actual_asset_reference["assetReferences"]["inputs"]["filenames"] = actual_filenames
-        
-        expected_asset_references["assetReferences"]["inputs"]["directories"] = expected_input_directories
-        actual_asset_reference["assetReferences"]["inputs"]["directories"] = actual_input_directories
-        
+
+        expected_asset_references["assetReferences"]["inputs"][
+            "directories"
+        ] = expected_input_directories
+        actual_asset_reference["assetReferences"]["inputs"][
+            "directories"
+        ] = actual_input_directories
+
         directories = expected_asset_references["assetReferences"]["outputs"]["directories"]
         expected_asset_references["assetReferences"]["outputs"]["directories"] = [
             d.replace("\\", "/") for d in directories

--- a/test/integ/helpers/output_comparison.py
+++ b/test/integ/helpers/output_comparison.py
@@ -106,8 +106,8 @@ def are_asset_references_similar(
         expected_asset_references["assetReferences"]["inputs"]["filenames"] = expected_filenames
         actual_asset_reference["assetReferences"]["inputs"]["filenames"] = actual_filenames
         
-        expected_asset_references["assetReferences"]["inputs"]["directories"] = list(expected_input_directories)
-        actual_asset_reference["assetReferences"]["inputs"]["directories"] = list(actual_input_directories)
+        expected_asset_references["assetReferences"]["inputs"]["directories"] = expected_input_directories
+        actual_asset_reference["assetReferences"]["inputs"]["directories"] = actual_input_directories
         
         directories = expected_asset_references["assetReferences"]["outputs"]["directories"]
         expected_asset_references["assetReferences"]["outputs"]["directories"] = [

--- a/test/integ/test_maya_submitters.py
+++ b/test/integ/test_maya_submitters.py
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-import dataclasses
+from dataclasses import dataclass
 
 import yaml
 import os
@@ -45,13 +45,13 @@ class TestSubmitters:
     Tests that ensure submitters produce the correct job bundle given a scene file.
     """
 
-    @dataclasses.dataclass
+    @dataclass
     class JobConfiguration:
         name: str
         asset_folder: str
         frame_list: str
         file_prefix: str
-        expected_scene_file_paths: list[str] = None
+        expected_scene_file_paths: list[str]
 
     def _cleanup_sticky_settings(self, scene_file: Path, script_location: Path):
         """
@@ -72,6 +72,7 @@ class TestSubmitters:
                 asset_folder="minimal_test",
                 frame_list="1-2",
                 file_prefix="rs_<RenderLayer>_<Camera>",
+                expected_scene_file_paths=[],
             ),
             JobConfiguration(
                 name="Redshift Test",
@@ -205,4 +206,6 @@ class TestSubmitters:
             }
         }
 
-        are_asset_references_similar(job_history_dir, expected_asset_references, job_configuration.expected_scene_file_paths)
+        are_asset_references_similar(
+            job_history_dir, expected_asset_references, job_configuration.expected_scene_file_paths
+        )

--- a/test/integ/test_maya_submitters.py
+++ b/test/integ/test_maya_submitters.py
@@ -51,6 +51,7 @@ class TestSubmitters:
         asset_folder: str
         frame_list: str
         file_prefix: str
+        expected_scene_file_paths: list[str] = None
 
     def _cleanup_sticky_settings(self, scene_file: Path, script_location: Path):
         """
@@ -77,6 +78,7 @@ class TestSubmitters:
                 asset_folder="redshift_test",
                 frame_list="1",
                 file_prefix="redshift_test",
+                expected_scene_file_paths=[r"config.ocio"],
             ),
         ],
         ids=["Minimal Maya Test", "Redshift Test"],
@@ -203,4 +205,4 @@ class TestSubmitters:
             }
         }
 
-        are_asset_references_similar(job_history_dir, expected_asset_references)
+        are_asset_references_similar(job_history_dir, expected_asset_references, job_configuration.expected_scene_file_paths)

--- a/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
@@ -120,6 +120,7 @@ steps:
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
+          cache_pathmapping: true
       actions:
         onEnter:
           command: MayaAdaptor
@@ -195,6 +196,7 @@ steps:
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
+          cache_pathmapping: true
       actions:
         onEnter:
           command: MayaAdaptor

--- a/test/integ/test_scripts/redshift_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/redshift_test/expected_job_bundle/template.yaml
@@ -119,6 +119,7 @@ steps:
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
+          cache_pathmapping: true
       actions:
         onEnter:
           command: MayaAdaptor


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A change was made earlier to [include cache files for job attachments](https://github.com/aws-deadline/deadline-cloud-for-maya/pull/259). However, there were a few issues with this change. Firstly, it caused the integration tests to fail. 

<img width="675" height="174" alt="image" src="https://github.com/user-attachments/assets/516f9fcd-0139-48c9-adc4-8187cd37a5a2" />

The submitter tests failed because it was not expecting the newly added `cache_pathmapping` field.

The submitter integration tests also failed because the redshift test uses the OCIO package, which links to a filepath of `config.ocio`. with these new changes, this path was added to the input file, causing the integ tests to fail.

Also, there was a change to autopopulate the asset directory based on if detected scene assets were a directory. However that caused errors with the vray settings node, which used `/var/folder/...`. This directory was being used by other applications as well, and files in that folder could not be rendered

### What was the solution? (How)
- Modified integ tests to accept a list of expected file paths. 
- Specified that  the redshift test expects `config.ocio`
- Will make sure this file is included in inputs/filenames and its directory is in inputs/directories

Actual Asset Reference
```
assetReferences:
  inputs:
    directories:
    - /var/folders/jw/ymwt404j0634pkzqkt60zwp00000gq/T
    filenames:
    - /Applications/Autodesk/maya2025/Maya.app/Contents/Resources/OCIO-configs/Maya2022-default/config.ocio
    - /Users/kenyrish/repos/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma
  outputs:
    directories:
    - /private/var/folders/jw/ymwt404j0634pkzqkt60zwp00000gq/T/pytest-of-kenyrish/pytest-85/popen-gw0/test_scene_submitter_job_confi1/output
  referencedPaths: []
```

Starting Expected Asset Reference
```
job_history_dir = PosixPath('/private/var/folders/jw/ymwt404j0634pkzqkt60zwp00000gq/T/pytest-of-kenyrish/pytest-73/popen-gw0/test_scene_submitter_Redshift_0/jobhistory')
expected_asset_references = {'assetReferences': {'inputs': {'directories': [], 'filenames': {'/Users/kenyrish/repos/deadline-cloud-for-maya/test/integ/test_scripts/redshift_test/scene/test.ma'}}, 'outputs': {'directories': ['/private/var/folders/jw/ymwt404j0634pkzqkt60zwp00000gq/T/pytest-of-kenyrish/pytest-73/popen-gw0/test_scene_submitter_Redshift_0/output']}, 'referencedPaths': []}}

```
It is missing only input directory and the additional input filename

### What is the impact of this change?
Integ tests now pass

### How was this change tested?


#### Integ test result

```
(deadline-cloud-for-maya) (base) kenyrish@7cf34dd39cf3 deadline-cloud-for-maya % hatch run integ:test
==================================================================================================================================== test session starts =====================================================================================================================================
platform darwin -- Python 3.11.4, pytest-8.4.1, pluggy-1.6.0 -- /Applications/Autodesk/maya2025/Maya.app/Contents/MacOS/mayapy
cachedir: .pytest_cache
rootdir: /Users/kenyrish/repos/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: xdist-3.7.0, flaky-3.8.1, cov-6.2.1
1 worker [4 items]     
scheduling tests via LoadScheduling

test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 25%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
[gw0] [ 50%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
[gw0] [ 75%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 

====================================================================================================================================== warnings summary ======================================================================================================================================
test/integ/test_maya_adaptors.py:27
  /Users/kenyrish/repos/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:27: PytestUnknownMarkWarning: Unknown pytest.mark.maya_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.maya_renderer

test/integ/test_maya_adaptors.py:51
  /Users/kenyrish/repos/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:51: PytestUnknownMarkWarning: Unknown pytest.mark.redshift_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.redshift_renderer

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===Flaky Test Report===

test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!
test_redshift_scene_adaptor passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
==================================================================================================================================== slowest 5 durations =====================================================================================================================================
26.36s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
23.93s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor
7.70s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
1.73s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
1.63s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
========================================================================================================================== 4 passed, 2 warnings in 64.12s (0:01:04) ==========================================================================================================================

```

#### Installer test result

N/A

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2025-09-10T09:50:20.405723-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2025-09-10T09:50:25.237506-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2025-09-10T09:50:28.939882-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2025-09-10T09:50:28.940154-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2025-09-10T09:50:32.799612-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2025-09-10T09:50:42.828924-07:00
```


### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
