### PR TITLE
feat: output filenames customizability with tokens

### DIFF
--- a/docs/design/output-filename-with-tokens.md
+++ b/docs/design/output-filename-with-tokens.md
@@ -1,0 +1,242 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# Output File Prefix Token System — Design Document
+
+## Overview
+
+This feature adds output file prefix token resolution to the Deadline Cloud for Maya submitter and adaptor. Users type the full `imageFilePrefix` pattern directly, with optional tokens that get resolved by the adaptor at render time.
+
+**WYSIWYG principle:** The pattern is passed through exactly as the user types it. No automatic prepending of tokens, no automatic cleanup. What you see is what you get.
+
+**Supported tokens:**
+
+- `<Scene>` (alias: `%s`) — Scene file name without extension (e.g., "myScene")
+- `<RenderLayer>` (aliases: `<Layer>`, `%l`) — Render layer display name (e.g., "masterLayer")
+- `<Camera>` (alias: `%c`) — Camera name (e.g., "persp", "renderCam")
+
+Token definitions are maintained in a single source of truth: `SUPPORTED_TOKENS` dict in `filename_utils.py`. The UI tooltip is generated from this dict via `get_tokens_tooltip()`, so adding a new token only requires updating one place.
+
+Everything else in the pattern is literal text. Path separators (`/`) create subdirectories.
+
+**All tokens are resolved by the adaptor at render time.** The submitter passes the raw pattern through to init-data. The adaptor already has all the data it needs: scene file path from init-data, render layer from init-data, and camera from run-data or init-data.
+
+**Unknown tokens pass through unmodified.** Renderer-specific tokens like `<RenderPass>` are left for Maya or the renderer to handle.
+
+**Token matching is case-insensitive.** Both `<Scene>` and `<scene>` resolve to the scene name.
+
+**Example patterns and results:**
+
+| Pattern | Scene=myScene, Layer=fg, Camera=renderCam |
+|---------|-------------------------------------------|
+| `<Scene>/<RenderLayer>/<RenderLayer>` | `myScene/fg/fg` |
+| `<Scene>/<Camera>/<RenderLayer>` | `myScene/renderCam/fg` |
+| `<Camera>/<Scene>` | `renderCam/myScene` |
+| `<Scene>` | `myScene` |
+| `myRender` | `myRender` |
+
+**Default pattern initialization:**
+
+1. Read `defaultRenderGlobals.imageFilePrefix` from the Maya scene
+2. If empty, default to `<Scene>`
+3. Sticky settings always take precedence — if the user previously saved a pattern, that loads instead
+
+---
+
+## 1. Data Structures
+
+### 1.1 New field on `RenderSubmitterUISettings`
+
+**File:** `src/deadline/maya_submitter/data_classes.py`
+
+```python
+@dataclass
+class RenderSubmitterUISettings:
+    ...existing fields...
+
+    # Output file prefix pattern with optional tokens (<Scene>, <RenderLayer>, <Camera>).
+    # Resolved by the adaptor at render time. Empty string means use scene default.
+    output_file_prefix_pattern: str = field(default="", metadata={"sticky": True})
+```
+
+### 1.2 Shared utility functions
+
+**File:** `src/deadline/maya_adaptor/MayaClient/filename_utils.py`
+
+This file contains:
+
+- `SUPPORTED_TOKENS` — single source of truth dict mapping canonical tokens to their aliases
+- `get_tokens_tooltip()` — builds the UI tooltip string from `SUPPORTED_TOKENS`
+- `resolve_tokens()` — case-insensitive token replacement with alias support
+
+```python
+SUPPORTED_TOKENS: dict[str, list[str]] = {
+    "<Scene>": ["%s"],
+    "<RenderLayer>": ["<Layer>", "%l"],
+    "<Camera>": ["%c"],
+}
+
+def resolve_tokens(
+    pattern: str,
+    scene_name: str = "",
+    render_layer: str = "",
+    camera: str = "",
+) -> str:
+    """
+    Replace supported tokens in a Maya imageFilePrefix pattern with actual values.
+    Case-insensitive. Aliases included. Path structure (/) is preserved.
+    Unknown tokens pass through unmodified.
+    """
+    ...
+```
+
+---
+
+## 2. UX Changes (Submitter Dialog)
+
+### 2.1 Output File Prefix pattern field
+
+**File:** `src/deadline/maya_submitter/ui/components/scene_settings_tab.py`
+
+A new "Output File Prefix" group box is added to the scene settings tab, containing the pattern input and a live preview:
+
+```
+Row 0: Project Path       [/path/to/project              ] [...]
+Row 1: Output Path        [/path/to/output               ] [...]
+Row 2: ┌─ Output File Prefix ────────────────────────────────────────┐
+       │  Pattern    [<Scene>/<RenderLayer>/<RenderLayer>          ]  │
+       │  Preview    myScene/masterLayer/masterLayer                  │
+       └─────────────────────────────────────────────────────────────┘
+Row 3: Render Layers      [All Renderable Layers          ▼]
+Row 4: Cameras            [All Cameras                    ▼]
+...
+```
+
+| Control | Type | Default | Sticky | Notes |
+|---------|------|---------|--------|-------|
+| Pattern | `QLineEdit` | Scene's `imageFilePrefix` or `<Scene>` | Yes | Tooltip generated from `SUPPORTED_TOKENS` |
+| Preview | `QLabel` | (computed) | No | Read-only, updates when pattern or camera changes |
+
+### 2.2 Default pattern initialization
+
+**File:** `src/deadline/maya_submitter/maya_render_submitter.py`
+
+The default pattern is read from the scene before sticky settings load:
+
+```python
+render_settings.output_file_prefix_pattern = get_base_output_prefix()
+render_settings.load_sticky_settings(Scene.name())
+```
+
+This means:
+
+- If `imageFilePrefix` = `<Scene>/<RenderLayer>/<RenderLayer>` → pattern = `<Scene>/<RenderLayer>/<RenderLayer>`
+- If `imageFilePrefix` is empty → pattern = `<Scene>`
+- If sticky settings exist → pattern = whatever the user last saved
+
+### 2.3 Preview update logic
+
+The preview updates whenever the pattern text or camera selection changes. It calls `resolve_tokens()` with the current scene name, a sample render layer name, and the selected camera.
+
+### 2.4 No auto-prepend
+
+The submitter does **not** automatically prepend `<Camera>` or `<RenderLayer>` tokens when they are missing. If the user omits tokens from a multi-camera or multi-layer render, the output files may overwrite each other — but that is the user's explicit choice.
+
+---
+
+## 3. Job Template and Bundle Changes
+
+### 3.1 No changes to `default_maya_job_template.yaml`
+
+The template stays as-is. The `OutputFilePrefix` parameter carries the raw pattern with unresolved tokens.
+
+### 3.2 No changes to `init_data.schema.json` or `run_data.schema.json`
+
+No new fields. The existing `output_file_prefix` field carries the raw pattern string.
+
+### 3.3 Raw pattern passed through to job bundle
+
+**File:** `src/deadline/maya_submitter/maya_render_submitter.py`
+
+When the user sets a pattern in the UI, it overrides all layers' `output_file_prefix`:
+
+```python
+if settings.output_file_prefix_pattern:
+    for layer_data in submit_render_layers:
+        layer_data.output_file_prefix = settings.output_file_prefix_pattern
+```
+
+The raw pattern flows into the `OutputFilePrefix` job parameter and into each step's init-data as `output_file_prefix`.
+
+---
+
+## 4. Adaptor Changes
+
+### 4.1 Token resolution in `DefaultMayaHandler`
+
+**File:** `src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py`
+
+A new `_resolve_output_file_prefix()` method resolves tokens using data available at render time:
+
+```python
+def _resolve_output_file_prefix(self, data: dict) -> Optional[str]:
+    raw_prefix = data.get("output_file_prefix", self.output_file_prefix)
+    if not raw_prefix:
+        return raw_prefix
+
+    scene_file = maya.cmds.file(query=True, sceneName=True)
+    scene_name = os.path.splitext(os.path.basename(scene_file))[0]
+    camera = data.get("camera", self.camera_name) or ""
+    render_layer = ...  # from render_kwargs or editRenderLayerGlobals query
+    render_layer = _get_render_layer_display_name(render_layer)
+
+    return resolve_tokens(raw_prefix, scene_name=scene_name, render_layer=render_layer, camera=camera)
+```
+
+### 4.2 All renderer handlers updated
+
+Each renderer handler's `start_render()` calls `_resolve_output_file_prefix()` instead of passing the raw prefix directly:
+
+```python
+# Before
+output_file_prefix = data.get("output_file_prefix", self.output_file_prefix)
+
+# After
+output_file_prefix = self._resolve_output_file_prefix(data)
+```
+
+This applies to:
+
+- `DefaultMayaHandler` (Maya Software)
+- `ArnoldHandler`
+- `VRayHandler`
+- `RedshiftHandler`
+- `RenderManHandler`
+
+Token resolution is centralized in the base class. Renderer handlers inherit it.
+
+---
+
+## 5. Removed: Auto-Prepend Logic
+
+**File:** `src/deadline/maya_submitter/renderers.py`
+
+The previous `get_output_prefix_with_tokens()` function automatically prepended `<Camera>` and `<Layer>` tokens when multiple cameras or render layers were detected. This has been removed. The function now returns the scene's `imageFilePrefix` exactly as set.
+
+---
+
+## Files Modified Summary
+
+| File | Changes |
+|------|---------|
+| `src/deadline/maya_adaptor/MayaClient/filename_utils.py` | New. `SUPPORTED_TOKENS`, `get_tokens_tooltip()`, `resolve_tokens()` |
+| `src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py` | `_resolve_output_file_prefix()` method; updated `start_render()` |
+| `src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py` | Uses `_resolve_output_file_prefix()` |
+| `src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py` | Uses `_resolve_output_file_prefix()` |
+| `src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py` | Uses `_resolve_output_file_prefix()` |
+| `src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py` | Uses `_resolve_output_file_prefix()` |
+| `src/deadline/maya_submitter/data_classes.py` | Add `output_file_prefix_pattern` sticky field |
+| `src/deadline/maya_submitter/ui/components/scene_settings_tab.py` | "Output File Prefix" group box with pattern + live preview |
+| `src/deadline/maya_submitter/maya_render_submitter.py` | Default pattern from scene; raw pattern passed to job bundle |
+| `src/deadline/maya_submitter/renderers.py` | Removed auto-prepend logic |
+| `test/unit/.../test_filename_utils.py` | Unit tests for `resolve_tokens()` |
+| `test/unit/.../test_maya_handler_base.py` | Unit tests for `_resolve_output_file_prefix()` |

