### PR TITLE
chore: Upgrade dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline == 0.52.*",
+    "deadline >= 0.52,< 0.55",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 

--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,4 +1,4 @@
-pillow == 11.*
+pillow == 12.*
 numpy == 2.*
 openjd-cli == 0.7.*
 flaky == 3.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to upgrade a few dependencies, including `deadline-cloud`.

### What was the solution? (How)
* Upgrade the dependencies for which there dependabot PRs opened.
* Upgrade `deadline-cloud` to its latest version.

### What is the impact of this change?
Up to date dependencies.

### How was this change tested?
* Submitted job from Maya 2024 (Windows) to SMF farm and verified it was rendered successfully.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
```

Timestamp: 2026-01-22T19:26:27.533308+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\cube

cube
Test succeeded

Timestamp: 2026-01-22T19:26:30.397722+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\layers

layers
Test succeeded

Timestamp: 2026-01-22T19:26:31.798115+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\layers_no_variation

layers_no_variation
Test succeeded

Timestamp: 2026-01-22T19:26:32.926411+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\referenced_layers

referenced_layers
Test succeeded

Timestamp: 2026-01-22T19:26:34.027288+00:00
Running job bundle output test: C:\Users\rdp\workplace\deadline-cloud-for-maya\job_bundle_output_tests\renderman
Skipping test renderman because Renderman for Maya is not installed.
All tests passed, ran 4 total.
Timestamp: 2026-01-22T19:26:47.507104+00:00
```

### Was this change documented?
N/A

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?
No

<img width="1582" height="914" alt="Screenshot 2026-01-23 at 9 21 21 AM" src="https://github.com/user-attachments/assets/580a2e83-c1f6-4d3f-8986-67a911b51cb7" />

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
