### PR TITLE
fix: Handle renderman texture path mapping

### DIFF
--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -461,6 +461,12 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
             if action_name in self.init_data:
                 self._action_queue.enqueue_action(self._action_from_action_item(action_name))
 
+        # RenderMan's texture manager bypasses Maya's dirmap, so we need to
+        # manually apply path mapping to RenderMan texture node attributes
+        # after the scene is loaded.
+        if self.init_data["renderer"] == "renderman" and self.path_mapping_rules:
+            self._action_queue.enqueue_action(Action("renderman_texture_pathmapping", {}))
+
     def on_start(self) -> None:
         """
         For job stickiness. Will start everything required for the Task.

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/renderman_handler.py
@@ -1,8 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from .default_maya_handler import DefaultMayaHandler
+from ..dir_map import DirectoryMapping
 
 import maya.cmds
+
+# RenderMan node types that have a "filename" attribute containing texture paths
+_RMAN_TEXTURE_NODE_TYPES = [
+    "PxrTexture",
+    "PxrNormalMap",
+    "PxrBump",
+    "PxrPtexture",
+    "PxrMultiTexture",
+]
 
 
 class RenderManHandler(DefaultMayaHandler):
@@ -14,6 +24,7 @@ class RenderManHandler(DefaultMayaHandler):
         """
         super().__init__()
         self.render_layer = "defaultRenderLayer"
+        self.action_dict["renderman_texture_pathmapping"] = self.set_renderman_texture_pathmapping
 
     def set_render_layer(self, data: dict) -> None:
         """
@@ -48,6 +59,36 @@ class RenderManHandler(DefaultMayaHandler):
         """
         xresolution = int(data.get("image_width", 0))
         maya.cmds.setAttr("defaultResolution.width", xresolution)