--- a/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
@@ -66,6 +66,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: OutputFilePrefix
   type: STRING
   userInterface:
@@ -116,6 +124,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}

--- a/job_bundle_output_tests/layers/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/layers/expected_job_bundle/parameter_values.yaml
@@ -25,24 +25,8 @@
    "value": "1-20"
   },
   {
-   "name": "layerDefaultFramesOutputFilePrefix",
-   "value": "<Layer>/layer_specific_file_prefix_"
-  },
-  {
-   "name": "layerFrameRange1OutputFilePrefix",
-   "value": "<Layer>/<Camera>/<Scene>"
-  },
-  {
-   "name": "masterLayerOutputFilePrefix",
-   "value": "<Layer>/<Camera>/<Scene>"
-  },
-  {
-   "name": "renderSetupLayer2OutputFilePrefix",
-   "value": "<Layer>/<Camera>/<Scene>"
-  },
-  {
-   "name": "renderSetupLayer4OutputFilePrefix",
-   "value": "<Layer>/<Camera>/<Scene>"
+   "name": "OutputFilePrefix",
+   "value": "<Scene>"
   },
   {
    "name": "layerDefaultFramesImageWidth",

--- a/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
@@ -58,6 +58,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: layerDefaultFramesFrames
   type: STRING
   userInterface:
@@ -98,41 +106,13 @@ parameterDefinitions:
     groupLabel: Layer renderSetupLayer4 Settings (mayaSoftware renderer)
   description: The frames to render. E.g. 1-3,8,11-15
   minLength: 1
-- name: layerDefaultFramesOutputFilePrefix
+- name: OutputFilePrefix
   type: STRING
   userInterface:
     control: LINE_EDIT
     label: Output File Prefix
-    groupLabel: Layer layerDefaultFrames Settings (arnold renderer)
-  description: The output filename prefix for layer layerDefaultFrames
-- name: layerFrameRange1OutputFilePrefix
-  type: STRING
-  userInterface:
-    control: LINE_EDIT
-    label: Output File Prefix
-    groupLabel: Layer layerFrameRange1 Settings (mayaHardware2 renderer)
-  description: The output filename prefix for layer layerFrameRange1
-- name: masterLayerOutputFilePrefix
-  type: STRING
-  userInterface:
-    control: LINE_EDIT
-    label: Output File Prefix
-    groupLabel: Layer masterLayer Settings (arnold renderer)
-  description: The output filename prefix for layer masterLayer
-- name: renderSetupLayer2OutputFilePrefix
-  type: STRING
-  userInterface:
-    control: LINE_EDIT
-    label: Output File Prefix
-    groupLabel: Layer renderSetupLayer2 Settings (arnold renderer)
-  description: The output filename prefix for layer renderSetupLayer2
-- name: renderSetupLayer4OutputFilePrefix
-  type: STRING
-  userInterface:
-    control: LINE_EDIT
-    label: Output File Prefix
-    groupLabel: Layer renderSetupLayer4 Settings (mayaSoftware renderer)
-  description: The output filename prefix for layer renderSetupLayer4
+    groupLabel: Maya Settings
+  description: The output filename prefix.
 - name: layerDefaultFramesImageWidth
   type: INT
   userInterface:
@@ -251,7 +231,8 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
-          output_file_prefix: '{{Param.layerDefaultFramesOutputFilePrefix}}'
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
+          output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.layerDefaultFramesImageWidth}}
           image_height: {{Param.layerDefaultFramesImageHeight}}
           cache_pathmapping: true
