### PR TITLE
chore: Revert "chore: temporary pin virtualenv<21 to fix build (#370)"

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -118,7 +118,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "virtualenv<21"
+pip install --upgrade hatch
 pip install --upgrade twine
 hatch -v run lint
 hatch run test

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -3,5 +3,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "virtualenv<21"
+pip install --upgrade hatch
 hatch run e2e:test

--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -3,5 +3,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "virtualenv<21"
+pip install --upgrade hatch
 hatch run integ:test


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The original commit temporarily pinned `virtualenv<21` to fix a build issue. This workaround is no longer needed as the underlying issue has been fixed in [hatch v1.16.5](https://github.com/pypa/hatch/releases/tag/hatch-v1.16.5).

### What was the solution? (How)

Reverted the commit that added the `virtualenv<21` pin across all workflow files and build scripts.

### What is the impact of this change?

Build and test workflows will now use the latest compatible version of `virtualenv` instead of being pinned to versions below 21.

### How was this change tested?

GitHub actions still succeed

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*