### PR TITLE
fix: Replace brittle RenderMan plugin name check with rfm2 import check

### DIFF
--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py
@@ -60,11 +60,6 @@ class RenderManHandler(DefaultMayaHandler):
             RuntimeError: If Renderman for Maya was not loaded
         """
 
-        if not maya.cmds.pluginInfo("RenderManForMaya.py", query=True, loaded=True):
-            raise RuntimeError(
-                "MayaClient: The RenderMan for Maya plugin was not loaded. Please verify that it is installed."
-            )
-
         frame = data.get("frame")
         if frame is None:
             raise RuntimeError("MayaClient: start_render called without a frame number.")
@@ -95,7 +90,13 @@ class RenderManHandler(DefaultMayaHandler):
 
         # Note that some overrides are currently not implemented (camera, resolution, etc...)
 
-        import rfm2
+        try:
+            import rfm2
+        except ImportError:
+            raise RuntimeError(
+                "MayaClient: Could not import the rfm2 module. "
+                "Please verify that RenderMan for Maya is installed and loaded."
+            )
 
         rfm2.render.RNDR.set_render_type(rfm2.render.RT_BATCH)
         rfm2.render_with_renderman()

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_renderman_handler.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_renderman_handler.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import pytest
 
-import maya.cmds
 from unittest.mock import patch
 from deadline.maya_adaptor.MayaClient.render_handlers.renderman_handler import RenderManHandler
 
@@ -38,17 +37,12 @@ class TestRenderManHandler:
         # THEN
         mock_cmds.setAttr.assert_called_with("defaultResolution.width", args["image_width"])
 
-    @patch.object(maya.cmds, "pluginInfo")
-    def test_no_renderman(self, plguinInfo) -> None:
+    @patch.dict("sys.modules", {"rfm2": None})
+    def test_no_renderman(self) -> None:
         """Tests that the handler detects missing RenderMan for Maya installation"""
         # GIVEN
         handler = RenderManHandler()
-        plguinInfo.return_value = False
 
         # WHEN/THEN
-        with pytest.raises(RuntimeError) as exc_info:
-            handler.start_render({})
-            assert (
-                str(exc_info.value)
-                == "MayaClient: The RenderMan for Maya plugin was not loaded. Please verify that it is installed."
-            )
+        with pytest.raises(RuntimeError, match="Could not import the rfm2 module"):
+            handler.start_render({"frame": 1})


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/389

### What was the problem/requirement? (What/Why)

The RenderMan for Maya plugin can register under multiple names depending on the version and installation method: `RenderManForMaya.py`, `RenderMan_for_Maya`, or `rfm`. The adaptor's `start_render` method in `renderman_handler.py` only checked for `RenderManForMaya.py` via `maya.cmds.pluginInfo`, causing it to incorrectly report that RenderMan was not loaded when the plugin registered under a different name.

This was reported by a user running RenderMan for Maya 26.3, where the plugin registers as `RenderMan_for_Maya`.

### What was the solution? (How)

Removed the `pluginInfo("RenderManForMaya.py")` check and replaced it with a `try/except ImportError` around `import rfm2`. The `rfm2` module is the RenderMan Python runtime that lives inside the RenderMan for Maya installation directory (`/Applications/Pixar/RenderManForMaya-X.X/scripts/rfm2/`). It only becomes importable when the RenderMan plugin is installed and loaded, because the plugin's startup code adds its `scripts/` directory to `sys.path`.

This is a better detection mechanism because:
- It works regardless of what name the plugin registered under
- It verifies the full RenderMan Python runtime is functional, not just that a name string was registered
- It doesn't require maintaining a growing list of possible plugin names

### What is the impact of this change?

Users whose RenderMan plugin registers under alternate names (`RenderMan_for_Maya`, `rfm`, etc.) will no longer get false "plugin not loaded" errors. When RenderMan is genuinely missing, the error message is clear and actionable:

> `MayaClient: Could not import the rfm2 module. Please verify that RenderMan for Maya is installed and loaded.`

### How was this change tested?

**Unit tests:** All 155 unit tests pass. The `test_no_renderman` test was updated to use `@patch.dict("sys.modules", {"rfm2": None})` to simulate a missing `rfm2` module, ensuring the test is robust regardless of whether `rfm2` is available in the test environment.

**Local adaptor testing (maya-openjd run):** Three scenarios were tested on macOS with Maya 2026:

1. **With RenderMan installed (version-incompatible scene):** Loaded `job_bundle_output_tests/renderman/scene/renderman.ma`. The adaptor failed at scene load because RenderMan 26.3 is incompatible with Maya 2026. Notably, the logs showed the plugin registered as `RenderMan_for_Maya` — confirming the original bug where the old `pluginInfo("RenderManForMaya.py")` check would have missed it.

2. **Old code (same scene):** Temporarily reverted the fix and ran the same test. Identical scene-load failure. Both old and new code behave the same when the failure occurs before `start_render`.

3. **No RenderMan installed (new code):** Temporarily hid the RenderMan installation by renaming `/Applications/Pixar/RenderManForMaya-26.3`. Used a minimal Maya scene with no RenderMan node dependencies. The scene loaded successfully, the adaptor reached `start_render`, `import rfm2` raised `ModuleNotFoundError`, and the new `RuntimeError` was displayed:
   ```
   File "renderman_handler.py", line 94, in start_render
       import rfm2
   ModuleNotFoundError: No module named 'rfm2'

   RuntimeError: MayaClient: Could not import the rfm2 module. Please verify that RenderMan for Maya is installed and loaded.
   ```
   This confirmed the `import rfm2` approach works because `rfm2` is not a standalone pip package — it's bundled inside the RenderMan installation directory and only added to `sys.path` when the plugin loads.

**Lint:** ruff, black, and mypy all pass clean.

#### Integ test result

N/A — the change is limited to the `start_render` error handling path in the RenderMan handler. No submitter or job bundle logic was modified.

#### Installer test result

N/A — no changes to `installer/` or file additions/removals in `src/`.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No — this change does not affect job bundle generation. It only modifies the adaptor's runtime render path.

### Was this change documented?

- Docstrings: No changes needed — the `start_render` docstring already says `Raises: RuntimeError: If Renderman for Maya was not loaded`, which remains accurate.
- README/DEVELOPMENT.md: No changes needed.
- Schema files: No changes.

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No. The adaptor still raises `RuntimeError` when RenderMan is not available, just with a different detection mechanism and slightly different error message. Jobs submitted with older versions of the submitter will work identically.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
