### PR TITLE
ci: add release environment option to build_installers.yml

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -27,6 +27,7 @@ on:
         type: choice
         options:
         - mainline
+        - release
 
 jobs:
   BuildInstaller:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want the ability to re-build prod installers outside of the release process in special circumstances. We need the option of the release deployment environment to do this.

### What was the solution? (How)
Add release env option to build_installers.yml

### What is the impact of this change?
Allows re-build of a prod installer

### How was this change tested?
Will be tested after merge

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*