### PR TITLE
chore: fix mechanism to update plugin and mod version

### DIFF
--- a/.github/actions/bump_precommit_hook/action.yml
+++ b/.github/actions/bump_precommit_hook/action.yml
@@ -9,7 +9,9 @@ runs:
   steps:
   - name: Update plugin Version
     shell: bash
+    env:
+      SEMVER: ${{ inputs.semver }}
     run: |
-      echo "+ DeadlineCloudForMaya ${{inputs.semver}} ." > ./maya_submitter_plugin/DeadlineCloudForMaya.mod
-      sed -i "s/^VERSION =.*/VERSION = \"${{inputs.semver}}\"/" ./maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py
+      echo "+ DeadlineCloudForMaya ${SEMVER} ." > ./maya_submitter_plugin/DeadlineCloudForMaya.mod
+      sed -i "s/^VERSION =.*/VERSION = \"${SEMVER}\"/" ./maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py
       git add ./maya_submitter_plugin/DeadlineCloudForMaya.mod ./maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py

--- a/.github/actions/prepush_release_hook/action.yml
+++ b/.github/actions/prepush_release_hook/action.yml
@@ -12,8 +12,10 @@ runs:
   steps:
   - name: Zip submitter plugin
     shell: bash
+    env:
+      SEMVER: ${{ inputs.semver }}
     run: |
       mkdir dist_extras
       cd maya_submitter_plugin 
-      zip -r  ../dist_extras/maya_submitter_plugin_${{inputs.semver}}.zip .
+      zip -r  "../dist_extras/maya_submitter_plugin_${SEMVER}.zip" .
       cd ..

--- a/maya_submitter_plugin/DeadlineCloudForMaya.mod
+++ b/maya_submitter_plugin/DeadlineCloudForMaya.mod
@@ -1,1 +1,1 @@
-+ DeadlineCloudForMaya 0.15.3 .
++ DeadlineCloudForMaya 0.15.14 .

--- a/maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py
+++ b/maya_submitter_plugin/plug-ins/DeadlineCloudForMaya.py
@@ -18,7 +18,7 @@ import maya.cmds
 # Tells maya which version of their api to use.
 maya_useNewAPI = True
 VENDOR = "AWS"
-VERSION = "0.13.2"
+VERSION = "0.15.14"
 
 __log__ = logging.getLogger("Deadline")
 _registered_mel_commands: List[str] = []


### PR DESCRIPTION
Fixes: #374

### What was the problem/requirement? (What/Why)

[bump](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_bump.yml#L72) and [publishv2](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_publish_v2.yml#L120) workflows reference two very specific files that have an extension of `.yml`, but they're in this repo with the extension `.yaml`. So these hooks were never firing when performing releases and thus the plugin and mod file were never updated as part of the release.

### What was the solution? (How)

Rename them (and update the version regardless, even though it'll be fixed next release)

Additionally, moved the inputs into a github action env variable to help prevent input injection into the run block

### What is the impact of this change?

New releases will have the correct version associated with them!

### How was this change tested?

Wasn't, will happen on next release.

### Was this change documented?

N/A

### Did you modify schema files?
- [ ] Yes
- [X] No

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
