### PR TITLE
feat: Remember last used shared job settings for job submissions. Add…

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,14 +78,24 @@ dependencies installed into it. Then, activate the hatch shell environment, set 
 developer options in the plugin, and run maya:
 
 ```bash
+# Linux
 hatch shell
 export DEADLINE_ENABLE_DEVELOPER_OPTIONS=true
 maya
 ```
 
+```bash
+# Windows
+hatch shell
+$env:DEADLINE_ENABLE_DEVELOPER_OPTIONS = "true"
+maya
+```
+
 You will need to load the plug-in within Maya once the application has completed loading. In the main menu bar, go to
 Windows > Settings/Preferences > Plug-In Manager and you will find that `DeadlineCloudForMaya.py` is available as a
-plug-in. Check the checkbox to have Maya load the plug-in and create the AWSDeadline tray for you. Click the icon on
+plug-in.
+
+ Check the checkbox to have Maya load the plug-in and create the AWSDeadline tray for you. Click the icon on
 the tray to open the submitter.
 
 You can use the "Export Bundle" option in the submitter to save the job bundle for a submission to your local disk

--- a/src/deadline/maya_submitter/data_classes.py
+++ b/src/deadline/maya_submitter/data_classes.py
@@ -23,6 +23,14 @@ class RenderSubmitterUISettings:
     name: str = field(default="", metadata={"sticky": True})
     description: str = field(default="", metadata={"sticky": True})
 
+    priority: int = field(default=50, metadata={"sticky": True})
+    initial_status: str = field(default="READY", metadata={"sticky": True})
+    max_failed_tasks_count: int = field(default=20, metadata={"sticky": True})
+    max_retries_per_task: int = field(default=5, metadata={"sticky": True})
+    max_worker_count: int = field(
+        default=-1, metadata={"sticky": True}
+    )  # -1 indicates unlimited max worker count
+
     override_frame_range: bool = field(default=False, metadata={"sticky": True})
     frame_list: str = field(default="", metadata={"sticky": True})
     project_path: str = field(default="")


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/305

### What was the problem/requirement? (What/Why)

Users needed the ability to have their shared job settings (priority, initial status, max failed tasks count, max retries per task, and max worker count) persist between job submissions in Maya. Previously, these settings would reset to defaults each time, requiring users to manually reconfigure them for each submission.

### What was the solution? (How)
- Reuse the solution defined in the reference https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/235/files
- Sticky works because the render settings data structure is passed to the Deadline Submission dialog created [here](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/91235ca814eeef38607613107a3da2e567d5b3d7/src/deadline/maya_submitter/maya_render_submitter.py#L760), then into the constructor [here](https://github.com/aws-deadline/deadline-cloud/blob/90e1325687dd334a67550cbe9bc421a6426f3ce5/src/deadline/client/ui/widgets/shared_job_settings_tab.py#L252). Finally it uses a an object parameters value to capture all variables to refresh the ui [here](https://github.com/aws-deadline/deadline-cloud/blob/90e1325687dd334a67550cbe9bc421a6426f3ce5/src/deadline/client/ui/widgets/shared_job_settings_tab.py#L114)

Added sticky metadata to five additional fields in the `RenderSubmitterUISettings` dataclass:
- `priority`: Job priority level (default: 50)
- `initial_status`: Initial job status (default: "READY") 
- `max_failed_tasks_count`: Maximum number of failed tasks allowed (default: 20)
- `max_retries_per_task`: Maximum retries per task (default: 5)
- `max_worker_count`: Maximum worker count, -1 for unlimited (default: -1)

These fields now have `metadata={"sticky": True}` which enables them to be saved to and loaded from the `.deadline_render_settings.json` file alongside the scene file.

### What is the impact of this change?

This change improves user experience by reducing repetitive configuration work. Users can now set their preferred shared job settings once, and they will be remembered for future submissions from the same Maya scene file. This is particularly beneficial for users who consistently use non-default values for these settings.

### How was this change tested?
hatch run build

Built the installer for Maya, and then submitted a job with changed settings. Launch the submitter again, the settings were persisted.

Note that the sticky settings for maya are somewhat inconsistent depending on when the dialog is launched. I am tracking this issue offline with stakeholders.

#### Integ test result
- NA

#### Installer test result
- NA

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
- NA

### Was this change documented?

- [x] Updated relevant docstrings (inline comments added for max_worker_count field)
- [ ] README.md, DEVELOPMENT.md, or docs/ directory updates needed: *<specify if any documentation updates are needed>*
- [ ] Schema files for adaptor init-data or run-data updates needed: No

### Is this a breaking change?

No, this is not a breaking change. The modification only adds sticky behavior to existing fields with their existing default values. All existing functionality remains unchanged and backwards compatible.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
