### PR TITLE
Add job bundle to run integ tests in Deadline Cloud

### DIFF
--- a/job_bundle_integ_tests/README.md
+++ b/job_bundle_integ_tests/README.md
@@ -1,0 +1,39 @@
+# Maya Integration Tests on Deadline Cloud
+
+Runs the deadline-cloud-for-maya integration tests on a Deadline Cloud Service Managed Fleet with all supported renderer plugins (Arnold, V-Ray, Redshift).
+
+## Prerequisites
+
+- A Deadline Cloud farm with a queue that has the default Conda queue environment.
+- The `deadline` CLI installed and configured (`deadline config`).
+
+## Usage
+
+```bash
+cd /path/to/deadline-cloud-for-maya
+deadline bundle submit job_bundle_integ_tests \
+  --name "maya-integ-tests" \
+  --parameter "RepoDir=." \
+  --parameter "CondaPackages=maya=2026 maya-mtoa=2026.5.5 maya-vray=2026.7 maya-redshift=2026.2" \
+  --max-retries-per-task 0
+```
+
+## Steps
+
+| Step | Description |
+|------|-------------|
+| `submitter` | Runs submitter tests (`test_maya_submitters.py`). Validates that the Maya submitter generates correct job bundles. |
+| `adaptor` | Runs adaptor tests (`test_maya_adaptors.py`). Validates that the Maya adaptor renders scenes correctly with all supported renderers. |
+
+## How It Works
+
+1. The repo is uploaded as a job attachment via the `RepoDir` input parameter.
+2. A shared job environment installs the package and test dependencies into `mayapy`'s Python environment, and symlinks the adaptor entry points (`MayaAdaptor`, `maya-openjd`) onto PATH.
+3. `QT_QPA_PLATFORM=offscreen` is set job-wide so PySide6 can initialize without a display server.
+4. The submitter step additionally sets `LD_LIBRARY_PATH=$MAYA_LOCATION/lib` to fix PySide6/shiboken6 shared library loading. This is scoped to the submitter step only — setting it job-wide causes adaptor subprocesses to resolve to a broken system Python.
+5. `numpy<2` is pinned because Maya 2026 bundles native modules compiled against NumPy 1.x.
+
+## Customization
+
+- To test against a different Maya version, change the `CondaPackages` parameter (e.g., `maya=2025 maya-mtoa=2025.5.4`).
+- To run only specific tests, modify the pytest marker filter in the step's run script.

