### PR TITLE
fix: specified attributes to exclude for autopopulating directories

### DIFF
--- a/src/deadline/maya_submitter/assets.py
+++ b/src/deadline/maya_submitter/assets.py
@@ -276,11 +276,15 @@ class AssetIntrospector:
             [str]: A list of all the paths found
         """
         paths: list[str] = []
+        # Excluding vraySettings attributes because the referenced file paths cause issues
+        # when auto-populating the attachment input directories
+        excluded_attrs_by_node: dict[str, set[str]] = {
+            "vraySettings": {
+                "vraySettings.sys_memory_tracking_output_path",
+                "vraySettings.sys_time_tracking_output_dir",
+            }
+        }
         for node in maya.cmds.ls():
-            # Excluding vraySettings node because a referenced file path causes issues
-            # when auto-populating the attachment input directories
-            if str(node) == "vraySettings":
-                continue
             attrs: list[str] = maya.cmds.listAttr(
                 node, usedAsFilename=True, fullNodeName=True, multi=True
             )
@@ -291,6 +295,8 @@ class AssetIntrospector:
                     attrs = []
                 attrs.append("%s.absoluteCacheName" % node)
             if attrs is not None:
+                if excluded_attrs := excluded_attrs_by_node.get(str(node), set()):
+                    attrs = [attr for attr in attrs if attr not in excluded_attrs]
                 new_paths: list[str] = list(
                     filter(None, map(maya.cmds.getAttr, attrs))
                 )  # Map attribute to their value, then filter out empty attributes

--- a/test/unit/deadline_submitter_for_maya/scripts/test_assets.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_assets.py
@@ -562,3 +562,55 @@ def test_get_node_attr_paths(
             "<project>/<scene>/<object>/water",
             "<project>/<scene>/<object>/cacheFile",
         ]
+
+
+@patch.object(assets_module, "maya")
+def test_get_node_attr_paths_excludes_vray_settings(mock_maya: MagicMock) -> None:
+    """Test that VRay settings attributes are excluded from node attribute paths because of issues with autopopulating asset directories"""
+
+    vray_settings_node = "vraySettings"
+    regular_node = "regularNode"
+
+    # Mock the nodes in the scene
+    mock_maya.cmds.ls.return_value = [vray_settings_node, regular_node]
+
+    # Mock attributes for vraySettings node (including excluded ones)
+    vray_attrs = [
+        "vraySettings.sys_memory_tracking_output_path",  # Should be excluded
+        "vraySettings.sys_time_tracking_output_dir",  # Should be excluded
+        "vraySettings.some_other_path",  # Should be included
+    ]
+
+    # Mock attributes for regular node
+    regular_attrs = [
+        "regularNode.texture_path",
+        "regularNode.cache_file",
+    ]
+
+    mock_maya.cmds.listAttr.side_effect = [vray_attrs, regular_attrs]
+    mock_maya.cmds.attributeQuery.return_value = False  # No bifrost nodes
+
+    # Mock attribute values
+    attr_map = {
+        "vraySettings.sys_memory_tracking_output_path": "/path/to/memory/tracking",
+        "vraySettings.sys_time_tracking_output_dir": "/path/to/time/tracking",
+        "vraySettings.some_other_path": "/path/to/other/file",
+        "regularNode.texture_path": "/path/to/texture",
+        "regularNode.cache_file": "/path/to/cache",
+    }
+    mock_maya.cmds.getAttr.side_effect = lambda attr: attr_map[attr]
+
+    result = assets_module.AssetIntrospector()._get_node_attr_paths(expand_tokens=False)
+
+    # Should include the non-excluded vraySettings attribute and all regular node attributes
+    expected_paths = [
+        "/path/to/other/file",  # vraySettings.some_other_path (not excluded)
+        "/path/to/texture",  # regularNode.texture_path
+        "/path/to/cache",  # regularNode.cache_file
+    ]
+
+    assert result == expected_paths
+
+    # Verify that the excluded attributes were not processed
+    assert "/path/to/memory/tracking" not in result
+    assert "/path/to/time/tracking" not in result


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
Recently a change was made to fix a bug with autopopulating asset directories. The vray settings node hat an attribute for a `/var/folder` file, causing errors when submitting jobs. The previous fix was to remove the vray settings nodes, however that was too general.

### What was the solution? (How)
Instead, changed it to only remove the specified attributes, and still have the rest of the attributers in the vray settings node be added.

### What is the impact of this change?
Fix issue with autopopulating directory for vray

### How was this change tested?

Manaully verified that the incorrect folder has not been added to the autopopulating directory, and submitted a render and verified it submitted.

#### Integ test result

```
=================================================== test session starts ====================================================
platform darwin -- Python 3.11.4, pytest-8.4.1, pluggy-1.6.0 -- /Applications/Autodesk/maya2025/Maya.app/Contents/MacOS/mayapy
cachedir: .pytest_cache
rootdir: /Users/kenyrish/repos/deadline-cloud-for-maya
configfile: pyproject.toml
plugins: xdist-3.7.0, flaky-3.8.1, cov-7.0.0
1 worker [4 items]     
scheduling tests via LoadScheduling

test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
[gw0] [ 25%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
[gw0] [ 50%] PASSED test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
[gw0] [ 75%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 
[gw0] [100%] PASSED test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 

===================================================== warnings summary =====================================================

```


#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2025-09-12T17:45:49.352056-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2025-09-12T17:45:53.826755-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2025-09-12T17:45:57.430413-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2025-09-12T17:45:57.430565-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2025-09-12T17:46:01.075286-07:00
Running job bundle output test: /Users/kenyrish/repos/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2025-09-12T17:46:07.367554-07:00

```


### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
