### PR TITLE
Revert "chore: pin the version of click that hatch uses to <8.3 due t…

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -118,7 +118,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "click<8.3"
+pip install --upgrade hatch
 pip install --upgrade twine
 hatch -v run codebuild:lint
 hatch run codebuild:test

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -3,5 +3,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "click<8.3"
+pip install --upgrade hatch
 hatch run e2e:test

--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -3,5 +3,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "click<8.3"
+pip install --upgrade hatch
 hatch run integ:test


### PR DESCRIPTION
This reverts commit e82431b973427ec7a59558b46e2bf07de82f61a7.

### What was the problem/requirement? (What/Why)

New hatch version has been released. https://github.com/pypa/hatch/releases/tag/hatch-v1.14.2
Don't need to pin click anymore.

### What was the solution? (How)
Reverted commit that pins click.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
