### PR TITLE
fix: Add error handling for legacy layer + render setup combination

### DIFF
--- a/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/cube/expected_job_bundle/template.yaml
@@ -66,6 +66,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: OutputFilePrefix
   type: STRING
   userInterface:
@@ -116,6 +124,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}

--- a/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers/expected_job_bundle/template.yaml
@@ -58,6 +58,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: layerDefaultFramesFrames
   type: STRING
   userInterface:
@@ -251,6 +259,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.layerDefaultFramesOutputFilePrefix}}'
           image_width: {{Param.layerDefaultFramesImageWidth}}
           image_height: {{Param.layerDefaultFramesImageHeight}}
@@ -328,6 +337,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.layerFrameRange1OutputFilePrefix}}'
           image_width: {{Param.layerFrameRange1ImageWidth}}
           image_height: {{Param.layerFrameRange1ImageHeight}}
@@ -404,6 +414,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.masterLayerOutputFilePrefix}}'
           image_width: {{Param.masterLayerImageWidth}}
           image_height: {{Param.masterLayerImageHeight}}
@@ -482,6 +493,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.renderSetupLayer2OutputFilePrefix}}'
           image_width: {{Param.renderSetupLayer2ImageWidth}}
           image_height: {{Param.renderSetupLayer2ImageHeight}}
@@ -559,6 +571,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.renderSetupLayer4OutputFilePrefix}}'
           image_width: {{Param.renderSetupLayer4ImageWidth}}
           image_height: {{Param.renderSetupLayer4ImageHeight}}

--- a/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/layers_no_variation/expected_job_bundle/template.yaml
@@ -66,6 +66,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: OutputFilePrefix
   type: STRING
   userInterface:
@@ -127,6 +135,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
@@ -203,6 +212,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}
@@ -279,6 +289,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}

--- a/job_bundle_output_tests/referenced_layers/expected_job_bundle/template.yaml
+++ b/job_bundle_output_tests/referenced_layers/expected_job_bundle/template.yaml
@@ -66,6 +66,14 @@ parameterDefinitions:
   allowedValues:
   - 'true'
   - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
 - name: OutputFilePrefix
   type: STRING
   userInterface:
@@ -127,6 +135,7 @@ steps:
           output_file_path: '{{Param.OutputFilePath}}'
           render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
           strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
           output_file_prefix: '{{Param.OutputFilePrefix}}'
           image_width: {{Param.ImageWidth}}
           image_height: {{Param.ImageHeight}}

--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -197,6 +197,9 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
         )
         _vray_license_error = "error: Could not obtain a license"
         _renderman_license_error = r".*{SEVERE}\s+License.*"
+        _legacy_render_layer_error = (
+            r"Error:[^\n]*contains legacy render layers[^\n]*uses render setup"
+        )
         callback_list = []
         completed_regexes = [re.compile("MayaClient: Finished Rendering Frame [0-9]+")]
         progress_regexes = [
@@ -237,6 +240,12 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
             )
         )
         callback_list.append(RegexCallback(version_regexes, self._handle_maya_version))
+        callback_list.append(
+            RegexCallback(
+                [re.compile(_legacy_render_layer_error)],
+                self._handle_legacy_render_layer_error,
+            )
+        )
 
         return callback_list
 
@@ -270,6 +279,24 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
             RuntimeError: Always raises a runtime error to halt the adaptor.
         """
         self._exc_info = RuntimeError(f"Maya Encountered an Error: {match.group(0)}")
+
+    def _handle_legacy_render_layer_error(self, match: re.Match) -> None:
+        """
+        Callback for stderr that indicates a legacy render layer incompatibility.
+        Args:
+            match (re.Match): The match object from the regex pattern that was matched the message
+
+        Raises:
+            RuntimeError: Always raises a runtime error to halt the adaptor.
+        """
+        self._exc_info = RuntimeError(
+            "This scene contains legacy render layers but Maya is running in Render Setup mode. "
+            "This combination is unsupported by Maya and will cause render layers to be ignored, "
+            "resulting in all frames rendering under 'masterLayer'. "
+            "Please convert your scene to use Render Setup layers, or switch your scene to "
+            "Legacy Render Layers mode (Preferences > Rendering > Preferred Render Setup System) "
+            "before submitting."
+        )
 
     def _handle_license_error(self, match: re.Match) -> None:
         """


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When a Maya scene containing legacy render layers is loaded on a Deadline Cloud worker, Maya (2024+) defaults to Render Setup mode. Maya does not support legacy render layers in Render Setup mode — it silently ignores render layer switches via editRenderLayerGlobals. As a result, all layers render under masterLayer, output files are misnamed and overwrite each other, and the rendered content is incorrect.

The adaptor did not detect or surface this error, so jobs appeared to succeed while producing incorrect output.

### What was the solution? (How)

Added a regex callback in the adaptor that catches Maya's stderr message "Error:.*contains legacy render layers.*uses render setup" and fails the job immediately with a clear, actionable error message explaining the problem and how to fix it.

Also updated the expected job bundle test templates to include the OCIOConfigFile parameter that was added in #361 but missing from the test fixtures.

### What is the impact of this change?

Jobs that previously succeeded silently with incorrect output will now fail fast with a clear error message telling the customer to either convert their scene to Render Setup layers or switch to Legacy Render Layers mode before submitting.

### How was this change tested?

- Reproduced issue using a test scene with legacy render layers + Arnold renderer submitted to a Service Managed Fleet
- Confirmed the job previously rendered all layers under masterLayer
- After the fix, confirmed the job fails immediately with the expected error message
- Verified the regex matches both observed Maya error message variants (Windows and Linux)

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
```

Timestamp: 2026-04-12T17:26:59.934022-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2026-04-12T17:27:01.883480-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2026-04-12T17:27:03.482139-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2026-04-12T17:27:03.482265-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2026-04-12T17:27:04.985810-07:00
Running job bundle output test: /Users/ruizjair/workplace/jairaws/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2026-04-12T17:27:09.310078-07:00
```

### Was this change documented?

- Docstring added to the new _handle_legacy_render_layer_error method following existing handler conventions
- No README or schema changes needed

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No. Jobs with Render Setup layers (the recommended workflow) are unaffected. Jobs with legacy render layers that previously produced silently incorrect output will now fail with a clear error instead.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
