### PR TITLE
chore(deps): update coverage[toml] version to 7.10.6

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
-coverage[toml] == 7.*
+coverage[toml] >= 7.10.6
 pytest == 8.*
 pytest-cov == 7.*
 pytest-xdist == 3.*


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
We recently upgraded the[ pytest-cov requirement to 7.*](https://github.com/aws-deadline/deadline-cloud-for-maya/pull/321). However, this requires [coverage 7.10.6,](https://pypi.org/project/pytest-cov/) which is the latest version.

### What was the solution? (How)
Updated pytest cov to use version at least 7.10.6.

### What is the impact of this change?

### How was this change tested?

*delete text starting here*
See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/DEVELOPMENT.md) for information on running tests.
*delete text ending here*

#### Integ test result

```

test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 25%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
[gw0] [ 50%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
[gw0] [ 75%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 

===================================================== warnings summary =====================================================
test/integ/test_maya_adaptors.py:27
  /Users/kenyrish/repos/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:27: PytestUnknownMarkWarning: Unknown pytest.mark.maya_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.maya_renderer

test/integ/test_maya_adaptors.py:51
  /Users/kenyrish/repos/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:51: PytestUnknownMarkWarning: Unknown pytest.mark.redshift_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.redshift_renderer

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===Flaky Test Report===

test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!
test_redshift_scene_adaptor passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
=================================================== slowest 5 durations ====================================================
27.09s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
22.98s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor
8.02s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
1.78s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
1.73s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
========================================= 4 passed, 2 warnings in 64.69s (0:01:04) =========================================
```


#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Timestamp: 2025-09-12T13:30:20.705685-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2025-09-12T13:30:25.230453-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2025-09-12T13:30:28.973848-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2025-09-12T13:30:28.973979-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2025-09-12T13:30:32.647197-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2025-09-12T13:30:38.569754-07:00
```


### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
