### PR TITLE
feat: Extract submitter logic with SubmissionContext pattern

### DIFF
--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -476,9 +476,7 @@ def _get_parameter_values(
             )
 
     parameter_values.extend(
-        {"name": param["name"], "value": param.get("value", param.get("default", ""))}
-        for param in queue_parameters
-        if "value" in param or "default" in param
+        {"name": param["name"], "value": param["value"]} for param in queue_parameters
     )
 
     return parameter_values
@@ -593,10 +591,18 @@ def create_submission_context() -> SubmissionContext:
     )
 
 
+@dataclass
+class PreparedRenderLayers:
+    """Result of filtering and annotating render layers for submission."""
+
+    layers: list[RenderLayerData]
+    renderers: set[str]
+
+
 def _prepare_render_layers_for_submission(
     settings: RenderSubmitterUISettings,
     context: SubmissionContext,
-) -> tuple[list[RenderLayerData], set[str]]:
+) -> PreparedRenderLayers:
     """Filter and annotate render layers based on settings.
 
     This is a pure transformation — no Maya scene queries. It works on
@@ -608,7 +614,7 @@ def _prepare_render_layers_for_submission(
         context: Pre-computed submission context.
 
     Returns:
-        A tuple of (submit_render_layers, renderers).
+        PreparedRenderLayers with the filtered layers and renderer set.
     """
     render_layers = deepcopy(context.render_layers)
 
@@ -630,6 +636,8 @@ def _prepare_render_layers_for_submission(
         layer.frame_range != first_frame_range for layer in submit_render_layers
     )
 
+    # If there are multiple frame ranges and we're not overriding the range,
+    # then we create per-layer Frames parameters.
     if per_layer_frames_parameters:
         for layer_data in submit_render_layers:
             layer_data.frames_parameter_name = f"{layer_data.display_name}Frames"
