### PR TITLE
chore: upgrade python to 3.13 for pypi publish workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           pip install --upgrade hatch


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Failing action due to python3.9/hatch/virtualenv incompatibility: https://github.com/aws-deadline/deadline-cloud-for-maya/actions/runs/23452124436/job/68241466854

### What was the solution? (How)

Update to python 3.13 for the action

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