@@ -328,7 +309,8 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
-          output_file_prefix: '{{Param.layerFrameRange1OutputFilePrefix}}'
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
+          output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.layerFrameRange1ImageWidth}}
           image_height: {{Param.layerFrameRange1ImageHeight}}
           cache_pathmapping: true
@@ -404,7 +386,8 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
-          output_file_prefix: '{{Param.masterLayerOutputFilePrefix}}'
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
+          output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.masterLayerImageWidth}}
           image_height: {{Param.masterLayerImageHeight}}
           cache_pathmapping: true
@@ -482,7 +465,8 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
-          output_file_prefix: '{{Param.renderSetupLayer2OutputFilePrefix}}'
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
+          output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.renderSetupLayer2ImageWidth}}
           image_height: {{Param.renderSetupLayer2ImageHeight}}
           cache_pathmapping: true
@@ -559,7 +543,8 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
-          output_file_prefix: '{{Param.renderSetupLayer4OutputFilePrefix}}'
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
+          output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.renderSetupLayer4ImageWidth}}
           image_height: {{Param.renderSetupLayer4ImageHeight}}
           cache_pathmapping: true

--- a/job_bundle_output_tests/layers_no_variation/expected_job_bundle/parameter_values.yaml
+++ b/job_bundle_output_tests/layers_no_variation/expected_job_bundle/parameter_values.yaml
@@ -10,7 +10,7 @@
   },
   {
    "name": "OutputFilePrefix",
-   "value": "<Layer>/<Scene>"
+   "value": "<Scene>"
   },
   {
    "name": "ImageWidth",

--- a/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
@@ -66,6 +66,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: OutputFilePrefix
   type: STRING
   userInterface:
@@ -127,6 +135,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
@@ -203,6 +212,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
@@ -279,6 +289,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}

--- a/job_bundle_output_tests/referenced_layers/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/referenced_layers/expected_job_bundle/template.yaml
@@ -66,6 +66,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: OutputFilePrefix
   type: STRING
   userInterface:
@@ -127,6 +135,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}

--- a/src/deadline/maya_adaptor/MayaClient/filename_utils.py
+++ b/src/deadline/maya_adaptor/MayaClient/filename_utils.py
@@ -1,0 +1,62 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+Shared output filename utilities for Deadline Cloud Maya integration.
+Provides token-based output filename prefix resolution.
+
+Supported tokens are resolved by the adaptor at render time.
+Unknown tokens (e.g., renderer-specific ones like <RenderPass>) pass through
+unmodified for Maya or the renderer to handle.
+"""
+import re
+
+SUPPORTED_TOKENS: dict[str, list[str]] = {
+    "<Scene>": ["%s"],
+    "<RenderLayer>": ["<Layer>", "%l"],
+    "<Camera>": ["%c"],
+}
+
+
+def get_tokens_tooltip() -> str:
+    """Build a tooltip string describing all supported tokens."""
+    lines: list[str] = ["Available tokens:"]
+    for token, aliases in SUPPORTED_TOKENS.items():
+        alias_str: str = f" (aliases: {', '.join(aliases)})" if aliases else ""
+        lines.append(f"  {token}{alias_str}")
+    lines.append("")
+    lines.append("Everything else is literal text.")
+    lines.append("Path separators (/) create subdirectories.")
+    lines.append("Examples:")
+    lines.append("  <Scene>/<RenderLayer>/<RenderLayer>")
+    lines.append("  <Scene>/<Camera>/<RenderLayer>")
+    lines.append("  <Scene>")
+    return "\n".join(lines)
+
+
+def resolve_tokens(
+    pattern: str,
+    scene_name: str = "",
+    render_layer: str = "",
+    camera: str = "",
+) -> str:
+    """
+    Replace supported tokens in a Maya imageFilePrefix pattern with actual values.
+    Case-insensitive. Aliases included. Path structure (/) is preserved.
+    Unknown tokens pass through unmodified.
+    """
+    if not pattern:
+        return pattern
+
+    replacements: dict[str, str] = {
+        "<Scene>": scene_name,
+        "%s": scene_name,
+        "<RenderLayer>": render_layer,
+        "<Layer>": render_layer,
+        "%l": render_layer,
+        "<Camera>": camera,
+        "%c": camera,
+    }
+
+    result: str = pattern
+    for token, value in replacements.items():
+        result = re.sub(re.escape(token), value, result, flags=re.IGNORECASE)
+    return result

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from typing import Optional
+
 from .default_maya_handler import DefaultMayaHandler
 
 import maya.cmds
@@ -33,8 +35,7 @@ class ArnoldHandler(DefaultMayaHandler):
 
         self.render_kwargs["camera"] = self.get_camera_to_render(data)
 
-        # In order of preference, use the task's output_file_prefix, the step's output_file_prefix, or the scene file setting.
-        output_file_prefix = data.get("output_file_prefix", self.output_file_prefix)
+        output_file_prefix: Optional[str] = self._resolve_output_file_prefix(data)
         if output_file_prefix:
             maya.cmds.setAttr(
                 "defaultRenderGlobals.imageFilePrefix", output_file_prefix, type="string"

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -9,6 +9,7 @@ import maya.cmds
 import maya.mel
 
 from ..dir_map import DirectoryMapping
+from ..filename_utils import resolve_tokens
 
 
 def _get_render_layer_display_name(render_layer_name: str) -> str:
@@ -97,6 +98,49 @@ class DefaultMayaHandler:
         else:
             return None
 
+    def _resolve_output_file_prefix(self, data: dict) -> Optional[str]:
+        """
+        Resolve supported tokens in the output file prefix.
+
+        Replaces <Scene>, <RenderLayer>/<Layer>/%l, and <Camera>/%c with actual values.
+        Unknown tokens (e.g., <RenderPass>) pass through for Maya/the renderer to handle.
+
+        Args:
+            data (dict): The run-data for the current task. May contain 'camera' and 'output_file_prefix'.
+
+        Returns:
+            The resolved prefix string, or None if no prefix is set.
+        """
+        raw_prefix: Optional[str] = data.get("output_file_prefix", self.output_file_prefix)
+        if not raw_prefix:
+            return raw_prefix
+
+        scene_file: str = maya.cmds.file(query=True, sceneName=True)
+        scene_name: str = os.path.splitext(os.path.basename(scene_file))[0] if scene_file else ""
+
+        camera: str = data.get("camera", self.camera_name) or ""
+        # Maya natively resolves <Camera> to the shape node name, so we do the same.
+        if camera:
+            shapes: Optional[List[str]] = maya.cmds.listRelatives(
+                camera, shapes=True, type="camera"
+            )
+            if shapes:
+                camera = shapes[0]
+
+        render_layer: str = self.render_kwargs.get("layer", "")
+        if not render_layer:
+            render_layer = (
+                maya.cmds.editRenderLayerGlobals(query=True, currentRenderLayer=True) or ""
+            )
+        if render_layer:
+            render_layer = _get_render_layer_display_name(render_layer)
+
+        resolved: str = resolve_tokens(
+            raw_prefix, scene_name=scene_name, render_layer=render_layer, camera=camera
+        )
+        print(f"Resolved output_file_prefix: '{raw_prefix}' -> '{resolved}'", flush=True)
+        return resolved
+
     def start_render(self, data: dict) -> None:
         """
         Starts a render in the mayasoftware renderer.
