### PR TITLE
feat: add support for Maya Vray 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This library requires:
 1. Python 3.9 or higher; and
 1. Linux, Windows, or a macOS operating system.
 
-Plugin support: Arnold, V-Ray, and Redshift for Maya 2024-2025; only Arnold for Maya 2026.
-Support for V-Ray and Redshift in Maya 2026 is planned for a future release.
+Plugin support: Arnold, V-Ray, and Redshift for Maya 2024-2025; Arnold and V-Ray for Maya 2026.
+Support for Redshift in Maya 2026 is planned for a future release.
 
 ## Versioning
 

--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -61,8 +61,8 @@
 		<stringParameter name="deadline_cloud_for_maya_summary" ask="0" cliOptionShow="0">
 			<value>Deadline Cloud for Maya 2024 - 2026
 - Compatible with Maya 2024 - 2026.
-- Plugin support: Arnold, V-Ray, and Redshift for Maya 2024-2025; only Arnold for Maya 2026.
-- Support for V-Ray and Redshift in Maya 2026 is planned for a future release.
+- Plugin support: Arnold, V-Ray, and Redshift for Maya 2024-2025; Arnold and V-Ray for Maya 2026.
+- Support for Redshift in Maya 2026 is planned for a future release.
 - Install the integrated Maya submitter files to the installation directory.
 - Register the plug-in with Maya by creating or updating the MAYA_MODULE_PATH environment variable.</value>
 		</stringParameter>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Vray wasn't support with Maya2026

### What was the solution? (How)
Vray is now supported with Maya2026, so we need to update the documentation.

### What is the impact of this change?
Docs are upto date

### How was this change tested?
N/A, a PR with recipe was tested in deadline-cloud-samples: https://github.com/aws-deadline/deadline-cloud-samples/commit/416baf7b4ff013d739e85d98b1437a256c07451a

#### Integ test result
N/A

#### Installer test result

N/A

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

N/A

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```
*delete text ending here*


### Was this change documented?

Yes, this is the documentation change

### Is this a breaking change?

*delete text starting here*
A breaking change is one that modifies a public contract in some way or otherwise changes functionality of this application in a way
that is not backwards compatible. Examples of changes that are breaking include:

1. Adding a new required value to the init-data or run-data of the adaptor;
2. Deleting or renaming a value in the init-data or run-data of the adaptor; and
3. Otherwise modifying the interface of the adaptor such that a job submitted with an older version of the Maya submitter plug-in
   will not work with a version of the adaptor that includes your modification.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
