### PR TITLE
feat: Added support for Redshift2025 with Maya2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ This library requires:
 1. Python 3.9 or higher; and
 1. Linux, Windows, or a macOS operating system.
 
-Plugin support: Arnold, V-Ray, and Redshift for Maya 2024-2025; Arnold and V-Ray for Maya 2026.
-Support for Redshift in Maya 2026 is planned for a future release.
+Plugin support: Arnold, V-Ray, and Redshift for Maya 2024-2025; Arnold, V-Ray, and Redshift for Maya 2026.
 
 ## Versioning
 

--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -61,8 +61,7 @@
 		<stringParameter name="deadline_cloud_for_maya_summary" ask="0" cliOptionShow="0">
 			<value>Deadline Cloud for Maya 2024 - 2026
 - Compatible with Maya 2024 - 2026.
-- Plugin support: Arnold, V-Ray, and Redshift for Maya 2024-2025; Arnold and V-Ray for Maya 2026.
-- Support for Redshift in Maya 2026 is planned for a future release.
+- Plugin support: Arnold, V-Ray, and Redshift for Maya 2024-2025; Arnold and V-Ray, and Redshift for Maya 2026.
 - Install the integrated Maya submitter files to the installation directory.
 - Register the plug-in with Maya by creating or updating the MAYA_MODULE_PATH environment variable.</value>
 		</stringParameter>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We did not support Redshift with Maya2026

### What was the solution? (How)
Added support for redshift with maya2026, so we need to update the installer text.

### What is the impact of this change?
Customers will know we support redshift with maya2026 now.

### How was this change tested?
N/A, all testing for redshift with maya2026 is performed in this PR <TODO add other PR link>

#### Integ test result
N/A

#### Installer test result
N/A

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

N/A


### Was this change documented?
N/A only documentation chnge

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