@@ -117,8 +161,7 @@ class DefaultMayaHandler:
         camera = self.get_camera_to_render(data)
         print(f"Rendering camera: {camera}", flush=True)
 
-        # In order of preference, use the task's output_file_prefix, the step's output_file_prefix, or the scene file setting.
-        output_file_prefix = data.get("output_file_prefix", self.output_file_prefix)
+        output_file_prefix: Optional[str] = self._resolve_output_file_prefix(data)
         if output_file_prefix:
             maya.cmds.setAttr(
                 "defaultRenderGlobals.imageFilePrefix", output_file_prefix, type="string"

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from typing import Optional
+
 import maya.cmds
 
 from .default_maya_handler import DefaultMayaHandler
@@ -43,7 +45,7 @@ class RedshiftHandler(DefaultMayaHandler):
         maya.cmds.setAttr("defaultRenderGlobals.animation", 1)
 
         # In order of preference, use the task's output_file_prefix, the step's output_file_prefix, or the scene file setting.
-        output_file_prefix = data.get("output_file_prefix", self.output_file_prefix)
+        output_file_prefix: Optional[str] = self._resolve_output_file_prefix(data)
         if output_file_prefix:
             maya.cmds.setAttr(
                 "defaultRenderGlobals.imageFilePrefix", output_file_prefix, type="string"

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from typing import Optional
+
 from .default_maya_handler import DefaultMayaHandler
 
 import maya.cmds
@@ -71,7 +73,7 @@ class RenderManHandler(DefaultMayaHandler):
         self.render_kwargs["seq"] = frame
 
         # In order of preference, use the task's output_file_prefix, the step's output_file_prefix, or the scene file setting.
-        output_file_prefix = data.get("output_file_prefix", self.output_file_prefix)
+        output_file_prefix: Optional[str] = self._resolve_output_file_prefix(data)
         if output_file_prefix:
             maya.cmds.setAttr(
                 "defaultRenderGlobals.imageFilePrefix", output_file_prefix, type="string"

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from typing import Optional
+
 from .default_maya_handler import DefaultMayaHandler
 
 import maya.cmds
@@ -74,7 +76,7 @@ class VRayHandler(DefaultMayaHandler):
             )
 
         # In order of preference, use the task's output_file_prefix, the step's output_file_prefix, or the scene file setting.
-        output_file_prefix = data.get("output_file_prefix", self.output_file_prefix)
+        output_file_prefix: Optional[str] = self._resolve_output_file_prefix(data)
         if output_file_prefix:
             maya.cmds.setAttr(
                 "defaultRenderGlobals.imageFilePrefix", output_file_prefix, type="string"
@@ -130,9 +132,7 @@ class VRayHandler(DefaultMayaHandler):
                 )
 
             # Set the output filename
-            maya.cmds.setAttr(
-                "vraySettings.fileNamePrefix", data.get("output_file_prefix"), type="string"
-            )
+            maya.cmds.setAttr("vraySettings.fileNamePrefix", output_file_prefix, type="string")
 
             # Set to allow region in batch rendering
             maya.cmds.setAttr("vraySettings.vfbRgnOffBatch", 0)

--- a/src/deadline/maya_submitter/data_classes.py
+++ b/src/deadline/maya_submitter/data_classes.py
@@ -48,6 +48,10 @@ class RenderSubmitterUISettings:
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 
+    # Output file prefix pattern with optional tokens (<Scene>, <RenderLayer>, <Camera>).
+    # Resolved by the adaptor at render time. Empty string means use scene default.
+    output_file_prefix_pattern: str = field(default="", metadata={"sticky": True})
+
     def load_sticky_settings(self, scene_filename: str):
         sticky_settings_filename = Path(scene_filename).with_suffix(
             RENDER_SUBMITTER_SETTINGS_FILE_EXT

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -23,7 +23,7 @@ from qtpy.QtCore import Qt  # type: ignore
 
 from . import Animation, Scene  # type: ignore
 from .assets import AssetIntrospector
-from .renderers import get_output_prefix_with_tokens, get_height, get_width
+from .renderers import get_output_prefix_with_tokens, get_height, get_width, get_base_output_prefix
 from .data_classes import (
     RenderSubmitterUISettings,
 )
@@ -461,7 +461,10 @@ def _set_render_setting(load_sticky_setting: bool = False) -> RenderSubmitterUIS
     render_settings.project_path = Scene.project_path()
     render_settings.output_path = Scene.output_path()
 
-    # Load the sticky settings
+    # Default output file prefix pattern from scene render globals
+    render_settings.output_file_prefix_pattern = get_base_output_prefix()
+
+    # Load the sticky settings (may override the pattern)
     if load_sticky_setting:
         render_settings.load_sticky_settings(Scene.name())
 
@@ -594,6 +597,12 @@ def on_create_job_bundle_callback(
     if per_layer_frames_parameters:
         for layer_data in submit_render_layers:
             layer_data.frames_parameter_name = f"{layer_data.display_name}Frames"
+
+    # If the user set an output file prefix pattern in the UI, use it for all layers.
+    # The pattern contains raw tokens — the adaptor resolves them at render time.
+    if settings.output_file_prefix_pattern:
+        for layer_data in submit_render_layers:
+            layer_data.output_file_prefix = settings.output_file_prefix_pattern
 
     first_output_file_prefix = submit_render_layers[0].output_file_prefix
     per_layer_output_file_prefix = any(

--- a/src/deadline/maya_submitter/renderers.py
+++ b/src/deadline/maya_submitter/renderers.py
@@ -1,12 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
-from collections import deque
-
 import maya.cmds
-
-from .cameras import get_renderable_camera_names
-from .render_layers import get_all_renderable_render_layer_names
 
 
 def get_width() -> int:
@@ -23,35 +18,19 @@ def get_height() -> int:
     return maya.cmds.getAttr("defaultResolution.height")
 
 
-_LAYER_TOKENS = ("<Layer>", "<RenderLayer>", "%l")
-_CAMERA_TOKENS = ("<Camera>", "%c")
-
-
-def _get_base_output_prefix():
+def get_base_output_prefix() -> str:
     """
     Retrieves the output prefix as specified in the scene.
     """
-    prefix = maya.cmds.getAttr("defaultRenderGlobals.imageFilePrefix")
+    prefix: str = maya.cmds.getAttr("defaultRenderGlobals.imageFilePrefix") or ""
     if prefix:
         return prefix
     return "<Scene>"
 
 
-def get_output_prefix_with_tokens():
+def get_output_prefix_with_tokens() -> str:
     """
-    Retrieves the Output Prefix adding in all missing tokens
+    Retrieves the output prefix as specified in the scene.
+    WYSIWYG — returns the prefix exactly as set, no auto-prepend of tokens.
     """
-    prefix = _get_base_output_prefix()
-
-    sections = deque(prefix.split("/"))
-
-    if len(get_renderable_camera_names()) > 1 and not any(
-        token in prefix for token in _CAMERA_TOKENS
-    ):
-        sections.appendleft("<Camera>")
-    if len(get_all_renderable_render_layer_names()) > 1 and not any(
-        token in prefix for token in _LAYER_TOKENS
-    ):
-        sections.appendleft("<Layer>")
-
-    return "/".join(sections)
+    return get_base_output_prefix()

--- a/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
@@ -1,12 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import os
 
+import maya.cmds  # type: ignore
+
 from qtpy.QtCore import QSize, Qt, QRegularExpression  # type: ignore
 from qtpy.QtWidgets import (  # type: ignore
     QCheckBox,
     QComboBox,
     QFileDialog,
     QGridLayout,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -19,6 +22,10 @@ from qtpy.QtGui import QRegularExpressionValidator  # type: ignore
 from deadline.client.ui import block_signals
 
 from ...render_layers import LayerSelection
+from deadline.maya_adaptor.MayaClient.filename_utils import (
+    get_tokens_tooltip,
+    resolve_tokens,
+)
 
 """
 UI widgets for the Scene Settings tab.
@@ -109,37 +116,57 @@ class SceneSettingsWidget(QWidget):
         lyt.addWidget(QLabel("Output Path"), 1, 0)
         lyt.addWidget(self.op_path_txt, 1, 1)
 
+        # Output File Prefix pattern with live preview
+        prefix_group: QGroupBox = QGroupBox("Output File Prefix")
+        prefix_lyt: QGridLayout = QGridLayout(prefix_group)
+
+        self.output_prefix_txt = QLineEdit(self)
+        self.output_prefix_txt.setToolTip(get_tokens_tooltip())
+        self.output_prefix_txt.setPlaceholderText("<Scene>/<RenderLayer>/<RenderLayer>")
+        self.output_prefix_txt.textChanged.connect(self._update_prefix_preview)
+        prefix_lyt.addWidget(QLabel("Pattern"), 0, 0)
+        prefix_lyt.addWidget(self.output_prefix_txt, 0, 1)
+
+        self.output_prefix_preview = QLabel("")
+        self.output_prefix_preview.setToolTip("Preview of the resolved output file prefix")
+        self.output_prefix_preview.setStyleSheet("color: gray;")
+        prefix_lyt.addWidget(QLabel("Preview"), 1, 0)
+        prefix_lyt.addWidget(self.output_prefix_preview, 1, 1)
+
+        lyt.addWidget(prefix_group, 2, 0, 1, 2)
+
         self.layers_box = QComboBox(self)
-        layer_items = [
+        layer_items: list[tuple[LayerSelection, str]] = [
             (LayerSelection.ALL, "All Renderable Layers"),
             (LayerSelection.CURRENT, "Current Layer"),
         ]
         for layer_value, text in layer_items:
             self.layers_box.addItem(text, layer_value)
-        lyt.addWidget(QLabel("Render Layers"), 2, 0)
-        lyt.addWidget(self.layers_box, 2, 1)
+        lyt.addWidget(QLabel("Render Layers"), 3, 0)
+        lyt.addWidget(self.layers_box, 3, 1)
         self.layers_box.currentIndexChanged.connect(self._fill_cameras_box)
 
         self.cameras_box = QComboBox(self)
-        lyt.addWidget(QLabel("Cameras"), 3, 0)
-        lyt.addWidget(self.cameras_box, 3, 1)
+        lyt.addWidget(QLabel("Cameras"), 4, 0)
+        lyt.addWidget(self.cameras_box, 4, 1)
+        self.cameras_box.currentIndexChanged.connect(self._update_prefix_preview)
 
         self.frame_override_chck = QCheckBox("Override Frame Range", self)
         self.frame_override_txt = QLineEdit(self)
         # Only allow numbers, colons, dashes, commas, and whitespace for frame ranges
         frame_pattern = QRegularExpression(r"^[0-9:\-,\s]*$")
         self.frame_override_txt.setValidator(QRegularExpressionValidator(frame_pattern))
-        lyt.addWidget(self.frame_override_chck, 4, 0)
-        lyt.addWidget(self.frame_override_txt, 4, 1)
+        lyt.addWidget(self.frame_override_chck, 5, 0)
+        lyt.addWidget(self.frame_override_txt, 5, 1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)
 
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 5, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 6, 0)
 
-        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
+        lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 11, 0)
 
         self._fill_cameras_box(0)
 
@@ -165,6 +192,7 @@ class SceneSettingsWidget(QWidget):
     def _configure_settings(self, settings):
         self.proj_path_txt.setText(settings.project_path)
         self.op_path_txt.setText(settings.output_path)
+        self.output_prefix_txt.setText(settings.output_file_prefix_pattern)
         self.frame_override_chck.setChecked(settings.override_frame_range)
         self.frame_override_txt.setEnabled(settings.override_frame_range)
         self.frame_override_txt.setText(settings.frame_list)
@@ -180,6 +208,39 @@ class SceneSettingsWidget(QWidget):
         if self.developer_options:
             self.include_adaptor_wheels.setChecked(settings.include_adaptor_wheels)
 
+        self._update_prefix_preview()
+
+    def _update_prefix_preview(self) -> None:
+        """Update the live preview label with resolved tokens."""
+        pattern: str = self.output_prefix_txt.text()
+        if not pattern:
+            self.output_prefix_preview.setText("")
+            return
+
+        # Use first camera as example for preview
+        camera: str = self.cameras_box.currentData() or ""
+        if camera == "ALL_CAMERAS" or camera == "All Cameras":
+            # Use first non-"all" camera if available
+            if self.cameras_box.count() > 1:
+                camera = self.cameras_box.itemData(1) or ""
+            else:
+                camera = ""
+
+        # Scene name from the scene file
+        scene_file: str = maya.cmds.file(query=True, sceneName=True)
+        scene_name: str = (
+            os.path.splitext(os.path.basename(scene_file))[0] if scene_file else "untitled"
+        )
+
+        # Render layer: use "masterLayer" as example since it exists in every Maya scene.
+        # The actual layer name is resolved at render time per-step on the farm.
+        render_layer: str = "masterLayer"
+
+        preview: str = resolve_tokens(
+            pattern, scene_name=scene_name, render_layer=render_layer, camera=camera
+        )
+        self.output_prefix_preview.setText(preview)
+
     def update_settings(self, settings):
         """
         Update a scene settings object with the latest values.
@@ -187,6 +248,7 @@ class SceneSettingsWidget(QWidget):
 
         settings.project_path = self.proj_path_txt.text()
         settings.output_path = self.op_path_txt.text()
+        settings.output_file_prefix_pattern = self.output_prefix_txt.text()
 
         settings.override_frame_range = self.frame_override_chck.isChecked()
         settings.frame_list = self.frame_override_txt.text()

--- a/test/integ/helpers/output_comparison.py
+++ b/test/integ/helpers/output_comparison.py
@@ -25,7 +25,13 @@ def are_images_similar(
         # Open the two image files with Pillow https://pillow.readthedocs.io/en/stable/index.html
         # and put them in numpy arrays. Pillow doesn't have a good built-in way to do image comparison
         # with tolerance.
-        actual = np.asarray(PIL.Image.open(actual_image_directory / image.name))
+        # Maya may render into subdirectories (e.g. <layer>/<camera>/), so search recursively.
+        matches = list(actual_image_directory.rglob(image.name))
+        if not matches:
+            raise FileNotFoundError(
+                f"No file named '{image.name}' found under {actual_image_directory}"
+            )
+        actual = np.asarray(PIL.Image.open(matches[0]))
         expected = np.asarray(PIL.Image.open(image))
 
         # Check that the two images are the same within a tolerance.

--- a/test/integ/test_maya_adaptors.py
+++ b/test/integ/test_maya_adaptors.py
@@ -25,6 +25,37 @@ class TestAdaptors:
     """
 
     @pytest.mark.maya_renderer
+    def test_token_resolution_adaptor(self, script_location: Path, tmp_path: Path) -> None:
+        """Tests that <Scene> and <RenderLayer> tokens in OutputFilePrefix are resolved
+        to actual values in the rendered output file paths."""
+        test_file_location = script_location / "minimal_test"
+        scene_location = test_file_location / TEST_SCENE_FOLDER / "test.ma"
+        output_path = tmp_path / OUTPUT_FOLDER
+
+        job_params: dict = {
+            "MayaSceneFile": str(scene_location),
+            "OutputFilePrefix": "<Scene>/<RenderLayer>/<RenderLayer>",
+            "Frames": "1",
+            "ImageWidth": 960,
+            "ImageHeight": 540,
+            "OutputFilePath": str(output_path),
+            "ProjectPath": str(test_file_location / "scene") + "/",
+            "RenderSetupIncludeLights": "false",
+        }
+
+        run_adaptor_test(test_file_location / EXPECTED_JOB_BUNDLE_FOLDER / TEMPLATE, job_params)
+
+        # Verify tokens were resolved: output should be under {scene_name}/{layer_name}/
+        # and NOT contain literal "<Scene>" or "<RenderLayer>" in file paths
+        output_files: list[Path] = list(output_path.rglob("*"))
+        rendered_files: list[Path] = [f for f in output_files if f.is_file()]
+        assert len(rendered_files) > 0, "No rendered files found"
+        for rendered_file in rendered_files:
+            relative: str = str(rendered_file.relative_to(output_path))
+            assert "<Scene>" not in relative, f"Unresolved <Scene> token in: {relative}"
+            assert "<RenderLayer>" not in relative, f"Unresolved <RenderLayer> token in: {relative}"
+
+    @pytest.mark.maya_renderer
     def test_minimal_scene_adaptor(self, script_location: Path, tmp_path: Path) -> None:
         test_file_location = script_location / "minimal_test"
         scene_location = test_file_location / TEST_SCENE_FOLDER / "test.ma"

--- a/test/integ/test_maya_submitters.py
+++ b/test/integ/test_maya_submitters.py
@@ -251,3 +251,82 @@ class TestSubmitters:
         are_asset_references_similar(
             job_history_dir, expected_asset_references, job_configuration.expected_scene_file_paths
         )
+
+    def test_output_prefix_pattern_wysiwyg(
+        self,
+        initialize_maya,
+        script_location: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Tests that the output_file_prefix_pattern is passed through to the job bundle
+        exactly as set (WYSIWYG), without auto-prepending tokens."""
+        show_maya_render_submitter = initialize_maya[0]
+        on_create_job_bundle_callback = initialize_maya[1]
+
+        job_history_dir: Path = tmp_path / "jobhistory"
+        output_path: Path = tmp_path / "output"
+        project_path: Path = script_location / "minimal_test" / "scene"
+        scene_location: Path = project_path / "test.ma"
+
+        self._cleanup_sticky_settings(scene_location, script_location)
+
+        os.makedirs(job_history_dir, exist_ok=True)
+        os.makedirs(output_path, exist_ok=True)
+
+        cmds.workspace(project_path, openWorkspace=True)
+        cmds.workspace(fileRule=["images", output_path])
+        cmds.file(scene_location, open=True, force=True)
+        cmds.setAttr("defaultResolution.width", 960)
+        cmds.setAttr("defaultResolution.height", 540)
+        cmds.optionVar(iv=("renderSetup_includeAllLights", 0))
+
+        raw_pattern: str = "<Scene>/<RenderLayer>/<RenderLayer>"
+
+        widget = show_maya_render_submitter(None)
+
+        settings = widget.job_settings_type()
+        widget.shared_job_settings.update_settings(settings)
+        widget.job_settings.update_settings(settings)
+
+        settings.output_file_prefix_pattern = raw_pattern
+        settings.override_frame_range = True
+        settings.frame_list = "1"
+        settings.description = ""
+        settings.include_adaptor_wheels = False
+
+        widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+            {"name": "deadline:targetTaskRunStatus", "value": "READY"}
+        )
+        widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+            {"name": "deadline:maxFailedTasksCount", "value": 20}
+        )
+        widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+            {"name": "deadline:maxRetriesPerTask", "value": 5}
+        )
+        widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+            {"name": "deadline:priority", "value": 50}
+        )
+
+        on_create_job_bundle_callback(
+            widget,
+            job_history_dir,
+            settings,
+            widget.shared_job_settings.get_parameters(),
+            widget.job_attachments.get_asset_references(),
+            widget.host_requirements.get_requirements(),
+            purpose="export",
+        )
+        widget.close()
+
+        # Verify the raw pattern appears in parameter_values.yaml exactly as set
+        with open(job_history_dir / "parameter_values.yaml") as f:
+            param_values: dict = yaml.safe_load(f)
+
+        prefix_params: list = [
+            p for p in param_values["parameterValues"] if "OutputFilePrefix" in p["name"]
+        ]
+        assert len(prefix_params) > 0, "No OutputFilePrefix parameter found"
+        for param in prefix_params:
+            assert (
+                param["value"] == raw_pattern
+            ), f"Expected raw pattern '{raw_pattern}', got '{param['value']}'"

--- a/test/integ/test_scripts/minimal_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/minimal_test/scene/test.deadline_render_settings.json
@@ -7,9 +7,10 @@
  "max_retries_per_task": 5,
  "max_worker_count": -1,
  "override_frame_range": true,
- "frame_list": "1-2",
+ "frame_list": "1",
  "input_filenames": [],
  "input_directories": [],
  "output_directories": [],
- "include_adaptor_wheels": false
+ "include_adaptor_wheels": false,
+ "output_file_prefix_pattern": "<Scene>/<RenderLayer>/<RenderLayer>"
 }

--- a/test/integ/test_scripts/mtoa_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/mtoa_test/scene/test.deadline_render_settings.json
@@ -11,5 +11,6 @@
  "input_filenames": [],
  "input_directories": [],
  "output_directories": [],
- "include_adaptor_wheels": false
+ "include_adaptor_wheels": false,
+ "output_file_prefix_pattern": "arnoldmayascene"
 }

--- a/test/integ/test_scripts/redshift_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/redshift_test/scene/test.deadline_render_settings.json
@@ -11,5 +11,6 @@
  "input_filenames": [],
  "input_directories": [],
  "output_directories": [],
- "include_adaptor_wheels": false
+ "include_adaptor_wheels": false,
+ "output_file_prefix_pattern": "redshift_test"
 }

