### PR TITLE
fix: enable custom ocio config for submitter

### DIFF
--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -43,6 +43,7 @@ _MAYA_INIT_KEYS = {
     "camera",
     "image_height",
     "image_width",
+    "ocio_config_file",
     "output_file_path",
     "output_file_prefix",
     "render_layer",
@@ -89,7 +90,7 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:
-        return SemanticVersion(major=0, minor=1)
+        return SemanticVersion(major=0, minor=2)
 
     @staticmethod
     def _get_timer(timeout: int | float) -> Callable[[], bool]:

--- a/src/deadline/maya_adaptor/MayaAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/maya_adaptor/MayaAdaptor/schemas/init_data.schema.json
@@ -6,6 +6,7 @@
         "error_on_arnold_license_fail": { "type": "boolean" },
         "image_height": { "type": "number" },
         "image_width": { "type": "number" },
+        "ocio_config_file": { "type": "string" },
         "output_file_path": { "type": "string" },
         "output_file_prefix": { "type": "string" },
         "project_path": { "type": "string" },

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -41,6 +41,7 @@ class DefaultMayaHandler:
             "camera": self.set_camera,
             "image_height": self.set_image_height,
             "image_width": self.set_image_width,
+            "ocio_config_file": self.set_ocio_config_file,
             "output_file_path": self.set_output_file_path,
             "output_file_prefix": self.set_output_file_prefix,
             "path_mapping": self.set_path_mapping,
@@ -284,3 +285,29 @@ class DefaultMayaHandler:
                 maya.mel.eval(pre_render_mel)
             except Exception as e:
                 print("Warning: preMel Failed: %s" % e)
+
+    def set_ocio_config_file(self, data: dict) -> None:
+        """
+        Sets the OCIO config file path for color management.
+
+        This should be called after the scene file is opened to override
+        the scene's embedded OCIO config path with the remapped path.
+
+        Args:
+            data (dict): The data given from the Adaptor. Keys expected: ['ocio_config_file']
+        """
+        ocio_path = data.get("ocio_config_file", "")
+        if not ocio_path:
+            return
+
+        # Apply path mapping to convert the source path to the worker's path
+        if DirectoryMapping.get_activated():
+            ocio_path = DirectoryMapping.convert(ocio_path)
+
+        if not os.path.isfile(ocio_path):
+            print(f"WARNING: OCIO config file not found: '{ocio_path}'", flush=True)
+            return
+
+        # Set the OCIO config file path in Maya's color management preferences
+        print(f"Setting OCIO config: '{ocio_path}'", flush=True)
+        maya.cmds.colorManagementPrefs(e=True, configFilePath=ocio_path)

--- a/src/deadline/maya_submitter/default_maya_job_template.yaml
+++ b/src/deadline/maya_submitter/default_maya_job_template.yaml
@@ -67,6 +67,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 steps:
 - name: Render
   parameterSpace:
@@ -88,6 +96,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
       actions:
         onEnter:
           command: MayaAdaptor

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -394,6 +394,11 @@ def _get_parameter_values(
         }
     )
 
+    # Add OCIO config file parameter if present
+    ocio_config = Scene.ocio_config_file()
+    if ocio_config:
+        parameter_values.append({"name": "OCIOConfigFile", "value": ocio_config})
+
     # Set the Arnold-specific parameter values
     if "arnold" in renderers:
         parameter_values.append(

--- a/src/deadline/maya_submitter/scene.py
+++ b/src/deadline/maya_submitter/scene.py
@@ -189,6 +189,32 @@ class Scene:
                 files.append(cache_file)
         return files
 
+    @staticmethod
+    def ocio_config_file() -> Optional[str]:
+        """
+        Returns the OCIO config file path if color management is enabled
+        and using a custom OCIO configuration.
+
+        Returns:
+            Optional[str]: The absolute path to the OCIO config file,
+                          or None if using default color management or no custom config
+        """
+        # Check if color management is enabled
+        cm_enabled = maya.cmds.colorManagementPrefs(query=True, cmEnabled=True)
+        if not cm_enabled:
+            return None
+
+        # Get the config file path - Maya returns bool if no path set
+        config_path = maya.cmds.colorManagementPrefs(query=True, configFilePath=True)
+        if not isinstance(config_path, str):
+            return None
+
+        # Skip Maya default configs
+        if "<MAYA_RESOURCES>" in config_path:
+            return None
+
+        return config_path
+
 
 @dataclass
 class FrameRange:

--- a/test/integ/test_maya_submitters.py
+++ b/test/integ/test_maya_submitters.py
@@ -79,7 +79,7 @@ class TestSubmitters:
                 asset_folder="redshift_test",
                 frame_list="1",
                 file_prefix="redshift_test",
-                expected_scene_file_paths=[r"config.ocio"],
+                expected_scene_file_paths=[],
             ),
         ],
         ids=["Minimal Maya Test", "Redshift Test"],

