### PR TITLE
chore: add test and docs for integration_data_interface_version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,17 @@ Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.
 - Did you update all relevant docstrings for Python functions that you modified?
 - Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?
 - Should the schema files for the adaptor's init-data or run-data be updated?
+
 *delete text ending here*
+
+### Did you modify schema files?
+- [ ] Yes
+- [ ] No
+
+If yes, Did you bump the `integration_data_interface_version` in `src/deadline/maya_adaptor/MayaAdaptor/adaptor.py` and update the test constants?
+See the "Schema Versioning" section in DEVELOPMENT.md for details.
+   - [ ] Yes
+   - [ ] No
 
 ### Is this a breaking change?
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -200,6 +200,18 @@ Testing locally like this will allow you to iterate faster on your change than t
 submitting jobs to Deadline Cloud to run using your modified adaptor. Then, test it out on a real render farm only once
 you think that your change is functioning as you'd like.
 
+#### Schema Versioning and the Integration Data Interface Version
+
+The adaptor uses two JSON schema files to define the contract between the Maya submitter (running on artist workstations)
+and the Maya adaptor (running on cloud render workers):
+
+- `src/deadline/maya_adaptor/MayaAdaptor/schemas/init_data.schema.json` - Defines the initialization data passed once when the adaptor starts
+- `src/deadline/maya_adaptor/MayaAdaptor/schemas/run_data.schema.json` - Defines the per-task data passed for each frame/task to render
+
+**Important:** Whenever you modify either of these schema files, you **must** also update the `integration_data_interface_version`
+in `src/deadline/maya_adaptor/MayaAdaptor/adaptor.py` following semantic versioning. 
+
+
 #### Running the Adaptor Locally
 
 To run the adaptor you will first need to create two files:

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from collections import namedtuple
@@ -20,6 +21,47 @@ from deadline.maya_adaptor.MayaAdaptor import MayaAdaptor
 from deadline.maya_adaptor.MayaAdaptor.adaptor import _FIRST_MAYA_ACTIONS, MayaNotRunningError
 
 # , _MAYA_INIT_KEYS
+
+# Test data that exercises ALL properties in init_data schema
+# If the schema changes (properties added/removed/modified), this test data
+# must be updated AND the integration_data_interface_version must be bumped
+EXPECTED_INIT_DATA_PROPERTIES = {
+    "camera": "test_camera",
+    "error_on_arnold_license_fail": True,
+    "image_height": 1080,
+    "image_width": 1920,
+    "output_file_path": "/path/to/output",
+    "output_file_prefix": "<Scene>/<RenderLayer>",
+    "project_path": "/path/to/project",
+    "render_layer": "defaultRenderLayer",
+    "render_setup_include_lights": True,
+    "renderer": "arnold",
+    "scene_file": "/path/to/scene.mb",
+    "strict_error_checking": True,
+}
+
+# Required fields for init_data schema
+EXPECTED_INIT_DATA_REQUIRED = ["project_path", "render_layer", "renderer", "scene_file"]
+
+# Test data that exercises ALL properties in run_data schema
+# If the schema changes (properties added/removed/modified), this test data
+# must be updated AND the integration_data_interface_version must be bumped
+EXPECTED_RUN_DATA_PROPERTIES = {
+    "frame": 1,
+    "region_min_x": 0,
+    "region_max_x": 1920,
+    "region_min_y": 0,
+    "region_max_y": 1080,
+    "camera": "test_camera",
+    "output_file_prefix": "<Scene>/<RenderLayer>",
+}
+
+# Required fields for run_data schema
+EXPECTED_RUN_DATA_REQUIRED = ["frame"]
+
+# Expected version - must be bumped when schemas change
+EXPECTED_SCHEMA_VERSION_MAJOR = 0
+EXPECTED_SCHEMA_VERSION_MINOR = 1
 
 
 @pytest.fixture()
@@ -471,6 +513,103 @@ class TestMayaAdaptor_on_start:
         """Tests that the adaptor semantic version is in the expected format"""
         adaptor = MayaAdaptor(init_data)
         assert adaptor.integration_data_interface_version == SemanticVersion(major=0, minor=1)