--- a/test/integ/test_scripts/vray_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/vray_test/scene/test.deadline_render_settings.json
@@ -11,5 +11,6 @@
  "input_filenames": [],
  "input_directories": [],
  "output_directories": [],
- "include_adaptor_wheels": false
+ "include_adaptor_wheels": false,
+ "output_file_prefix_pattern": "vraymayascene"
 }

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from io import StringIO
 import os
+from typing import Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -384,3 +385,85 @@ class TestSetOcioConfigFile:
             mock_color_prefs.assert_not_called()
             assert "WARNING" in output.getvalue()
             assert "/nonexistent/config.ocio" in output.getvalue()
+
+
+class TestResolveOutputFilePrefix:
+    """Tests for DefaultMayaHandler._resolve_output_file_prefix"""
+
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.file",
+        return_value="/path/to/test.ma",
+    )
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.editRenderLayerGlobals",
+        return_value="rs_layer1",
+    )
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval",
+        return_value="layer1",
+    )
+    def test_resolves_init_data_prefix(
+        self,
+        mock_mel_eval: Mock,
+        mock_edit_render_layer: Mock,
+        mock_file: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+    ) -> None:
+        """Tests that tokens in init-data prefix are resolved."""
+        # GIVEN
+        mayahandlerbase.output_file_prefix = "<Scene>/<RenderLayer>"
+
+        # WHEN
+        result: Optional[str] = mayahandlerbase._resolve_output_file_prefix({})
+
+        # THEN
+        assert result == "test/layer1"
+
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.file",
+        return_value="/path/to/scene.ma",
+    )
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.editRenderLayerGlobals",
+        return_value="defaultRenderLayer",
+    )
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval",
+        return_value="masterLayer",
+    )
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds.listRelatives",
+        return_value=["cam1Shape"],
+    )
+    def test_run_data_overrides_init_data(
+        self,
+        mock_list_relatives: Mock,
+        mock_mel_eval: Mock,
+        mock_edit_render_layer: Mock,
+        mock_file: Mock,
+        mayahandlerbase: DefaultMayaHandler,
+    ) -> None:
+        """Tests that run-data prefix overrides init-data prefix and camera resolves to shape."""
+        # GIVEN
+        mayahandlerbase.output_file_prefix = "<Scene>_init"
+        data: dict = {"output_file_prefix": "<Camera>_out", "camera": "cam1"}
+
+        # WHEN
+        result: Optional[str] = mayahandlerbase._resolve_output_file_prefix(data)
+
+        # THEN
+        assert result == "cam1Shape_out"
+
+    def test_no_prefix_returns_none(
+        self,
+        mayahandlerbase: DefaultMayaHandler,
+    ) -> None:
+        """Tests that None is returned when no prefix is set."""
+        # GIVEN
+        mayahandlerbase.output_file_prefix = None
+
+        # WHEN
+        result = mayahandlerbase._resolve_output_file_prefix({})
+
+        # THEN
+        assert result is None

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/test_filename_utils.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/test_filename_utils.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+import pytest
+
+from deadline.maya_adaptor.MayaClient.filename_utils import resolve_tokens
+
+
+class TestResolveTokens:
+    @pytest.mark.parametrize(
+        "pattern, scene_name, render_layer, camera, expected",
+        [
+            # 1. All tokens
+            (
+                "<Scene>/<RenderLayer>/<RenderLayer>",
+                "myScene",
+                "myLayer",
+                "cam1",
+                "myScene/myLayer/myLayer",
+            ),
+            # 2. Camera token
+            ("<Camera>/<Scene>", "shot01", "", "renderCam", "renderCam/shot01"),
+            # 3. Alias %l
+            ("<Scene>/%l/%l", "test", "fg", "", "test/fg/fg"),
+            # 4. Alias %c
+            ("%c_<Scene>", "s", "", "cam", "cam_s"),
+            # 5. Alias <Layer>
+            ("<Layer>/<Scene>", "shot", "bg", "", "bg/shot"),
+            # 6. Alias %s
+            ("%s_render", "myFile", "", "", "myFile_render"),
+            # 7. Case insensitive
+            ("<scene>/<renderlayer>/<camera>", "s", "l", "c", "s/l/c"),
+            # 8. No tokens
+            ("myRender", "", "", "", "myRender"),
+            # 9. Empty string
+            ("", "", "", "", ""),
+            # 10. None
+            (None, "", "", "", None),
+            # 11. Unknown token passes through
+            ("<Scene>/<RenderPass>/beauty", "s", "", "", "s/<RenderPass>/beauty"),
+            # 12. Empty token values
+            ("<Scene>/<RenderLayer>", "", "", "", "/"),
+        ],
+    )
+    def test_resolve_tokens(
+        self,
+        pattern: str,
+        scene_name: str,
+        render_layer: str,
+        camera: str,
+        expected: str,
+    ) -> None:
+        result: str = resolve_tokens(
+            pattern, scene_name=scene_name, render_layer=render_layer, camera=camera
+        )
+        assert result == expected


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The previous submitter automatically prepended \<Layer\> and \<Camera\> tokens to the output file prefix based on the number of renderable layers/cameras. This was opaque and surprising — users couldn't control the output directory structure or
filename pattern directly.