--- a/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/minimal_test/expected_job_bundle/template.yaml
@@ -66,6 +66,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: OutputFilePrefix
   type: STRING
   userInterface:
@@ -117,6 +125,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
@@ -193,6 +202,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}

--- a/test/integ/test_scripts/redshift_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/redshift_test/expected_job_bundle/template.yaml
@@ -66,6 +66,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: OutputFilePrefix
   type: STRING
   userInterface:
@@ -116,6 +124,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -30,6 +30,7 @@ EXPECTED_INIT_DATA_PROPERTIES = {
     "error_on_arnold_license_fail": True,
     "image_height": 1080,
     "image_width": 1920,
+    "ocio_config_file": "/path/to/config.ocio",
     "output_file_path": "/path/to/output",
     "output_file_prefix": "<Scene>/<RenderLayer>",
     "project_path": "/path/to/project",
@@ -61,7 +62,7 @@ EXPECTED_RUN_DATA_REQUIRED = ["frame"]
 
 # Expected version - must be bumped when schemas change
 EXPECTED_SCHEMA_VERSION_MAJOR = 0
-EXPECTED_SCHEMA_VERSION_MINOR = 1
+EXPECTED_SCHEMA_VERSION_MINOR = 2
 
 
 @pytest.fixture()
@@ -512,7 +513,7 @@ class TestMayaAdaptor_on_start:
     def test_semantic_version(self, init_data: dict) -> None:
         """Tests that the adaptor semantic version is in the expected format"""
         adaptor = MayaAdaptor(init_data)
-        assert adaptor.integration_data_interface_version == SemanticVersion(major=0, minor=1)
+        assert adaptor.integration_data_interface_version == SemanticVersion(major=0, minor=2)
 
     def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(
         self, init_data: dict

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
@@ -279,3 +279,108 @@ class TestDefaultMayaHandler:
             mock_get_attr.assert_called_once_with("defaultRenderGlobals.preMel")
             mock_mel_eval.assert_called_once_with(mock_get_attr.return_value)
             assert "Unrecognized value" in output.getvalue()
+
+
+class TestSetOcioConfigFile:
+    """Tests for DefaultMayaHandler.set_ocio_config_file"""
+
+    @patch("os.path.isfile")
+    def test_set_ocio_config_file_empty_path(
+        self, mock_isfile: Mock, mayahandlerbase: DefaultMayaHandler
+    ):
+        """Tests that empty ocio_config_file path returns early without setting anything"""
+        # WHEN
+        mayahandlerbase.set_ocio_config_file({"ocio_config_file": ""})
+
+        # THEN
+        mock_isfile.assert_not_called()
+
+    @patch("os.path.isfile")
+    def test_set_ocio_config_file_missing_key(
+        self, mock_isfile: Mock, mayahandlerbase: DefaultMayaHandler
+    ):
+        """Tests that missing ocio_config_file key returns early without setting anything"""
+        # WHEN
+        mayahandlerbase.set_ocio_config_file({})
+
+        # THEN
+        mock_isfile.assert_not_called()
+
+    @patch("os.path.isfile")
+    @patch.object(DirectoryMapping, "get_activated")
+    @patch.object(DirectoryMapping, "convert")
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.colorManagementPrefs"
+    )
+    def test_set_ocio_config_file_with_path_mapping(
+        self,
+        mock_color_prefs: Mock,
+        mock_convert: Mock,
+        mock_get_activated: Mock,
+        mock_isfile: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+    ):
+        """Tests that path mapping is applied when activated"""
+        # GIVEN
+        mock_get_activated.return_value = True
+        mock_convert.return_value = "/mapped/path/config.ocio"
+        mock_isfile.return_value = True
+
+        # WHEN
+        mayahandlerbase.set_ocio_config_file({"ocio_config_file": "/original/path/config.ocio"})
+
+        # THEN
+        mock_convert.assert_called_once_with("/original/path/config.ocio")
+        mock_isfile.assert_called_once_with("/mapped/path/config.ocio")
+        mock_color_prefs.assert_called_once_with(e=True, configFilePath="/mapped/path/config.ocio")
+
+    @patch("os.path.isfile")
+    @patch.object(DirectoryMapping, "get_activated")
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.colorManagementPrefs"
+    )
+    def test_set_ocio_config_file_without_path_mapping(
+        self,
+        mock_color_prefs: Mock,
+        mock_get_activated: Mock,
+        mock_isfile: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+    ):
+        """Tests that original path is used when path mapping is not activated"""
+        # GIVEN
+        mock_get_activated.return_value = False
+        mock_isfile.return_value = True
+
+        # WHEN
+        mayahandlerbase.set_ocio_config_file({"ocio_config_file": "/path/to/config.ocio"})
+
+        # THEN
+        mock_isfile.assert_called_once_with("/path/to/config.ocio")
+        mock_color_prefs.assert_called_once_with(e=True, configFilePath="/path/to/config.ocio")
+
+    @patch("os.path.isfile")
+    @patch.object(DirectoryMapping, "get_activated")
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.colorManagementPrefs"
+    )
+    def test_set_ocio_config_file_not_found(
+        self,
+        mock_color_prefs: Mock,
+        mock_get_activated: Mock,
+        mock_isfile: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+    ):
+        """Tests that colorManagementPrefs is not called when file doesn't exist"""
+        # GIVEN
+        mock_get_activated.return_value = False
+        mock_isfile.return_value = False
+
+        # WHEN
+        with patch("sys.stdout", new=StringIO()) as output:
+            mayahandlerbase.set_ocio_config_file({"ocio_config_file": "/nonexistent/config.ocio"})
+
+            # THEN
+            mock_isfile.assert_called_once_with("/nonexistent/config.ocio")
+            mock_color_prefs.assert_not_called()
+            assert "WARNING" in output.getvalue()
+            assert "/nonexistent/config.ocio" in output.getvalue()