--- a/job_bundle_integ_tests/template.yaml
+++ b/job_bundle_integ_tests/template.yaml
@@ -1,0 +1,118 @@
+# Job template for running deadline-cloud-for-maya integration tests on
+# Deadline Cloud Service Managed Fleets. See README.md for usage instructions.
+specificationVersion: jobtemplate-2023-09
+name: deadline-cloud-for-maya integ tests
+parameterDefinitions:
+# The local checkout of the deadline-cloud-for-maya repository.
+# Uploaded automatically as a job attachment because dataFlow is IN.
+- name: RepoDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  description: Path to the deadline-cloud-for-maya repository root.
+jobEnvironments:
+# Headless Qt: PySide6 needs a platform plugin to initialize.
+# "offscreen" allows it to run without a display server.
+- name: EnvVars
+  variables:
+    QT_QPA_PLATFORM: offscreen
+# Shared setup: installs the package, test dependencies, and symlinks
+# the adaptor entry points onto PATH. Runs once per session and applies
+# to all steps.
+- name: SetupTestEnv
+  script:
+    embeddedFiles:
+    - name: Setup
+      filename: setup.sh
+      type: TEXT
+      runnable: true
+      data: |
+        #!/bin/bash
+        set -euo pipefail
+
+        # Install the package (non-editable so entry points are created)
+        # and pin numpy<2 for Maya 2026 ABI compatibility.
+        mayapy -m pip install '{{Param.RepoDir}}' --force-reinstall
+        mayapy -m pip install 'numpy<2'
+        mayapy -m pip install -r '{{Param.RepoDir}}/requirements-testing.txt'
+        mayapy -m pip install -r '{{Param.RepoDir}}/requirements-integ-testing.txt'
+
+        # pip installs entry points (MayaAdaptor, maya-openjd) into Maya's
+        # internal bin dir, which is not on PATH. Symlink them to .env/bin/
+        # so that `openjd run` can find the adaptor binary.
+        SCRIPTS_DIR=$(mayapy -c "import sysconfig; print(sysconfig.get_path('scripts'))" 2>/dev/null)
+        ENV_BIN=$(dirname $(which mayapy))
+        ln -sf "$SCRIPTS_DIR/MayaAdaptor" "$ENV_BIN/MayaAdaptor"
+        ln -sf "$SCRIPTS_DIR/maya-openjd" "$ENV_BIN/maya-openjd"
+    actions:
+      onEnter:
+        command: '{{Env.File.Setup}}'
+        timeout: 300
+steps:
+# Submitter tests: validate that the Maya submitter generates correct job bundles.
+# Requires LD_LIBRARY_PATH for PySide6 (step-scoped to avoid breaking adaptor).
+- name: submitter
+  hostRequirements:
+      attributes:
+        - name: attr.worker.os.family
+          anyOf:
+            - linux
+  stepEnvironments:
+  # PySide6's shiboken6.Shiboken.so needs Qt shared libraries from
+  # $MAYA_LOCATION/lib. The Conda Maya package has incomplete RPATH patching
+  # for these files. This MUST be step-scoped: setting LD_LIBRARY_PATH
+  # job-wide causes adaptor subprocesses to resolve to a broken system Python.
+  - name: MayaLibPath
+    script:
+      embeddedFiles:
+      - name: SetLibPath
+        filename: set-lib-path.sh
+        type: TEXT
+        runnable: true
+        data: |
+          #!/bin/bash
+          set -euo pipefail
+          echo "openjd_env: LD_LIBRARY_PATH=${MAYA_LOCATION}/lib:${LD_LIBRARY_PATH:-}"
+      actions:
+        onEnter:
+          command: '{{Env.File.SetLibPath}}'
+  script:
+    embeddedFiles:
+    - name: Run
+      filename: run.sh
+      type: TEXT
+      runnable: true
+      data: |
+        #!/bin/bash
+        set -euo pipefail
+        cd '{{Param.RepoDir}}'
+        mayapy -m pytest test/integ/test_maya_submitters.py -vvv --numprocesses=1 --no-cov -m submitter
+    actions:
+      onRun:
+        command: '{{Task.File.Run}}'
+        timeout: 600
+# Adaptor tests: validate that the Maya adaptor renders scenes correctly
+# with all supported renderers (mayaHardware2, Arnold, V-Ray, Redshift).
+# Pytest is pointed at the specific test file to avoid collecting
+# test_maya_submitters.py, which imports PySide6 at module level.
+- name: adaptor
+  hostRequirements:
+    attributes:
+      - name: attr.worker.os.family
+        anyOf:
+          - linux
+  script:
+    embeddedFiles:
+    - name: Run
+      filename: run.sh
+      type: TEXT
+      runnable: true
+      data: |
+        #!/bin/bash
+        set -euo pipefail
+        cd '{{Param.RepoDir}}'
+        mayapy -m pytest test/integ/test_maya_adaptors.py -vvv --numprocesses=1 --no-cov -m adaptor
+    actions:
+      onRun:
+        command: '{{Task.File.Run}}'
+        timeout: 600


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Running the integration requires setting up Maya and its plugins in the user environment. The environment needs to have licenses configured for all the plugins (when it applies). Thus, running the full set of integration tests as part of the development cycle can be complicated.

### What was the solution? (How)
Create a job bundle to submit a job that runs the integ tests in an real fleet. The job bundle is configured to pull the plugins from the default conda channel.

### What is the impact of this change?
Easier to run the integ tests.

### How was this change tested?
Submitted the job and verified it passed.

### Was this change documented?
Yes, added README file.

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
