### PR TITLE
fix: populate cameras dropdown when submitter dialog opens (#384)

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -45,6 +45,30 @@ import time
 logger = getLogger(__name__)
 
 
+def _populate_selectable_cameras(
+    render_settings: "RenderSubmitterUISettings",
+    render_layers: list["RenderLayerData"],
+) -> None:
+    """Populate the selectable camera lists on render_settings for the UI dropdowns.
+
+    - current_layer_selectable_cameras: all renderable cameras in the current layer
+    - all_layer_selectable_cameras: only cameras common to ALL render layers (intersection)
+    """
+    current_layer_selectable_cameras: list[str] = get_renderable_camera_names()
+    render_settings.current_layer_selectable_cameras = [ALL_CAMERAS] + sorted(
+        current_layer_selectable_cameras
+    )
+
+    all_layer_selectable_cameras_set: set[str] = set(render_layers[0].renderable_camera_names)
+    for layer in render_layers:
+        all_layer_selectable_cameras_set = all_layer_selectable_cameras_set.intersection(
+            layer.renderable_camera_names
+        )
+    render_settings.all_layer_selectable_cameras = [ALL_CAMERAS] + sorted(
+        all_layer_selectable_cameras_set
+    )
+
+
 @dataclass
 class RenderLayerData:
     name: str
@@ -535,20 +559,8 @@ def on_create_job_bundle_callback(
 
     render_layers: list[RenderLayerData] = _set_render_layer_data()
 
-    # Tell the settings tab the selectable cameras when only the current layer is in the job
-    current_layer_selectable_cameras: list[str] = get_renderable_camera_names()
-    render_settings.current_layer_selectable_cameras = [ALL_CAMERAS] + sorted(
-        current_layer_selectable_cameras
-    )
-
-    # Tell the settings tab the selectable cameras when all layers are in the job
-    all_layer_selectable_cameras_set: set[str] = set(render_layers[0].renderable_camera_names)
-    for layer in render_layers:
-        all_layer_selectable_cameras_set = all_layer_selectable_cameras_set.intersection(
-            layer.renderable_camera_names
-        )
-    all_layer_selectable_cameras: list[str] = list(sorted(all_layer_selectable_cameras_set))
-    render_settings.all_layer_selectable_cameras = [ALL_CAMERAS] + all_layer_selectable_cameras
+    # Tell the settings tab the selectable cameras
+    _populate_selectable_cameras(render_settings, render_layers)
 
     # if submitting, warn if the current scene has been modified
     scene_modified = maya.cmds.file(q=True, mf=True) == 1
@@ -623,8 +635,8 @@ def on_create_job_bundle_callback(
         settings=settings,
         renderers=renderers,
         render_layers=submit_render_layers,
-        all_layer_selectable_cameras=all_layer_selectable_cameras,
-        current_layer_selectable_cameras=current_layer_selectable_cameras,
+        all_layer_selectable_cameras=render_settings.all_layer_selectable_cameras,
+        current_layer_selectable_cameras=render_settings.current_layer_selectable_cameras,
     )
     parameter_values = _get_parameter_values(
         settings, renderers, submit_render_layers, cast(list[dict[str, Any]], queue_parameters)
@@ -688,6 +700,9 @@ def show_maya_render_submitter(
     render_layers: list[RenderLayerData] = _set_render_layer_data()
     print(f"Render layers processed at {time.time()}")
     all_renderers: set[str] = {layer_data.renderer_name for layer_data in render_layers}
+
+    # Populate the selectable cameras for the UI dropdowns
+    _populate_selectable_cameras(render_settings, render_layers)
 
     auto_detected_attachments = AssetReferences()
     introspector = AssetIntrospector()

--- a/test/unit/deadline_submitter_for_maya/scripts/test_submitter.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_submitter.py
@@ -3,8 +3,14 @@
 import sys
 from unittest.mock import Mock
 
+import pytest
+
 
 def test_frame_override_has_text_validation():
+    # Modules to clean up after the test
+    modules_to_restore = {}
+    modules_to_remove = []
+
     try:
         # Create new mocks. We need to use a real class for QWidget instead of a Mock() so that the
         # SceneSettingsWidget which is a subclass of QWidget actually runs its methods (instead its
@@ -18,15 +24,48 @@ def test_frame_override_has_text_validation():
         mock_q_widgets = Mock()
         mock_line_edit = Mock()
 
-        sys.modules["qtpy.QtWidgets"] = mock_q_widgets
         mock_q_widgets.QWidget = MockQWidget
         mock_q_widgets.QLineEdit = mock_line_edit
 
-        # Reload SceneSettingsWidget with the new mocks in place.
-        del sys.modules["deadline.maya_submitter.ui.components.scene_settings_tab"]
+        # Mock all modules needed by scene_settings_tab.py and its transitive imports
+        mocks = {
+            "qtpy.QtWidgets": mock_q_widgets,
+            "qtpy.QtCore": Mock(),
+            "qtpy.QtGui": Mock(),
+            "deadline.client.ui": Mock(),
+            "maya": Mock(),
+            "maya.cmds": Mock(),
+            "maya.mel": Mock(),
+            "maya.app": Mock(),
+            "maya.app.renderSetup": Mock(),
+            "maya.app.renderSetup.model": Mock(),
+            "maya.app.renderSetup.model.renderSetupPreferences": Mock(),
+        }
+
+        for mod_name, mock_obj in mocks.items():
+            if mod_name in sys.modules:
+                modules_to_restore[mod_name] = sys.modules[mod_name]
+            else:
+                modules_to_remove.append(mod_name)
+            sys.modules[mod_name] = mock_obj
+
+        # Remove cached imports of the module under test so it reimports with mocks
+        modules_to_clear = [
+            "deadline.maya_submitter.ui",
+            "deadline.maya_submitter.ui.components",
+            "deadline.maya_submitter.ui.components.scene_settings_tab",
+            "deadline.maya_submitter.render_layers",
+            "deadline.maya_submitter.cameras",
+            "deadline.maya_submitter.data_classes",
+        ]
+        for mod_name in modules_to_clear:
+            if mod_name in sys.modules:
+                modules_to_restore.setdefault(mod_name, sys.modules[mod_name])
+                del sys.modules[mod_name]
+
         from deadline.maya_submitter.ui.components.scene_settings_tab import SceneSettingsWidget
 
-        # Stub out a method
+        # Stub out methods that interact with Qt state
         SceneSettingsWidget._configure_settings = Mock()  # type: ignore
         SceneSettingsWidget._fill_cameras_box = Mock()  # type: ignore
 
@@ -39,5 +78,156 @@ def test_frame_override_has_text_validation():
         assert mock_line_edit.call_count > 0
 
     finally:
-        # Reset QtWidgets mock
-        sys.modules["qtpy.QtWidgets"] = Mock()
+        # Restore original module state
+        for mod_name in modules_to_remove:
+            sys.modules.pop(mod_name, None)
+        for mod_name, original in modules_to_restore.items():
+            if original is not None:
+                sys.modules[mod_name] = original
+            else:
+                sys.modules.pop(mod_name, None)
+
+
+class TestCameraPopulation:
+    """Tests that _populate_selectable_cameras correctly populates render_settings."""
+
+    @pytest.fixture(autouse=True)
+    def mock_maya_modules(self):
+        """Mock Maya modules so we can import deadline.maya_submitter modules."""
+        mocks = {
+            "maya": Mock(),
+            "maya.cmds": Mock(),
+            "maya.mel": Mock(),
+            "maya.app": Mock(),
+            "maya.app.renderSetup": Mock(),
+            "maya.app.renderSetup.model": Mock(),
+            "maya.app.renderSetup.model.renderSetupPreferences": Mock(),
+        }
+        saved = {}
+        added = []
+        for mod_name, mock_obj in mocks.items():
+            if mod_name in sys.modules:
+                saved[mod_name] = sys.modules[mod_name]
+            else:
+                added.append(mod_name)
+            sys.modules[mod_name] = mock_obj
+
+        modules_to_clear = [
+            "deadline.maya_submitter.cameras",
+            "deadline.maya_submitter.render_layers",
+            "deadline.maya_submitter.data_classes",
+            "deadline.maya_submitter.maya_render_submitter",
+        ]
+        for mod_name in modules_to_clear:
+            if mod_name in sys.modules:
+                saved[mod_name] = sys.modules.pop(mod_name)
+
+        yield
+
+        for mod_name in added:
+            sys.modules.pop(mod_name, None)
+        for mod_name, original in saved.items():
+            if original is not None:
+                sys.modules[mod_name] = original
+            else:
+                sys.modules.pop(mod_name, None)
+
+    def _make_layer(self, renderable_cameras):
+        """Create a mock render layer with the given camera names."""
+        layer = Mock()
+        layer.renderable_camera_names = renderable_cameras
+        return layer
+
+    def test_cameras_populated_with_multiple_layers(self):
+        """All-layers mode should show only cameras common to ALL layers (intersection)."""
+        from unittest.mock import patch
+
+        from deadline.maya_submitter.cameras import ALL_CAMERAS
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import _populate_selectable_cameras
+
+        render_settings = RenderSubmitterUISettings()
+        render_layers = [
+            self._make_layer(["cam_front", "cam_side", "cam_top"]),
+            self._make_layer(["cam_front", "cam_side"]),
+        ]
+
+        with patch(
+            "deadline.maya_submitter.maya_render_submitter.get_renderable_camera_names",
+            return_value=["cam_front", "cam_side", "cam_top"],
+        ):
+            _populate_selectable_cameras(render_settings, render_layers)
+
+        assert render_settings.current_layer_selectable_cameras == [
+            ALL_CAMERAS,
+            "cam_front",
+            "cam_side",
+            "cam_top",
+        ]
+        assert render_settings.all_layer_selectable_cameras == [
+            ALL_CAMERAS,
+            "cam_front",
+            "cam_side",
+        ]
+
+    def test_cameras_default_without_population(self):
+        """Without camera population, dropdown only shows ALL_CAMERAS (the bug)."""
+        from deadline.maya_submitter.cameras import ALL_CAMERAS
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+
+        render_settings = RenderSubmitterUISettings()
+
+        assert render_settings.all_layer_selectable_cameras == [ALL_CAMERAS]
+        assert render_settings.current_layer_selectable_cameras == [ALL_CAMERAS]
+
+    def test_cameras_single_layer(self):
+        """With a single render layer, all its cameras appear in both modes."""
+        from unittest.mock import patch
+
+        from deadline.maya_submitter.cameras import ALL_CAMERAS
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import _populate_selectable_cameras
+
+        render_settings = RenderSubmitterUISettings()
+        render_layers = [self._make_layer(["persp", "renderCam"])]
+
+        with patch(
+            "deadline.maya_submitter.maya_render_submitter.get_renderable_camera_names",
+            return_value=["persp", "renderCam"],
+        ):
+            _populate_selectable_cameras(render_settings, render_layers)
+
+        assert render_settings.all_layer_selectable_cameras == [
+            ALL_CAMERAS,
+            "persp",
+            "renderCam",
+        ]
+        assert render_settings.current_layer_selectable_cameras == [
+            ALL_CAMERAS,
+            "persp",
+            "renderCam",
+        ]
+
+    def test_cameras_sorted_alphabetically(self):
+        """Camera names should be sorted alphabetically after ALL_CAMERAS."""
+        from unittest.mock import patch
+
+        from deadline.maya_submitter.cameras import ALL_CAMERAS
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import _populate_selectable_cameras
+
+        render_settings = RenderSubmitterUISettings()
+        render_layers = [self._make_layer(["zebra_cam", "alpha_cam", "middle_cam"])]
+
+        with patch(
+            "deadline.maya_submitter.maya_render_submitter.get_renderable_camera_names",
+            return_value=["zebra_cam", "alpha_cam", "middle_cam"],
+        ):
+            _populate_selectable_cameras(render_settings, render_layers)
+
+        assert render_settings.current_layer_selectable_cameras == [
+            ALL_CAMERAS,
+            "alpha_cam",
+            "middle_cam",
+            "zebra_cam",
+        ]


### PR DESCRIPTION
## What was the problem

The Cameras dropdown in the Maya submitter UI only showed "All Renderable Cameras" instead of listing individual scene cameras. This prevented artists from selecting a specific camera for their render job.

**Root cause:** Commit 321adbd refactored `show_maya_render_submitter` by moving `on_create_job_bundle_callback` from a nested closure to a module-level function. During this refactoring, the camera population code was moved INTO `on_create_job_bundle_callback` (which only runs at submit time) but was NOT kept in `show_maya_render_submitter` (which runs at dialog open time). As a result, the camera lists retained their default values of `[ALL_CAMERAS]` when the dialog opened.

GitHub issue: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/384

## What was the solution

Added the camera population code back into `show_maya_render_submitter()`, after `_set_render_layer_data()` returns and before the dialog is created. This mirrors the same logic already in `on_create_job_bundle_callback`.

Also fixed `test_frame_override_has_text_validation` which was broken since its introduction (commit 5467cbf) due to:
1. Using `del sys.modules[...]` on a module that was never imported (KeyError)
2. Not mocking transitive dependencies (maya.*, qtpy.QtCore, qtpy.QtGui, deadline.client.ui)

## How was this change tested

- Unit tests: 39 submitter tests pass, 79 adaptor tests pass
- Linting: ruff check + black --check pass
- The previously-failing test_frame_override_has_text_validation now passes

 Manual testing in Maya 2026:
  
  1. Created scene with 3 cameras (camera1, camera2, camera3) + persp, all marked renderable
  2. Created 2 render layers (layer_A, layer_B) with per-layer camera overrides via Render Setup (camera3 disabled on layer_A, camera2 disabled on layer_B)
  3. Opened submitter → Camera dropdown shows all 4 cameras ✅ (previously only showed "All Renderable Cameras")
  4. Switched Layers to "All Renderable Layers" → Camera dropdown shows only camera1 and persp (intersection) ✅
  5. Switched Layers to "Current Layer" → Camera dropdown shows camera1, camera2, persp (current layer's renderable cameras) ✅


<img width="542" height="721" alt="image" src="https://github.com/user-attachments/assets/a27c1391-4a98-4825-afcf-d70547254a62" />

<img width="546" height="729" alt="image" src="https://github.com/user-attachments/assets/ebd71003-2d75-4d5b-a6c5-a8ccbcfd9701" />