+
+    def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(
+        self, init_data: dict
+    ) -> None:
+        """
+        Test to validate that if the init data or run data schema are changed, we also bump the
+        integration_data_interface_version. We load the schema files and validate expected test data
+        that we define as EXPECTED_INIT_DATA_PROPERTIES and EXPECTED_RUN_DATA_PROPERTIES
+        """
+        adaptor = MayaAdaptor(init_data)
+        semantic_version = adaptor.integration_data_interface_version
+
+        root_directory_path = Path(__file__).parent.parent.parent.parent.parent
+        schema_path = root_directory_path.joinpath(
+            "src", "deadline", "maya_adaptor", "MayaAdaptor", "schemas"
+        )
+        init_data_path = schema_path.joinpath("init_data.schema.json")
+        run_data_path = schema_path.joinpath("run_data.schema.json")
+
+        # Load actual schemas
+        with init_data_path.open() as init_data_schema_file:
+            init_data_schema = json.load(init_data_schema_file)
+
+        with run_data_path.open() as run_data_schema_file:
+            run_data_schema = json.load(run_data_schema_file)
+
+        # Validate that our test data covers all schema properties
+        init_schema_properties = set(init_data_schema.get("properties", {}).keys())
+        expected_init_properties = set(EXPECTED_INIT_DATA_PROPERTIES.keys())
+
+        run_schema_properties = set(run_data_schema.get("properties", {}).keys())
+        expected_run_properties = set(EXPECTED_RUN_DATA_PROPERTIES.keys())
+
+        # Check init_data schema properties
+        assert init_schema_properties == expected_init_properties, (
+            f"If the init_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+            f"Schema properties have changed - "
+            f"Missing in test: {init_schema_properties - expected_init_properties}. "
+            f"Extra in test: {expected_init_properties - init_schema_properties}. "
+        )
+
+        # Check run_data schema properties
+        assert run_schema_properties == expected_run_properties, (
+            f"If the run_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+            f"Schema properties have changed - "
+            f"Missing in test: {run_schema_properties - expected_run_properties}. "
+            f"Extra in test: {expected_run_properties - run_schema_properties}. "
+        )
+
+        # Check init_data required fields
+        init_schema_required = set(init_data_schema.get("required", []))
+        expected_init_required = set(EXPECTED_INIT_DATA_REQUIRED)
+        assert init_schema_required == expected_init_required, (
+            f"If the init_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+            f"Schema required fields have changed - "
+            f"Missing in test: {init_schema_required - expected_init_required}. "
+            f"Extra in test: {expected_init_required - init_schema_required}. "
+        )
+
+        # Check run_data required fields
+        run_schema_required = set(run_data_schema.get("required", []))
+        expected_run_required = set(EXPECTED_RUN_DATA_REQUIRED)
+        assert run_schema_required == expected_run_required, (
+            f"If the run_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+            f"Schema required fields have changed - "
+            f"Missing in test: {run_schema_required - expected_run_required}. "
+            f"Extra in test: {expected_run_required - run_schema_required}. "
+        )
+
+        # Validate test data against schemas using jsonschema
+        try:
+            jsonschema.validate(EXPECTED_INIT_DATA_PROPERTIES, init_data_schema)
+        except jsonschema.ValidationError as e:
+            pytest.fail(
+                f"If the init_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+                f"Schema validation failed: {e.message}. "
+            )
+
+        try:
+            jsonschema.validate(EXPECTED_RUN_DATA_PROPERTIES, run_data_schema)
+        except jsonschema.ValidationError as e:
+            pytest.fail(
+                f"If the run_data.schema.json is changed, the integration_data_interface_version must be bumped. "
+                f"Schema validation failed: {e.message}. "
+            )
+
+        # Verify version matches expected version
+        assert semantic_version.major == EXPECTED_SCHEMA_VERSION_MAJOR, (
+            f"If the init_data.schema.json or run_data.schema.json is changed, "
+            f"the integration_data_interface_version must be bumped. "
+            f"Expected major version {EXPECTED_SCHEMA_VERSION_MAJOR}, got {semantic_version.major}. "
+        )
+        assert semantic_version.minor == EXPECTED_SCHEMA_VERSION_MINOR, (
+            f"If the init_data.schema.json or run_data.schema.json is changed, "
+            f"the integration_data_interface_version must be bumped. "
+            f"Expected minor version {EXPECTED_SCHEMA_VERSION_MINOR}, got {semantic_version.minor}. "
+        )
 
 
 class TestMayaAdaptor_on_run:


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/233

### What was the problem/requirement? (What/Why)
When the init_data.schema.yaml or run_data.schema.yaml is changed, the adaptor's integration_data_interface_version should also be increased. We have a note in the pull request template that this is a breaking change, but the instructions only indicate to include an ! in your conventional commit title and to add instructions for upgrading to the PR. However, they don't indicate that you need to increase the integration_data_interface_version, which could be missed.

### What was the solution? (How)
We added an additional unit test to make sure this is caught during the `hatch run test`, as well as documentation to DEVELOPMENT.md and edits to the pull request remplate.

### What is the impact of this change?
User's running tests will now be reminded to update the integration_data_interface_version if init_data or run_data schemas have been changed. Users can also see this documented on relevant sections.

### How was this change tested?
ran `hatch run all:test` after adding new test case

```
0.12s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.02s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run_render_fail
0.02s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run
0.02s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[arnold-True]
0.02s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_populate_action_queue_test_mapping
================================================================================ 123 passed in 2.85s =================================================================================
```

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```

Timestamp: 2025-11-10T14:36:53.084347-08:00
Running job bundle output test: /Users/stangch/DeadlineClient/myForks/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2025-11-10T14:36:55.044679-08:00
Running job bundle output test: /Users/stangch/DeadlineClient/myForks/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2025-11-10T14:36:56.602270-08:00
Running job bundle output test: /Users/stangch/DeadlineClient/myForks/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2025-11-10T14:36:56.602380-08:00
Running job bundle output test: /Users/stangch/DeadlineClient/myForks/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2025-11-10T14:36:58.145276-08:00
Running job bundle output test: /Users/stangch/DeadlineClient/myForks/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2025-11-10T14:37:01.279225-08:00
```


### Was this change documented?
Yes, added notes in DEVELOPMENT.md and pull request template

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
