### PR TITLE
chore(deps): update deadline version to 0.52.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.51.*",
+    "deadline == 0.52.*",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)
Using older version of deadline

### What was the solution? (How)
Upgrade deadline to use 0.52.*

### What is the impact of this change?

### How was this change tested?

Ran: `hatch run test`, `hatch run lint`, `hatch run fmt`, `hatch run integ:test`, and verified all were successful. Also manually tested by submitting a job.

#### Integ test result

```

test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 25%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
[gw0] [ 50%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
[gw0] [ 75%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 

===================================================== warnings summary =====================================================
test/integ/test_maya_adaptors.py:27
  /Users/kenyrish/repos/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:27: PytestUnknownMarkWarning: Unknown pytest.mark.maya_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.maya_renderer

test/integ/test_maya_adaptors.py:51
  /Users/kenyrish/repos/deadline-cloud-for-maya/test/integ/test_maya_adaptors.py:51: PytestUnknownMarkWarning: Unknown pytest.mark.redshift_renderer - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.redshift_renderer

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===Flaky Test Report===

test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!
test_redshift_scene_adaptor passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
=================================================== slowest 5 durations ====================================================
27.09s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
22.98s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor
8.02s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
1.78s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
1.73s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
========================================= 4 passed, 2 warnings in 64.69s (0:01:04) =========================================
```




#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Timestamp: 2025-09-12T13:30:20.705685-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2025-09-12T13:30:25.230453-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2025-09-12T13:30:28.973848-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2025-09-12T13:30:28.973979-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2025-09-12T13:30:32.647197-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2025-09-12T13:30:38.569754-07:00
```


### Was this change documented?

*delete text starting here*
- Did you update all relevant docstrings for Python functions that you modified?
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?
- Should the schema files for the adaptor's init-data or run-data be updated?
*delete text ending here*

### Is this a breaking change?

*delete text starting here*
A breaking change is one that modifies a public contract in some way or otherwise changes functionality of this application in a way
that is not backwards compatible. Examples of changes that are breaking include:

1. Adding a new required value to the init-data or run-data of the adaptor;
2. Deleting or renaming a value in the init-data or run-data of the adaptor; and
3. Otherwise modifying the interface of the adaptor such that a job submitted with an older version of the Maya submitter plug-in
   will not work with a version of the adaptor that includes your modification.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