@@ -657,7 +665,7 @@ def _prepare_render_layers_for_submission(
 
     renderers: set[str] = {layer_data.renderer_name for layer_data in submit_render_layers}
 
-    return submit_render_layers, renderers
+    return PreparedRenderLayers(layers=submit_render_layers, renderers=renderers)
 
 
 def get_default_job_template() -> dict[str, Any]:
@@ -687,13 +695,13 @@ def get_job_template_for_submission(
         context = create_submission_context()
 
     default_job_template = get_default_job_template()
-    submit_render_layers, renderers = _prepare_render_layers_for_submission(settings, context)
+    prepared = _prepare_render_layers_for_submission(settings, context)
 
     job_template = _get_job_template(
         default_job_template=default_job_template,
         settings=settings,
-        renderers=renderers,
-        render_layers=submit_render_layers,
+        renderers=prepared.renderers,
+        render_layers=prepared.layers,
         all_layer_selectable_cameras=context.all_layer_selectable_cameras,
         current_layer_selectable_cameras=context.current_layer_selectable_cameras,
     )
@@ -729,9 +737,9 @@ def get_parameter_values_for_submission(
     if queue_parameters is None:
         queue_parameters = []
 
-    submit_render_layers, renderers = _prepare_render_layers_for_submission(settings, context)
+    prepared = _prepare_render_layers_for_submission(settings, context)
 
-    return _get_parameter_values(settings, renderers, submit_render_layers, queue_parameters)
+    return _get_parameter_values(settings, prepared.renderers, prepared.layers, queue_parameters)
 
 
 def get_asset_references_for_submission(
@@ -749,9 +757,9 @@ def get_asset_references_for_submission(
 
 
 def get_queue_parameters(
-    farm_id: Optional[str] = None,
-    queue_id: Optional[str] = None,
-    initial_values: Optional[dict[str, Any]] = None,
+    farm_id_override: Optional[str] = None,
+    queue_id_override: Optional[str] = None,
+    initial_values_override: Optional[dict[str, Any]] = None,
 ) -> list[dict[str, Any]]:
     """Get queue parameters from Deadline Cloud for external API usage.
 
@@ -761,9 +769,9 @@ def get_queue_parameters(
     going through the UI.
 
     Args:
-        farm_id: The farm ID. If not provided, uses the default from settings.
-        queue_id: The queue ID. If not provided, uses the default from settings.
-        initial_values: Optional dict of {parameter_name: value} to override
+        farm_id_override: The farm ID. If not provided, uses the default from settings.
+        queue_id_override: The queue ID. If not provided, uses the default from settings.
+        initial_values_override: Optional dict of {parameter_name: value} to override
             default parameter values.
 
     Returns:
@@ -773,10 +781,10 @@ def get_queue_parameters(
     Raises:
         DeadlineOperationError: If farm_id or queue_id are not configured.
     """
-    if farm_id is None:
-        farm_id = get_setting("defaults.farm_id")
-    if queue_id is None:
-        queue_id = get_setting("defaults.queue_id")
+    farm_id = farm_id_override if farm_id_override is not None else get_setting("defaults.farm_id")
+    queue_id = (
+        queue_id_override if queue_id_override is not None else get_setting("defaults.queue_id")
+    )
 
     if not farm_id or not queue_id:
         raise DeadlineOperationError(
@@ -786,10 +794,10 @@ def get_queue_parameters(
 
     queue_parameters = get_queue_parameter_definitions(farmId=farm_id, queueId=queue_id)
 
-    if initial_values:
+    if initial_values_override:
         for parameter in queue_parameters:
-            if parameter["name"] in initial_values:
-                parameter["value"] = initial_values[parameter["name"]]
+            if parameter["name"] in initial_values_override:
+                parameter["value"] = initial_values_override[parameter["name"]]
 
     return cast(list[dict[str, Any]], queue_parameters)
 

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -11,7 +11,11 @@ from dataclasses import dataclass
 
 import maya.cmds  # pylint: disable=import-error
 
-from deadline.client.api import get_deadline_cloud_library_telemetry_client
+from deadline.client.api import (
+    get_deadline_cloud_library_telemetry_client,
+    get_queue_parameter_definitions,
+)
+from deadline.client.config import get_setting
 from deadline.client.job_bundle.parameters import JobParameter
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint: disable=import-error
@@ -459,18 +463,22 @@ def _get_parameter_values(
                 conda_param = param
         # Remove the deadline_cloud_for_maya/maya-openjd package
         if rez_param:
+            current_value = rez_param.get("value", rez_param.get("default", ""))
             rez_param["value"] = " ".join(
                 pkg
-                for pkg in rez_param["value"].split()
+                for pkg in current_value.split()
                 if not pkg.startswith("deadline_cloud_for_maya")
             )
         if conda_param:
+            current_value = conda_param.get("value", conda_param.get("default", ""))
             conda_param["value"] = " ".join(
-                pkg for pkg in conda_param["value"].split() if not pkg.startswith("maya-openjd")
+                pkg for pkg in current_value.split() if not pkg.startswith("maya-openjd")
             )
 
     parameter_values.extend(
-        {"name": param["name"], "value": param["value"]} for param in queue_parameters
+        {"name": param["name"], "value": param.get("value", param.get("default", ""))}
+        for param in queue_parameters
+        if "value" in param or "default" in param
     )
 
     return parameter_values
@@ -543,46 +551,67 @@ def _set_render_layer_data() -> list[RenderLayerData]:
     return render_layers
 
 
-def on_create_job_bundle_callback(
-    widget: SubmitJobToDeadlineDialog,
-    job_bundle_dir: str,
-    settings: RenderSubmitterUISettings,
-    queue_parameters: list[JobParameter],
-    asset_references: AssetReferences,
-    host_requirements: Optional[dict[str, Any]] = None,
-    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
-) -> dict[str, Any]:
-    with open(Path(__file__).parent / "default_maya_job_template.yaml") as fh:
-        default_job_template = yaml.safe_load(fh)
+@dataclass
+class SubmissionContext:
+    """Pre-computed scene data for submission.
 
-    render_settings = _set_render_setting()
+    Caches expensive Maya scene queries (render layer switching, camera
+    enumeration, etc.) so that multiple submission functions can share
+    the same data without redundant computation.
 
-    render_layers: list[RenderLayerData] = _set_render_layer_data()
+    Use create_submission_context() to build an instance.
+    """
 
-    # Tell the settings tab the selectable cameras
-    _populate_selectable_cameras(render_settings, render_layers)
+    render_layers: list[RenderLayerData]
+    current_layer_selectable_cameras: list[str]
+    all_layer_selectable_cameras: list[str]
 
-    # if submitting, warn if the current scene has been modified
-    scene_modified = maya.cmds.file(q=True, mf=True) == 1
-    if scene_modified and purpose == JobBundlePurpose.SUBMISSION:
-        scene_name = maya.cmds.file(q=True, sn=True)
-        button = maya.cmds.confirmDialog(
-            title="Warning: Scene Changes not Saved",
-            message=(
-                "The scene has unsaved local changes that will not be included in the job submission.\n\nDo you want to save the scene to %s before submitting?"
-                % scene_name
-            ),
-            button=["Yes", "No"],
-            defaultButton="No",
-            cancelButton="No",
-            dismissString="No",
+
+def create_submission_context() -> SubmissionContext:
+    """Gather scene data and build a SubmissionContext.
+
+    This performs the expensive Maya queries (render layer switching,
+    camera enumeration, etc.) exactly once.
+
+    Returns:
+        SubmissionContext with all scene data populated.
+    """
+    render_layers = _set_render_layer_data()
+    current_layer_selectable_cameras = [ALL_CAMERAS] + sorted(get_renderable_camera_names())
+
+    all_layer_selectable_cameras_set: set[str] = set(render_layers[0].renderable_camera_names)
+    for layer in render_layers:
+        all_layer_selectable_cameras_set = all_layer_selectable_cameras_set.intersection(
+            layer.renderable_camera_names
         )
-        if button == "Yes":
-            maya.cmds.file(save=True)
+    all_layer_selectable_cameras = [ALL_CAMERAS] + sorted(all_layer_selectable_cameras_set)
 
-    job_bundle_path = Path(job_bundle_dir)
+    return SubmissionContext(
+        render_layers=render_layers,
+        current_layer_selectable_cameras=current_layer_selectable_cameras,
+        all_layer_selectable_cameras=all_layer_selectable_cameras,
+    )
 
-    # If we're only submitting the current layer, filter our list of layers by that
+
+def _prepare_render_layers_for_submission(
+    settings: RenderSubmitterUISettings,
+    context: SubmissionContext,
+) -> tuple[list[RenderLayerData], set[str]]:
+    """Filter and annotate render layers based on settings.
+
+    This is a pure transformation — no Maya scene queries. It works on
+    deep copies of the context's render layers to avoid mutation issues
+    when the context is reused across multiple calls.
+
+    Args:
+        settings: The render submitter UI settings.
+        context: Pre-computed submission context.
+
+    Returns:
+        A tuple of (submit_render_layers, renderers).
+    """
+    render_layers = deepcopy(context.render_layers)
+
     if settings.render_layer_selection == LayerSelection.CURRENT:
         current_render_layer_name = get_current_render_layer_name()
         submit_render_layers = [
@@ -601,8 +630,6 @@ def on_create_job_bundle_callback(
         layer.frame_range != first_frame_range for layer in submit_render_layers
     )
 
-    # If there are multiple frame ranges and we're not overriding the range,
-    # then we create per-layer Frames parameters.
     if per_layer_frames_parameters:
         for layer_data in submit_render_layers:
             layer_data.frames_parameter_name = f"{layer_data.display_name}Frames"
@@ -630,23 +657,230 @@ def on_create_job_bundle_callback(
 
     renderers: set[str] = {layer_data.renderer_name for layer_data in submit_render_layers}
 
+    return submit_render_layers, renderers
+
+
+def get_default_job_template() -> dict[str, Any]:
+    """Returns the default job template for Maya render submissions."""
+    with open(Path(__file__).parent / "default_maya_job_template.yaml") as fh:
+        return yaml.safe_load(fh)
+
+
+def get_job_template_for_submission(
+    settings: RenderSubmitterUISettings,
+    host_requirements: Optional[dict[str, Any]] = None,
+    *,
+    context: Optional[SubmissionContext] = None,
+) -> dict[str, Any]:
+    """Generate the job template for Maya render submissions.
+
+    Args:
+        settings: The render submitter UI settings.
+        host_requirements: Optional host requirements to inject into job steps.
+        context: Optional pre-computed submission context. If not provided,
+            one will be created (which queries the Maya scene).
+
+    Returns:
+        The job template dictionary ready for serialization.
+    """
+    if context is None:
+        context = create_submission_context()
+
+    default_job_template = get_default_job_template()
+    submit_render_layers, renderers = _prepare_render_layers_for_submission(settings, context)
+
     job_template = _get_job_template(
         default_job_template=default_job_template,
         settings=settings,
         renderers=renderers,
         render_layers=submit_render_layers,
-        all_layer_selectable_cameras=render_settings.all_layer_selectable_cameras,
-        current_layer_selectable_cameras=render_settings.current_layer_selectable_cameras,
-    )
-    parameter_values = _get_parameter_values(
-        settings, renderers, submit_render_layers, cast(list[dict[str, Any]], queue_parameters)
+        all_layer_selectable_cameras=context.all_layer_selectable_cameras,
+        current_layer_selectable_cameras=context.current_layer_selectable_cameras,
     )
 
-    # If "HostRequirements" is provided, inject it into each of the "Step"
     if host_requirements:
-        # for each step in the template, append the same host requirements.
         for step in job_template["steps"]:
             step["hostRequirements"] = host_requirements
+
+    return job_template
+
+
+def get_parameter_values_for_submission(
+    settings: RenderSubmitterUISettings,
+    queue_parameters: Optional[list[dict[str, Any]]] = None,
+    *,
+    context: Optional[SubmissionContext] = None,
+) -> list[dict[str, Any]]:
+    """Generate the parameter values for Maya render submissions.
+
+    Args:
+        settings: The render submitter UI settings.
+        queue_parameters: Optional queue parameters. When omitted, no
+            queue-specific parameters (like RezPackages or CondaPackages)
+            will be included.
+        context: Optional pre-computed submission context. If not provided,
+            one will be created (which queries the Maya scene).
+
+    Returns:
+        The parameter values list ready for serialization.
+    """
+    if context is None:
+        context = create_submission_context()
+    if queue_parameters is None:
+        queue_parameters = []
+
+    submit_render_layers, renderers = _prepare_render_layers_for_submission(settings, context)
+
+    return _get_parameter_values(settings, renderers, submit_render_layers, queue_parameters)
+
+
+def get_asset_references_for_submission(
+    asset_references: AssetReferences,
+) -> dict[str, Any]:
+    """Get the asset references in dictionary form for Maya render submissions.
+
+    Args:
+        asset_references: The asset references object.
+
+    Returns:
+        The asset references dictionary ready for serialization.
+    """
+    return asset_references.to_dict()
+
+
+def get_queue_parameters(
+    farm_id: Optional[str] = None,
+    queue_id: Optional[str] = None,
+    initial_values: Optional[dict[str, Any]] = None,
+) -> list[dict[str, Any]]:
+    """Get queue parameters from Deadline Cloud for external API usage.
+
+    Retrieves queue parameter definitions from the Deadline Cloud API
+    and optionally applies initial values. Use this to construct
+    queue_parameters for get_parameter_values_for_submission() without
+    going through the UI.
+
+    Args:
+        farm_id: The farm ID. If not provided, uses the default from settings.
+        queue_id: The queue ID. If not provided, uses the default from settings.
+        initial_values: Optional dict of {parameter_name: value} to override
+            default parameter values.
+
+    Returns:
+        A list of parameter definition dicts suitable for passing to
+        get_parameter_values_for_submission().
+
+    Raises:
+        DeadlineOperationError: If farm_id or queue_id are not configured.
+    """
+    if farm_id is None:
+        farm_id = get_setting("defaults.farm_id")
+    if queue_id is None:
+        queue_id = get_setting("defaults.queue_id")
+
+    if not farm_id or not queue_id:
+        raise DeadlineOperationError(
+            "Farm ID and Queue ID must be configured. "
+            "Either provide them as arguments or configure them in Deadline Cloud settings."
+        )
+
+    queue_parameters = get_queue_parameter_definitions(farmId=farm_id, queueId=queue_id)
+
+    if initial_values:
+        for parameter in queue_parameters:
+            if parameter["name"] in initial_values:
+                parameter["value"] = initial_values[parameter["name"]]
+
+    return cast(list[dict[str, Any]], queue_parameters)
+
+
+def get_job_bundle_for_submission(
+    settings: RenderSubmitterUISettings,
+    queue_parameters: Optional[list[dict[str, Any]]] = None,
+    host_requirements: Optional[dict[str, Any]] = None,
+    asset_references: Optional[AssetReferences] = None,
+) -> dict[str, Any]:
+    """Generate a complete job bundle in one call.
+
+    This is the recommended entry point for external integrations.
+    It performs expensive scene queries exactly once.
+
+    Args:
+        settings: Render submitter UI settings.
+        queue_parameters: Queue parameters (use get_queue_parameters() to obtain).
+        host_requirements: Optional host requirements.
+        asset_references: Optional asset references.
+
+    Returns:
+        Dict with keys "job_template", "parameter_values", and optionally
+        "asset_references".
+    """
+    context = create_submission_context()
+
+    result: dict[str, Any] = {
+        "job_template": get_job_template_for_submission(
+            settings, host_requirements, context=context
+        ),
+        "parameter_values": get_parameter_values_for_submission(
+            settings, queue_parameters, context=context
+        ),
+    }
+
+    if asset_references is not None:
+        result["asset_references"] = get_asset_references_for_submission(asset_references)
+
+    return result
+
+
+def on_create_job_bundle_callback(
+    widget: SubmitJobToDeadlineDialog,
+    job_bundle_dir: str,
+    settings: RenderSubmitterUISettings,
+    queue_parameters: list[JobParameter],
+    asset_references: AssetReferences,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+) -> dict[str, Any]:
+    render_settings = _set_render_setting()
+
+    # Single expensive call — queries Maya scene once
+    context = create_submission_context()
+
+    # Tell the settings tab the selectable cameras
+    render_settings.current_layer_selectable_cameras = [ALL_CAMERAS] + sorted(
+        context.current_layer_selectable_cameras
+    )
+    render_settings.all_layer_selectable_cameras = (
+        [ALL_CAMERAS] + context.all_layer_selectable_cameras
+    )
+
+    # if submitting, warn if the current scene has been modified
+    scene_modified = maya.cmds.file(q=True, mf=True) == 1
+    if scene_modified and purpose == JobBundlePurpose.SUBMISSION:
+        scene_name = maya.cmds.file(q=True, sn=True)
+        button = maya.cmds.confirmDialog(
+            title="Warning: Scene Changes not Saved",
+            message=(
+                "The scene has unsaved local changes that will not be included in the job submission.\n\nDo you want to save the scene to %s before submitting?"
+                % scene_name
+            ),
+            button=["Yes", "No"],
+            defaultButton="No",
+            cancelButton="No",
+            dismissString="No",
+        )
+        if button == "Yes":
+            maya.cmds.file(save=True)
+
+    job_bundle_path = Path(job_bundle_dir)
+
+    # Reuse the same context — no redundant computation
+    job_template = get_job_template_for_submission(
+        settings, host_requirements, context=context
+    )
+    parameter_values = get_parameter_values_for_submission(
+        settings, cast(list[dict[str, Any]], queue_parameters), context=context
+    )
 
     with open(job_bundle_path / "template.yaml", "w", encoding="utf8") as f:
         deadline_yaml_dump(job_template, f, indent=1)

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -850,9 +850,9 @@ def on_create_job_bundle_callback(
     render_settings.current_layer_selectable_cameras = [ALL_CAMERAS] + sorted(
         context.current_layer_selectable_cameras
     )
-    render_settings.all_layer_selectable_cameras = (
-        [ALL_CAMERAS] + context.all_layer_selectable_cameras
-    )
+    render_settings.all_layer_selectable_cameras = [
+        ALL_CAMERAS
+    ] + context.all_layer_selectable_cameras
 
     # if submitting, warn if the current scene has been modified
     scene_modified = maya.cmds.file(q=True, mf=True) == 1
@@ -875,9 +875,7 @@ def on_create_job_bundle_callback(
     job_bundle_path = Path(job_bundle_dir)
 
     # Reuse the same context — no redundant computation
-    job_template = get_job_template_for_submission(
-        settings, host_requirements, context=context
-    )
+    job_template = get_job_template_for_submission(settings, host_requirements, context=context)
     parameter_values = get_parameter_values_for_submission(
         settings, cast(list[dict[str, Any]], queue_parameters), context=context
     )

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -476,7 +476,9 @@ def _get_parameter_values(
             )
 
     parameter_values.extend(
-        {"name": param["name"], "value": param["value"]} for param in queue_parameters
+        {"name": param["name"], "value": param.get("value", param.get("default", ""))}
+        for param in queue_parameters
+        if "value" in param or "default" in param
     )
 
     return parameter_values

--- a/test/unit/deadline_submitter_for_maya/scripts/test_submission_api.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_submission_api.py
@@ -1,0 +1,351 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_maya_modules():
+    """Mock Maya modules so we can import deadline.maya_submitter modules."""
+    mocks = {
+        "maya": Mock(),
+        "maya.cmds": Mock(),
+        "maya.mel": Mock(),
+        "maya.app": Mock(),
+        "maya.app.renderSetup": Mock(),
+        "maya.app.renderSetup.model": Mock(),
+        "maya.app.renderSetup.model.renderSetupPreferences": Mock(),
+        "qtpy": Mock(),
+        "qtpy.QtCore": Mock(),
+        "qtpy.QtWidgets": Mock(),
+        "qtpy.QtGui": Mock(),
+    }
+    saved = {}
+    added = []
+    for mod_name, mock_obj in mocks.items():
+        if mod_name in sys.modules:
+            saved[mod_name] = sys.modules[mod_name]
+        else:
+            added.append(mod_name)
+        sys.modules[mod_name] = mock_obj
+
+    modules_to_clear = [
+        "deadline.maya_submitter.cameras",
+        "deadline.maya_submitter.render_layers",
+        "deadline.maya_submitter.data_classes",
+        "deadline.maya_submitter.maya_render_submitter",
+        "deadline.maya_submitter.ui",
+        "deadline.maya_submitter.ui.components",
+        "deadline.maya_submitter.ui.components.scene_settings_tab",
+    ]
+    for mod_name in modules_to_clear:
+        if mod_name in sys.modules:
+            saved[mod_name] = sys.modules.pop(mod_name)
+
+    yield
+
+    for mod_name in added:
+        sys.modules.pop(mod_name, None)
+    for mod_name, original in saved.items():
+        if original is not None:
+            sys.modules[mod_name] = original
+        else:
+            sys.modules.pop(mod_name, None)
+
+
+def _make_render_layer(
+    name="defaultRenderLayer",
+    display_name="masterLayer",
+    renderer_name="arnold",
+    frame_range="1-10",
+    renderable_cameras=None,
+    output_file_prefix="<Scene>",
+    image_resolution=(1920, 1080),
+):
+    from deadline.maya_submitter.maya_render_submitter import RenderLayerData
+
+    return RenderLayerData(
+        name=name,
+        display_name=display_name,
+        renderer_name=renderer_name,
+        ui_group_label=f"Layer: {display_name}",
+        frames_parameter_name=None,
+        frame_range=frame_range,
+        renderable_camera_names=renderable_cameras or ["persp"],
+        output_directories={"/tmp/renders"},
+        output_file_prefix_parameter_name=None,
+        output_file_prefix=output_file_prefix,
+        image_width_parameter_name=None,
+        image_height_parameter_name=None,
+        image_resolution=image_resolution,
+    )
+
+
+def _make_context(render_layers=None):
+    from deadline.maya_submitter.maya_render_submitter import SubmissionContext
+    from deadline.maya_submitter.cameras import ALL_CAMERAS
+
+    if render_layers is None:
+        render_layers = [_make_render_layer()]
+
+    return SubmissionContext(
+        render_layers=render_layers,
+        current_layer_selectable_cameras=[ALL_CAMERAS, "persp"],
+        all_layer_selectable_cameras=[ALL_CAMERAS, "persp"],
+    )
+
+
+class TestGetJobTemplateForSubmission:
+    def test_returns_job_template_dict(self):
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_job_template_for_submission,
+        )
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "test_job"
+        settings.description = "A test job"
+        settings.override_frame_range = False
+
+        context = _make_context()
+
+        result = get_job_template_for_submission(settings, context=context)
+
+        assert isinstance(result, dict)
+        assert result["name"] == "test_job"
+        assert result["description"] == "A test job"
+
+    def test_host_requirements_injected_into_steps(self):
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_job_template_for_submission,
+        )
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "test_job"
+        settings.description = ""
+        settings.override_frame_range = False
+
+        context = _make_context()
+        host_requirements = {"amounts": [{"name": "amount.worker.vcpu", "min": 4}]}
+
+        result = get_job_template_for_submission(settings, host_requirements, context=context)
+
+        assert result["steps"][0]["hostRequirements"] == host_requirements
+
+    def test_creates_context_if_not_provided(self):
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_job_template_for_submission,
+        )
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "test_job"
+        settings.description = ""
+        settings.override_frame_range = False
+
+        context = _make_context()
+
+        with patch(
+            "deadline.maya_submitter.maya_render_submitter.create_submission_context",
+            return_value=context,
+        ) as mock_create:
+            get_job_template_for_submission(settings)
+
+        mock_create.assert_called_once()
+
+
+class TestGetParameterValuesForSubmission:
+    def test_returns_parameter_values_list(self):
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_parameter_values_for_submission,
+        )
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "test_job"
+        settings.override_frame_range = False
+        settings.frame_list = "1-10"
+        settings.project_path = "/tmp/project"
+        settings.output_path = "/tmp/output"
+
+        context = _make_context()
+
+        with patch(
+            "deadline.maya_submitter.maya_render_submitter._get_parameter_values",
+            return_value=[{"name": "Frames", "value": "1-10"}],
+        ):
+            result = get_parameter_values_for_submission(settings, context=context)
+
+        assert isinstance(result, list)
+        assert result[0]["name"] == "Frames"
+
+    def test_queue_parameters_included(self):
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_parameter_values_for_submission,
+        )
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "test_job"
+        settings.override_frame_range = False
+        settings.frame_list = "1-10"
+        settings.project_path = "/tmp/project"
+        settings.output_path = "/tmp/output"
+
+        context = _make_context()
+        queue_params = [{"name": "CondaPackages", "value": "maya=2026.*"}]
+
+        with patch(
+            "deadline.maya_submitter.maya_render_submitter._get_parameter_values",
+        ) as mock_get_params:
+            mock_get_params.return_value = [
+                {"name": "Frames", "value": "1-10"},
+                {"name": "CondaPackages", "value": "maya=2026.*"},
+            ]
+            get_parameter_values_for_submission(settings, queue_params, context=context)
+
+        # Verify queue_parameters were passed through
+        call_args = mock_get_params.call_args
+        assert call_args[0][3] == queue_params
+
+    def test_creates_context_if_not_provided(self):
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_parameter_values_for_submission,
+        )
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "test_job"
+        settings.override_frame_range = False
+        settings.frame_list = "1-10"
+        settings.project_path = "/tmp/project"
+        settings.output_path = "/tmp/output"
+
+        context = _make_context()
+
+        with (
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.create_submission_context",
+                return_value=context,
+            ) as mock_create,
+            patch(
+                "deadline.maya_submitter.maya_render_submitter._get_parameter_values",
+                return_value=[],
+            ),
+        ):
+            get_parameter_values_for_submission(settings)
+
+        mock_create.assert_called_once()
+
+
+class TestGetAssetReferencesForSubmission:
+    def test_returns_dict(self):
+        from deadline.client.job_bundle.submission import AssetReferences
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_asset_references_for_submission,
+        )
+
+        asset_refs = AssetReferences(
+            input_filenames={"scene.ma", "texture.png"},
+            input_directories={"/textures"},
+            output_directories={"/renders"},
+        )
+
+        result = get_asset_references_for_submission(asset_refs)
+
+        assert isinstance(result, dict)
+        assert "inputFilenames" in result or "assetReferences" in result or len(result) > 0
+
+    def test_preserves_asset_data(self):
+        from deadline.client.job_bundle.submission import AssetReferences
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_asset_references_for_submission,
+        )
+
+        asset_refs = AssetReferences(
+            input_filenames={"scene.ma"},
+            input_directories=set(),
+            output_directories={"/renders"},
+        )
+
+        result = get_asset_references_for_submission(asset_refs)
+
+        assert isinstance(result, dict)
+
+
+class TestGetQueueParameters:
+    def test_uses_default_settings_when_no_overrides(self):
+        from deadline.maya_submitter.maya_render_submitter import get_queue_parameters
+
+        with (
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.get_setting",
+                side_effect=lambda key: "farm-123" if "farm" in key else "queue-456",
+            ),
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.get_queue_parameter_definitions",
+                return_value=[{"name": "CondaPackages", "value": "maya=2026.*"}],
+            ) as mock_get_params,
+        ):
+            result = get_queue_parameters()
+
+        mock_get_params.assert_called_once_with(farmId="farm-123", queueId="queue-456")
+        assert result == [{"name": "CondaPackages", "value": "maya=2026.*"}]
+
+    def test_uses_override_ids(self):
+        from deadline.maya_submitter.maya_render_submitter import get_queue_parameters
+
+        with (
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.get_setting",
+            ) as mock_setting,
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.get_queue_parameter_definitions",
+                return_value=[{"name": "CondaPackages", "value": ""}],
+            ) as mock_get_params,
+        ):
+            get_queue_parameters(
+                farm_id_override="farm-override", queue_id_override="queue-override"
+            )
+
+        mock_setting.assert_not_called()
+        mock_get_params.assert_called_once_with(farmId="farm-override", queueId="queue-override")
+
+    def test_applies_initial_values_override(self):
+        from deadline.maya_submitter.maya_render_submitter import get_queue_parameters
+
+        with (
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.get_setting",
+                side_effect=lambda key: "farm-123" if "farm" in key else "queue-456",
+            ),
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.get_queue_parameter_definitions",
+                return_value=[
+                    {"name": "CondaPackages", "value": ""},
+                    {"name": "OtherParam", "value": "default"},
+                ],
+            ),
+        ):
+            result = get_queue_parameters(
+                initial_values_override={"CondaPackages": "maya=2026.* maya-mtoa"}
+            )
+
+        assert result[0]["value"] == "maya=2026.* maya-mtoa"
+        assert result[1]["value"] == "default"
+
+    def test_raises_error_when_ids_not_configured(self):
+        from deadline.client.exceptions import DeadlineOperationError
+        from deadline.maya_submitter.maya_render_submitter import get_queue_parameters
+
+        with (
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.get_setting",
+                return_value="",
+            ),
+            pytest.raises(DeadlineOperationError),
+        ):
+            get_queue_parameters()