Users need full control over the imageFilePrefix pattern, including the ability to use tokens like \<Scene\>, \<RenderLayer\>, and \<Camera\> that get resolved at render time.

### What was the solution? (How)

- Added a new filename_utils.py module with a SUPPORTED_TOKENS dict (single source of truth) and a resolve_tokens() function that performs case-insensitive token replacement at render time.
- Replaced the auto-prepend logic in renderers.py with a WYSIWYG approach: the pattern is passed through exactly as the user types it.
- Added an "Output File Prefix" group box to the Scene Settings tab with a pattern input field and a live preview that resolves tokens using the current scene context.
- The pattern is stored as a sticky setting (output_file_prefix_pattern in RenderSubmitterUISettings) and applied uniformly to all render layers at submission time.
- All five render handlers (default_maya_handler, arnold_handler, redshift_handler, renderman_handler, vray_handler) now call _resolve_output_file_prefix() instead of passing raw tokens to Maya.
- The <Camera> token resolves to the camera shape node name (e.g., topCamShape1) to match Maya's native <Camera> token behavior.
- Changed from per-layer OutputFilePrefix parameters to a single global OutputFilePrefix parameter in the job template.
- Added OCIOConfigFile parameter to the job template init-data.
- Updated are_images_similar in integ test helper to search recursively for output images, since Maya renders into subdirectories based on layer/camera.