--- a/test/unit/deadline_submitter_for_maya/scripts/test_scene.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_scene.py
@@ -75,3 +75,66 @@ class TestScene:
         output_path: str = Scene.output_path()
 
         assert output_path == test_project_path
+
+
+class TestOcioConfigFile:
+    """Tests for Scene.ocio_config_file"""
+
+    @patch("deadline.maya_submitter.scene.maya.cmds")
+    def test_ocio_config_file_cm_disabled(self, mock_maya_cmds: Mock) -> None:
+        """Tests that None is returned when color management is disabled"""
+        # GIVEN
+        mock_maya_cmds.colorManagementPrefs.return_value = False
+
+        # WHEN
+        result = Scene.ocio_config_file()
+
+        # THEN
+        assert result is None
+        mock_maya_cmds.colorManagementPrefs.assert_called_once_with(query=True, cmEnabled=True)
+
+    @patch("deadline.maya_submitter.scene.maya.cmds")
+    def test_ocio_config_file_returns_bool(self, mock_maya_cmds: Mock) -> None:
+        """Tests that None is returned when Maya returns bool instead of string for configFilePath"""
+        # GIVEN
+        mock_maya_cmds.colorManagementPrefs.side_effect = [
+            True,
+            True,
+        ]  # cmEnabled=True, configFilePath=True (bool)
+
+        # WHEN
+        result = Scene.ocio_config_file()
+
+        # THEN
+        assert result is None
+
+    @patch("deadline.maya_submitter.scene.maya.cmds")
+    def test_ocio_config_file_maya_default_resources(self, mock_maya_cmds: Mock) -> None:
+        """Tests that None is returned for Maya default OCIO configs with MAYA_RESOURCES"""
+        # GIVEN
+        mock_maya_cmds.colorManagementPrefs.side_effect = [
+            True,  # cmEnabled
+            "<MAYA_RESOURCES>/OCIO-configs/Maya2022-default/config.ocio",  # configFilePath
+        ]
+
+        # WHEN
+        result = Scene.ocio_config_file()
+
+        # THEN
+        assert result is None
+
+    @patch("deadline.maya_submitter.scene.maya.cmds")
+    def test_ocio_config_file_custom_config(self, mock_maya_cmds: Mock) -> None:
+        """Tests that custom OCIO config path is returned"""
+        # GIVEN
+        custom_path = "/projects/show/config/aces_1.2/config.ocio"
+        mock_maya_cmds.colorManagementPrefs.side_effect = [
+            True,  # cmEnabled
+            custom_path,  # configFilePath
+        ]
+
+        # WHEN
+        result = Scene.ocio_config_file()
+
+        # THEN
+        assert result == custom_path


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Maya has OCIO config files for color management. Scenes can have custom OCIO configs, or default maya ones. When submitting jobs with custom OCIO configs, Job Attachments detects it properly, but the Maya adaptor does not properly set the custom OCIO when rendering the scene.