+
+    def set_renderman_texture_pathmapping(self, data: dict) -> None:
+        """
+        Applies path mapping to RenderMan texture node attributes.
+
+        RfM's texture manager reads texture paths directly from Maya node
+        attributes and bypasses Maya's dirmap. This method manually applies
+        dirmap to the filename attributes of RenderMan texture nodes so that
+        the paths are correct when the texture manager processes them.
+
+        This follows the same pattern as set_cache_pathmapping in the base
+        class, which solves the same problem for cache node attributes.
+        """
+        if not DirectoryMapping.get_activated():
+            return
+
+        # Iterate each RenderMan node type that references texture files.
+        # All these node types have a "filename" attribute by definition.
+        for node_type in _RMAN_TEXTURE_NODE_TYPES:
+            for node in maya.cmds.ls(type=node_type) or []:
+                attr: str = f"{node}.filename"
+                old_path: str = maya.cmds.getAttr(attr)
+                # Apply dirmap to convert the path (e.g. Windows -> Linux)
+                new_path: str = DirectoryMapping.convert(old_path)
+                if new_path != old_path:
+                    maya.cmds.setAttr(attr, new_path, type="string")
+                    print(
+                        f"RenderMan texture pathmapping: {old_path} -> {new_path}",
+                        flush=True,
+                    )
 
     def start_render(self, data: dict) -> None:
         """

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -440,6 +440,64 @@ class TestMayaAdaptor_on_start:
                 expected_json, mock_open.return_value.__enter__.return_value
             )
 
+    @pytest.mark.parametrize(
+        "renderer, has_rules, expected",
+        [
+            ("renderman", True, True),
+            ("renderman", False, False),
+            ("arnold", True, False),
+            ("mayaSoftware", True, False),
+        ],
+    )
+    @patch.object(MayaAdaptor, "map_path")
+    @patch.object(MayaAdaptor, "path_mapping_rules", new_callable=PropertyMock)
+    @patch.object(MayaAdaptor, "_action_queue")
+    def test_renderman_texture_pathmapping_action_enqueued(
+        self,
+        mock_actions_queue: Mock,
+        mock_rules: Mock,
+        mock_map: Mock,
+        renderer: str,
+        has_rules: bool,
+        expected: bool,
+    ):
+        """Tests that renderman_texture_pathmapping action is enqueued only for renderman with rules"""
+        # GIVEN
+        if has_rules:
+            mock_rules.return_value = [
+                PathMappingRule(
+                    source_path_format="windows",
+                    source_path="C:\\Users",
+                    destination_os="linux",
+                    destination_path="/mnt/storage",
+                )
+            ]
+        else:
+            mock_rules.return_value = []
+
+        adaptor = MayaAdaptor(
+            {
+                "renderer": renderer,
+                "scene_file": "/path/to/file",
+                "project_path": "/path/to/dir",
+                "animation": True,
+                "version": 2022,
+                "render_layer": "layer",
+            }
+        )
+
+        # WHEN
+        adaptor._populate_action_queue()
+
+        # THEN
+        enqueued_actions = [
+            call.args[0].name for call in mock_actions_queue.enqueue_action.call_args_list
+        ]
+        if expected:
+            assert "renderman_texture_pathmapping" in enqueued_actions
+        else:
+            assert "renderman_texture_pathmapping" not in enqueued_actions
+
     @patch.object(MayaAdaptor, "_maya_is_running", False)
     @patch("deadline.maya_adaptor.MayaAdaptor.adaptor.ActionsQueue.__len__", return_value=1)
     @patch("deadline.maya_adaptor.MayaAdaptor.adaptor.LoggingSubprocess")

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_renderman_handler.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_renderman_handler.py
@@ -46,3 +46,57 @@ class TestRenderManHandler:
         # WHEN/THEN
         with pytest.raises(RuntimeError, match="Could not import the rfm2 module"):
             handler.start_render({"frame": 1})
+
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.renderman_handler.DirectoryMapping")
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.renderman_handler.maya.cmds")
+    def test_renderman_texture_pathmapping_remaps_paths(self, mock_cmds, mock_dirmap) -> None:
+        """Tests that texture paths on RenderMan nodes are remapped via dirmap"""
+        # GIVEN
+        handler = RenderManHandler()
+        mock_dirmap.get_activated.return_value = True
+        mock_cmds.ls.side_effect = lambda type=None: (["udim_tex"] if type == "PxrTexture" else [])
+        mock_cmds.getAttr.return_value = "C:\\Users\\artist\\color.<UDIM>.png"
+        mock_dirmap.convert.return_value = "/mnt/storage/color.<UDIM>.png"
+
+        # WHEN
+        handler.set_renderman_texture_pathmapping({})
+
+        # THEN
+        mock_cmds.setAttr.assert_called_with(
+            "udim_tex.filename", "/mnt/storage/color.<UDIM>.png", type="string"
+        )
+
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.renderman_handler.DirectoryMapping")
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.renderman_handler.maya.cmds")
+    def test_renderman_texture_pathmapping_skips_when_dirmap_inactive(
+        self, mock_cmds, mock_dirmap
+    ) -> None:
+        """Tests that no remapping occurs when dirmap is not active"""
+        # GIVEN
+        handler = RenderManHandler()
+        mock_dirmap.get_activated.return_value = False
+
+        # WHEN
+        handler.set_renderman_texture_pathmapping({})
+
+        # THEN
+        mock_cmds.ls.assert_not_called()
+
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.renderman_handler.DirectoryMapping")
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.renderman_handler.maya.cmds")
+    def test_renderman_texture_pathmapping_skips_unchanged_paths(
+        self, mock_cmds, mock_dirmap
+    ) -> None:
+        """Tests that setAttr is not called when the path is unchanged"""
+        # GIVEN
+        handler = RenderManHandler()
+        mock_dirmap.get_activated.return_value = True
+        mock_cmds.ls.side_effect = lambda type=None: (["tex1"] if type == "PxrTexture" else [])
+        mock_cmds.getAttr.return_value = "/already/linux/path.png"
+        mock_dirmap.convert.return_value = "/already/linux/path.png"
+
+        # WHEN
+        handler.set_renderman_texture_pathmapping({})
+
+        # THEN
+        mock_cmds.setAttr.assert_not_called()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/365

### What was the problem/requirement? (What/Why)

When a RenderMan job with UDIM textures is submitted from Windows to a Linux worker fleet, the texture paths are not remapped. RenderMan's texture manager (`rfm2.txmanager_maya`) reads texture paths directly from Maya node attributes, bypassing Maya's `dirmap` path mapping system. This causes RenderMan to look for textures at the original Windows path on the Linux worker, producing `T02041 {ERROR} Can't open texture atlas` errors. The render completes with exit code 0 but the output image is missing all textures — a silent data-correctness failure.

### What was the solution? (How)

Added a new `renderman_texture_pathmapping` action that runs after the scene is loaded. It iterates all RenderMan texture node types (`PxrTexture`, `PxrNormalMap`, `PxrBump`, `PxrPtexture`, `PxrMultiTexture`) and manually applies Maya's `dirmap` to their `filename` attributes. This rewrites the stored paths from Windows to Linux format before RenderMan's texture manager reads them.

This follows the same pattern already used by `set_cache_pathmapping` in `DefaultMayaHandler`, which solves the identical problem for Bifrost cache node attributes that also bypass `dirmap`.

**Changes:**
- `adaptor.py`: Enqueues the `renderman_texture_pathmapping` action at the end of the init queue when renderer is `renderman` and path mapping rules exist
- `renderman_handler.py`: New `set_renderman_texture_pathmapping()` method that applies dirmap to RenderMan texture node filename attributes

### What is the impact of this change?

- RenderMan jobs with UDIM textures (and non-UDIM textures) now render correctly when submitted cross-platform (e.g., Windows → Linux)
- No impact on other renderers (Arnold, V-Ray, Redshift, Maya Software)
- No impact on same-OS submissions (the method is a no-op when dirmap doesn't change the path)

### How was this change tested?

- 4 new unit tests added (3 in `test_renderman_handler.py`, 1 in `test_adaptor.py`)
- All 58 unit tests pass
- mypy passes with no errors on all changed files
- Manually tested end-to-end: submitted a RenderMan scene with 4 UDIM texture tiles from Windows to a Linux fleet. Before the fix: `T02041` texture atlas errors, missing textures in output. After the fix: no errors, textures render correctly

#### Integ test result

```
2026/04/30 10:39:07-07:00 test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
2026/04/30 10:39:07-07:00 [gw0][36m [ 25%] [0m[32mPASSED[0m test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
2026/04/30 10:39:12-07:00 test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 
2026/04/30 10:39:12-07:00 [gw0][36m [ 50%] [0m[32mPASSED[0m test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 
2026/04/30 10:39:13-07:00 test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Arnold Test] 
2026/04/30 10:39:13-07:00 [gw0][36m [ 75%] [0m[32mPASSED[0m test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Arnold Test] 
2026/04/30 10:39:14-07:00 test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[VRay Test] 
2026/04/30 10:39:15-07:00 [gw0][36m [100%] [0m[32mPASSED[0m test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[VRay Test]
```

```
2026/04/30 10:39:51-07:00 test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
2026/04/30 10:39:51-07:00 [gw0][36m [ 25%] [0m[32mPASSED[0m test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
2026/04/30 10:40:38-07:00 test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
2026/04/30 10:40:38-07:00 [gw0][36m [ 50%] [0m[32mPASSED[0m test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
2026/04/30 10:40:54-07:00 test/integ/test_maya_adaptors.py::TestAdaptors::test_mtoa_scene_adaptor 
2026/04/30 10:40:54-07:00 [gw0][36m [ 75%] [0m[32mPASSED[0m test/integ/test_maya_adaptors.py::TestAdaptors::test_mtoa_scene_adaptor 
2026/04/30 10:41:16-07:00 test/integ/test_maya_adaptors.py::TestAdaptors::test_vray_scene_adaptor 
2026/04/30 10:41:17-07:00 [gw0][36m [100%] [0m[32mPASSED[0m test/integ/test_maya_adaptors.py::TestAdaptors::test_vray_scene_adaptor 
```

#### Installer test result

No installer changes.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
```

Timestamp: 2026-04-30T17:39:37.498063+00:00
Running job bundle output test: C:\Users\RDP.EC2AMAZ-M9FSML7\workplace\deadline-cloud-for-maya\job_bundle_output_tests\cube

cube
Test succeeded

Timestamp: 2026-04-30T17:39:39.100400+00:00
Running job bundle output test: C:\Users\RDP.EC2AMAZ-M9FSML7\workplace\deadline-cloud-for-maya\job_bundle_output_tests\layers

layers
Test succeeded

Timestamp: 2026-04-30T17:39:40.744692+00:00
Running job bundle output test: C:\Users\RDP.EC2AMAZ-M9FSML7\workplace\deadline-cloud-for-maya\job_bundle_output_tests\layers_no_variation

layers_no_variation
Test succeeded

Timestamp: 2026-04-30T17:39:41.952845+00:00
Running job bundle output test: C:\Users\RDP.EC2AMAZ-M9FSML7\workplace\deadline-cloud-for-maya\job_bundle_output_tests\referenced_layers

referenced_layers
Test succeeded
```

### Was this change documented?

- Yes, all new methods have docstrings explaining what they do and why
- No README/DEVELOPMENT.md changes needed — this is a bug fix, not a new user-facing feature
- No schema changes needed — the new action is enqueued internally by the adaptor, not driven by init-data

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No. This change is fully backwards compatible. It adds a new internal action that only runs for RenderMan jobs with path mapping rules. Existing jobs, templates, and submitter versions are unaffected.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
