### PR TITLE
fix: Use unzip -o and pull 7-Zip from S3 with checksum

### DIFF
--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -391,7 +391,7 @@ def _install_mtoa_linux(version: str) -> None:
         # Unzip the package into the install dir
         pkg_zip = next(extract_tmp.glob("*.zip"), None)
         if pkg_zip:
-            run(["unzip", "-q", str(pkg_zip), "-d", str(mtoa_install_dir)])
+            run(["unzip", "-qo", str(pkg_zip), "-d", str(mtoa_install_dir)])
         else:
             print(f"ERROR: No .zip found in {extract_tmp}")
             run(["ls", "-la", str(extract_tmp)], check=False)
@@ -945,12 +945,17 @@ def setup_windows(maya_versions: Sequence[str], renderers: Sequence[str]) -> Non
     seven_zip = Path("C:/Program Files/7-Zip/7z.exe")
     if not seven_zip.exists():
         print("Installing 7-Zip...")
+        installer_path = Path("C:/temp/7z-install.exe")
+        installer_path.parent.mkdir(parents=True, exist_ok=True)
+        download_from_s3("tools/7z2408-x64.exe", installer_path)
+        verify_checksum(
+            installer_path, "67cb9d3452c9dd974b04f4a5fd842dbcba8184f2344ff72e3662d7cdb68b099b"
+        )
         run(
             [
                 "powershell",
                 "-Command",
-                "Invoke-WebRequest -Uri 'https://www.7-zip.org/a/7z2408-x64.exe' -OutFile C:\\temp\\7z-install.exe; "
-                + "Start-Process C:\\temp\\7z-install.exe -ArgumentList '/S' -Wait",
+                f"Start-Process '{installer_path}' -ArgumentList '/S' -Wait",
             ]
         )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1. **MtoA unzip fails on reserved fleets**: The prod fleet already has MtoA partially installed from previous runs. `unzip` prompts for overwrite confirmation (`replace file? [y/n/A/N]`), gets no TTY input, and exits 1.
2. **7-Zip downloaded from internet**: The Windows setup downloads 7-Zip from `7-zip.org` which is an external network dependency that could fail or be tampered with.

### What was the solution? (How)

- `unzip -qo`: The `-o` flag forces overwrite without prompting
- 7-Zip: Download from S3 (`tools/7z2408-x64.exe`) with SHA256 checksum verification instead of fetching from the internet

### What is the impact of this change?

Fixes MtoA installation on reserved capacity fleets where previous installs persist. Removes external network dependency for Windows builds.

### How was this change tested?

Linux validated via fork CI (build #79 SUCCEEDED). Windows will be validated after 7z binary is uploaded to S3.

**Prerequisite**: Upload 7-Zip to S3:
```
aws s3 cp 7z2408-x64.exe s3://common-bealinerezpackage-resources-bucket/tools/7z2408-x64.exe
```
SHA256: `67cb9d3452c9dd974b04f4a5fd842dbcba8184f2344ff72e3662d7cdb68b099b`

### Did you modify schema files?
- [x] No

### Is this a breaking change?

No.