### PR TITLE
feat: Notify customers if newer submitter is available.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.52,< 0.55",
+    "deadline >= 0.55.1,< 0.56",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 

--- a/src/deadline/maya_submitter/mel_commands.py
+++ b/src/deadline/maya_submitter/mel_commands.py
@@ -13,6 +13,7 @@ from qtpy.QtWidgets import (  # type: ignore
 from deadline.client.ui import gui_error_handler
 from . import logger as deadline_logger  # type: ignore
 from .maya_render_submitter import show_maya_render_submitter
+from .update_utils import check_and_show_update_dialog
 from .job_bundle_output_test_runner import run_maya_render_submitter_job_bundle_output_test
 
 
@@ -58,6 +59,9 @@ class DeadlineCloudSubmitterCmd(om.MPxCommand):
                     if DeadlineCloudSubmitterCmd.dialog:
                         DeadlineCloudSubmitterCmd.dialog.close()
                     DeadlineCloudSubmitterCmd.dialog = None
+
+                if check_and_show_update_dialog():
+                    return
 
                 # Create a new submitter dialog. If this is the first time the submitter is
                 # opened, load the sticky settings. If this is not the first time, close

--- a/src/deadline/maya_submitter/update_utils.py
+++ b/src/deadline/maya_submitter/update_utils.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Utilities for checking and displaying update notifications."""
+
+import logging
+from dataclasses import dataclass
+
+from deadline.client.api import safe_check_for_updates, UpdateCheckResult, UpdateCheckStatus
+from deadline.client.ui.dialogs.update_available_dialog import UpdateAvailableDialog
+
+from ._version import version_tuple as adaptor_version_tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SessionState:
+    """Session-level state: once the user dismisses the update dialog,
+    don't show it again until Maya is restarted."""
+
+    update_dismissed: bool = False
+
+
+_session_state = _SessionState()
+
+
+def _check_for_update() -> UpdateCheckResult:
+    """Check if a newer version of the Maya submitter is available.
+
+    Returns:
+        An UpdateCheckResult describing whether an update is available.
+    """
+    current_version = ".".join(str(v) for v in adaptor_version_tuple[:3])
+    return safe_check_for_updates(
+        integration_name="deadline-cloud-for-maya",
+        current_version=current_version,
+    )
+
+
+def check_and_show_update_dialog() -> bool:
+    """Check for updates and show the update dialog if one is available.
+
+    If the user previously dismissed the dialog in this Maya session,
+    the check is skipped entirely.
+
+    Returns:
+        True if the user clicked Download (caller should skip opening the submitter),
+        False otherwise.
+    """
+    if _session_state.update_dismissed:
+        return False
+
+    update_result = _check_for_update()
+    if update_result.status == UpdateCheckStatus.SUCCESS and update_result.update_available:
+        update_dialog = UpdateAvailableDialog(
+            integration_name="Maya",
+            current_version=update_result.current_version or "",
+            latest_version=update_result.latest_version or "",
+            download_url=update_result.download_url or "",
+            release_notes_url="https://github.com/aws-deadline/deadline-cloud-for-maya/releases",
+        )
+        update_dialog.exec_()
+        if update_dialog.user_downloaded:
+            return True
+        # User dismissed — suppress for the rest of this Maya session
+        _session_state.update_dismissed = True
+    return False

--- a/src/deadline/maya_submitter/update_utils.py
+++ b/src/deadline/maya_submitter/update_utils.py
@@ -30,6 +30,9 @@ def _check_for_update() -> UpdateCheckResult:
     Returns:
         An UpdateCheckResult describing whether an update is available.
     """
+    # Unlike the maya_render_submitter.py (which only extracts the major+minor version), we
+    # compare major.minor.patch so users are also notified about any new features,
+    # not just breaking changes.
     current_version = ".".join(str(v) for v in adaptor_version_tuple[:3])
     return safe_check_for_updates(
         integration_name="deadline-cloud-for-maya",

--- a/test/unit/deadline_submitter_for_maya/test_mel_commands.py
+++ b/test/unit/deadline_submitter_for_maya/test_mel_commands.py
@@ -9,10 +9,14 @@ from qtpy.QtWidgets import (  # type: ignore
 
 
 @patch("deadline.maya_submitter.mel_commands.show_maya_render_submitter")
+@patch("deadline.maya_submitter.mel_commands.check_and_show_update_dialog", return_value=False)
 @patch.object(QApplication, "instance")
 @patch.object(om.MGlobal, "mayaState")
 def test_deadline_cloud_submitter_cmd_sticky_setting_load_only_once(
-    mock_maya_state: Mock, mock_q_app: Mock, mock_show_maya_render_submitter: Mock
+    mock_maya_state: Mock,
+    mock_q_app: Mock,
+    mock_update_check: Mock,
+    mock_show_maya_render_submitter: Mock,
 ) -> None:
     mock_maya_state.return_value = om.MGlobal.kInteractive
     maya_widget: Mock = Mock()

--- a/test/unit/deadline_submitter_for_maya/test_update_utils.py
+++ b/test/unit/deadline_submitter_for_maya/test_update_utils.py
@@ -1,0 +1,152 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from deadline.client.api import UpdateCheckResult, UpdateCheckStatus
+
+from deadline.maya_submitter.update_utils import (
+    _check_for_update,
+    _session_state,
+    check_and_show_update_dialog,
+)
+
+MODULE = "deadline.maya_submitter.update_utils"
+
+
+@pytest.fixture(autouse=True)
+def _reset_session_state():
+    """Reset session state before each test."""
+    _session_state.update_dismissed = False
+
+
+class TestCheckForUpdate:
+    """Tests for _check_for_update()."""
+
+    @patch(f"{MODULE}.safe_check_for_updates")
+    def test_passes_correct_integration_name(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+        )
+
+        # WHEN
+        _check_for_update()
+
+        # THEN
+        call_kwargs = mock_check.call_args[1]
+        assert call_kwargs["integration_name"] == "deadline-cloud-for-maya"
+
+
+class TestCheckAndShowUpdateDialog:
+    """Tests for check_and_show_update_dialog()."""
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_false_when_no_update(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.10.0",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_false_on_error_status(self, mock_check):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.NETWORK_ERROR,
+            current_version="0.9.0",
+            update_available=False,
+        )
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_returns_true_when_user_downloads(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is True
+        mock_dialog.exec_.assert_called_once()
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_dismiss_sets_session_state(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = False
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        assert _session_state.update_dismissed is True
+
+    @patch(f"{MODULE}._check_for_update")
+    def test_skips_check_when_previously_dismissed(self, mock_check):
+        # GIVEN
+        _session_state.update_dismissed = True
+
+        # WHEN
+        result = check_and_show_update_dialog()
+
+        # THEN
+        assert result is False
+        mock_check.assert_not_called()
+
+    @patch(f"{MODULE}.UpdateAvailableDialog")
+    @patch(f"{MODULE}._check_for_update")
+    def test_download_does_not_set_dismissed(self, mock_check, mock_dialog_cls):
+        # GIVEN
+        mock_check.return_value = UpdateCheckResult(
+            status=UpdateCheckStatus.SUCCESS,
+            current_version="0.9.0",
+            update_available=True,
+            latest_version="0.10.0",
+            download_url="https://example.com/installer",
+        )
+        mock_dialog = MagicMock()
+        mock_dialog.user_downloaded = True
+        mock_dialog_cls.return_value = mock_dialog
+
+        # WHEN
+        check_and_show_update_dialog()
+
+        # THEN
+        assert _session_state.update_dismissed is False


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Customers did not know whether they were on the latest submitter or not. This means they would not have the latest bug fixes or features to work with our product. 

This is based off a similar PR for Cinema 4D: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/pull/414

### What was the solution? (How)

This adds a dialog which checks our download manifests and if there's a new update available notifies customer  that. 

<img width="464" height="189" alt="image" src="https://github.com/user-attachments/assets/37e28952-acfd-434c-8082-a4a4111260d2" />


### What is the impact of this change?

### How was this change tested?

Here's the test cases that I manually tested in Maya 2026 on Mac:

| # | Test Case | Steps | Expected Result | Pass? |
|---|-----------|-------|-----------------|-------|
| | **Config GUI — setting visible** | | | |
| 1 | Setting in config GUI | Open Maya → AWS Deadline Cloud → Submit to Deadline Cloud | "Show submitter update notifications" checkbox is visible | YES |
| | **Config disabled — no dialog** | | | |
| 2 | Notification disabled via GUI | Uncheck "Show submitter update notifications" → Apply → close & reopen submitter | No network call, no dialog, submitter opens normally | YES |
| | **Config enabled, no internet — graceful failure** | | | |
| 3 | Re-enable notification via GUI | Check "Show submitter update notifications" → Apply | Setting updated | YES |
| | **Config enabled, internet available, no update** | | | |
| 5 | Current == latest | Restore network, ensure installed version matches manifest | No dialog, submitter opens normally | YES |
| 6 | Current > latest (dev build) | Install a version newer than manifest | No dialog, submitter opens normally | YES |
| | **Config enabled, internet available, update exists** | | | |
| 7 | Current < latest | Install an older version than manifest | Update dialog appears | YES |
| 8 | Dialog content | Inspect the dialog | Shows "Maya", correct current & latest versions | YES |
| 9 | Dialog layout | Resize / check | Min width 400px, text wraps properly | YES |
| 10 | Dialog timing | Observe launch order | Dialog appears before Maya submitter window | YES |
| | **Dialog interactions — Dismiss** | | | |
| 11 | Click "Dismiss" | Click Dismiss button | Dialog closes, submitter opens normally | YES |
| 12 | Close via X | Click X button on dialog | Dialog closes, submitter opens normally | YES |
| | **Dialog interactions — Download** | | | |
| 13 | Click "View release notes" | Click the link | Maya GitHub releases page opens in browser | YES |
| 14 | Click "Download" | Click Download button | Correct installer URL opens in browser | YES |
| 15 | Restart reminder | After Download click | "Application Restart Required" info box appears | YES |
| | **Edge cases** | | | |
| 16 | Non-standard `_version.py` tuple | Modify version tuple | No crash | YES |
| 17 | Click "Don't remind me again" | Will dismiss and also never show the dialog again | No crash | YES |
| 18 | Click "Dismiss" | Does not show the dialog again for the session| No crash | YES | 

### Was this change documented?

This change does not require documentation. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