### What was the solution? (How)
Fixed bug where path mapping was not being properly applied to OCIO configs, due to chicken and egg problem. To get the OCIO config path, we must first open the scene file. But opening the scene file automatically loads the unmapped OCIO config path, leading to error and automatically enabling the default Maya OCIO.

Added fix parses the OCIO path in the submitter, and passes to adaptor, which mapping is then applied and set to the maya instance.

### What is the impact of this change?
Maya renders can now properly use custom OCIO config files.

### How was this change tested?

ran `hatch` unit tests
ran `hatch` integ tests


### REPRODUCED ERROR:

output form deadline cloud monitor, under task output logs
setting a custom config path under `/Users/stangch/DeadlineClient/mayaTests/ocio_test/config.ocio` leads to this output:
```
2026/01/28 13:37:18-08:00 ADAPTOR_OUTPUT: STDERR: Error: Color management settings cannot be applied: Error could not read '/Users/stangch/DeadlineClient/mayaTests/ocio_test/config.ocio' OCIO profile..

2026/01/28 13:37:20-08:00 ADAPTOR_OUTPUT: STDOUT: 00:00:04   868MB         
| [color_manager] using color manager defaultColorMgtGlobals of type "color_manager_ocio"
2026/01/28 13:37:20-08:00 ADAPTOR_OUTPUT: STDOUT: 00:00:04   869MB        | [color_manager_ocio] defaultColorMgtGlobals : using OCIO configuration file /sessions/session-a09e882b274b430ab7cf66279714df04pl4z7q2z/.env/usr/autodesk/maya2026/resources/OCIO-configs/Maya2022-default/config.ocio
2026/01/28 13:37:20-08:00 ADAPTOR_OUTPUT: STDOUT: 00:00:04   870MB        | [color_manager] rendering color space is "ACEScg"
```
incorrectly using thedefault maya `ocio.config`

### AFTER FIX:
```
2026/02/02 13:04:34-08:00 ADAPTOR_OUTPUT: STDOUT: Setting OCIO config: '/sessions/session-c42a9eca3e654a699ffb9178fb6ecc20zmo8c_m5/assetroot-f55c5bc9cc6737a83d5e/DeadlineClient/mayaTests/ocio_test/jericht_custom_config.ocio'


2026/02/02 13:04:36-08:00 ADAPTOR_OUTPUT: STDOUT: 00:00:04   907MB         | [color_manager] using color manager defaultColorMgtGlobals of type "color_manager_ocio"
2026/02/02 13:04:36-08:00 ADAPTOR_OUTPUT: STDOUT: 00:00:04   908MB         | [color_manager_ocio] defaultColorMgtGlobals : using OCIO configuration file /sessions/session-c42a9eca3e654a699ffb9178fb6ecc20zmo8c_m5/assetroot-f55c5bc9cc6737a83d5e/DeadlineClient/mayaTests/ocio_test/jericht_custom_config.ocio
2026/02/02 13:04:36-08:00 ADAPTOR_OUTPUT: STDOUT: 00:00:04   908MB         | [color_manager] narrow color space "sRGB" is linear, and will cause banding for narrow bit widths: use an sRGB equivalent
2026/02/02 13:04:36-08:00 ADAPTOR_OUTPUT: STDOUT: 00:00:04   908MB         | [color_manager] unable to determine rendering color space chromaticities, assuming "sRGB"
```

#### Integ test result

```
=================================== slowest 5 durations ===================================
3.98s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
2.12s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
1.45s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test]
0.06s teardown test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
0.00s setup    test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
```

modified integ tests to introduce optional OCIO config

### Was this change documented?

Updated schema file along with adaptor change, will be separate PR.

### Did you modify schema files?
- [x] Yes
- [ ] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/maya_adaptor/MayaAdaptor/adaptor.py` and update the test constants?
See the "Schema Versioning" section in DEVELOPMENT.md for details.
   - [x] Yes
   - [ ] No

### Is this a breaking change?

no, OCIO config files are optional. There are default values provided to fallback on, since not all scenes have a custom OCIO.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