### PR DESCRIPTION
## Change
Refactor the submission pipeline to separate expensive Maya scene queries from data transformation. Introduces `SubmissionContext` to cache scene data and avoid redundant `_set_render_layer_data()` calls when multiple public functions are used together.

This makes parts of the submitter logic externally callable, allowing integrations (e.g. AYON) to get submission data as dictionaries before they are dumped to job bundle YAML files.

### Public API for external integrations

```python
from deadline.maya_submitter.maya_render_submitter import (
    create_submission_context,
    get_job_template_for_submission,
    get_parameter_values_for_submission,
    get_asset_references_for_submission,
    get_queue_parameters,
    get_job_bundle_for_submission,
)
from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
from deadline.client.job_bundle.submission import AssetReferences


settings = RenderSubmitterUISettings()
queue_parameters: list[dict[str, Any]] = get_queue_parameters()
asset_references = AssetReferences(
    input_filenames=set(settings.input_filenames),
    input_directories=set(settings.input_directories),
    output_directories=set(settings.output_directories),
)

# Recommended: single entry point
job_bundle = get_job_bundle_for_submission()

# Or use individual functions with shared context to avoid redundant scene queries:
context = create_submission_context(settings)
job_template = get_job_template_for_submission(settings, context=context)
parameter_values = get_parameter_values_for_submission(settings, queue_parameters, context=context)
asset_refs_dict = get_asset_references_for_submission(asset_references)
```

#### Note about `get_queue_parameters()`
This function sets Open Job Description queue parameters manually (not from the UI).

```python
# With initial values
queue_params = get_queue_parameters(
    initial_values={"CondaPackages": "maya=2026.* maya-mtoa"}
)

# Explicitly (won't get farm_id and queue_id from settings)
queue_params = get_queue_parameters(
    farm_id="farm-xxxxx",
    queue_id="queue-xxxx",
    initial_values={"CondaPackages": "maya=2026.* maya-mtoa"}
)
```

## Test plan
- [x] Run `hatch run test` to verify unit tests pass
- [x] Run `hatch run install --maya-version 2026` and verify plugin loads in Maya
- [x] Test `get_job_bundle_for_submission()` from Maya Script Editor
- [x] Test individual functions with shared `SubmissionContext`
- [x] Verify existing submitter UI workflow still works end-to-end