### PR TITLE
chore(dev): add manual pypi publish action

### DIFF
--- a/.github/workflows/manual_pypi_release.yml
+++ b/.github/workflows/manual_pypi_release.yml
@@ -1,0 +1,66 @@
+name: "Manual PyPI Release"
+run-name: "Manual PyPI Release: ${{ inputs.tag }}"
+
+# Perform a manual PyPI release outside of the regular release process
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        default: ""
+        type: string
+
+jobs:
+  ValidateTag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate semantic versioning
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Tag '$TAG' does not follow semantic versioning format (X.Y.Z)"
+            exit 1
+          fi
+          echo "Tag validation successful"
+                
+  UnitTests:
+    needs: ValidateTag
+    name: Unit Tests
+    uses: ./.github/workflows/code_quality.yml
+    with:
+      tag: ${{ inputs.tag }}
+      
+  PublishToPyPI:
+    needs: UnitTests
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+      - name: Validate semantic versioning
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
+            echo "Error: Tag '$TAG' does not follow semantic versioning format (X.Y.Z)"
+            exit 1
+          fi
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade hatch
+      - name: Build
+        run: hatch -v build
+      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
pypi publish failed in latest release: https://github.com/aws-deadline/deadline-cloud-for-maya/actions/runs/23452124436/job/68241466854

### What was the solution? (How)

The issue with the action is fixed, but it's nice to not have to redo a whole release, just to publish to pypi. so I copied the manual action from deadline-cloud: https://github.com/aws-deadline/deadline-cloud/blob/mainline/.github/workflows/manual_pypi_release.yml

Only change I did here was add a name/run-name. Which I took from release_publish

### What is the impact of this change?

Can manually publish artifacts to pypi.

### How was this change tested?

Worked in deadline-cloud: https://github.com/aws-deadline/deadline-cloud/pull/1067

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