### What is the impact of this change?

- Users now have explicit control over output filename patterns via the submitter UI.
- The submitter no longer silently modifies the output prefix — what you type is what gets submitted.
- Jobs submitted with older versions of the submitter that used per-layer OutputFilePrefix parameters will not work with this version of the adaptor. However, the adaptor still resolves the same tokens Maya supports, so the rendered output is functionally equivalent.

### How was this change tested?

- Unit tests for resolve_tokens() in test_filename_utils.py
- Unit tests for _resolve_output_file_prefix() in test_maya_handler_base.py, including camera shape node resolution
- Integration tests for token resolution (test_token_resolution_adaptor) and minimal scene rendering (test_minimal_scene_adaptor)
- Submitter integration tests in test_maya_submitters.py
- Job bundle output tests for all scene types

#### Integ test result

PASS
hatch run integ:test_submitters
hatch run integ:test_adaptors_maya (test_token_resolution_adaptor, test_minimal_scene_adaptor).

#### Installer test result

N/A — no changes to installer/.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Timestamp: 2026-04-08T10:51:21.883958-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2026-04-08T10:51:23.717737-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2026-04-08T10:51:25.360205-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2026-04-08T10:51:25.360297-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2026-04-08T10:51:26.907453-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2026-04-08T10:51:32.362913-07:00


### Was this change documented?

- Yes — added docs/design/output-filename-with-tokens.md design document.
- Docstrings added/updated for all new and modified functions.
- Schema files were not modified.

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No. The adaptor consumes output_file_prefix as a plain string in init-data — it doesn't know or care about the template parameter names. Old job bundles with per-layer parameters still resolve to valid output_file_prefix strings that the new
adaptor handles correctly. Similarly, new job bundles with the single OutputFilePrefix parameter produce tokens that the old adaptor passes through to Maya, which resolves them natively.

### Default

<img width="285" height="103" alt="Screenshot 2026-04-08 at 7 58 36 PM" src="https://github.com/user-attachments/assets/8f7a0efb-f766-402f-8dd9-6b6dbee389b2" />

### Custom Tokens

<img width="536" height="324" alt="Screenshot 2026-04-08 at 8 01 52 PM" src="https://github.com/user-attachments/assets/19e589b6-52c8-40cb-98e1-fe587f10378f" />

<img width="229" height="166" alt="Screenshot 2026-04-08 at 7 58 46 PM" src="https://github.com/user-attachments/assets/893f3627-9ad7-457e-9b3c-5d7248c78bc6" />

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.