### PR TITLE
test: add OCIO config file submission test coverage

### DIFF
--- a/test/integ/test_maya_submitters.py
+++ b/test/integ/test_maya_submitters.py
@@ -251,3 +251,171 @@ class TestSubmitters:
         are_asset_references_similar(
             job_history_dir, expected_asset_references, job_configuration.expected_scene_file_paths
         )
+
+    def test_scene_submitter_with_ocio_config(
+        self,
+        initialize_maya,
+        script_location: Path,
+        tmp_path: Path,
+    ) -> None:
+        """OCIO config file regression coverage.
+
+        Companion to the 0.15.13 OCIO submission failure that was fixed
+        in 0.15.14 (the customer-default code path was uncovered by
+        existing tests).
+
+        The four parametrized tests above implicitly cover the
+        no-custom-OCIO case (scene's ``cfp`` is the default
+        ``<MAYA_RESOURCES>/...`` path which ``Scene.ocio_config_file()``
+        correctly returns ``None`` for, so ``OCIOConfigFile`` is omitted
+        from parameter_values and falls back to its empty-string default
+        in the template). That's the customer state that broke when
+        ``openjd-model-for-python < 0.9.1`` rejected empty defaults on
+        HIDDEN PATH parameters.
+
+        This test covers the custom-OCIO case — scene **with** a custom
+        OCIO config. We programmatically apply the config via
+        ``cmds.colorManagementPrefs(e=True, configFilePath=...)``
+        post-scene-open (simulating a customer with a studio-wide OCIO
+        config set in Maya's preferences). The submitter must then pick
+        it up via ``Scene.ocio_config_file()`` and emit it as the
+        ``OCIOConfigFile`` parameter value in the bundle.
+        """
+        show_maya_render_submitter = initialize_maya[0]
+        on_create_job_bundle_callback = initialize_maya[1]
+
+        asset_folder = "ocio_test"
+        file_prefix = "ocio_test"
+        frame_list = "1"
+
+        job_history_dir = tmp_path / "jobhistory"
+        output_path = tmp_path / "output"
+        project_path = script_location / asset_folder / "scene"
+        scene_location = project_path / "test.ma"
+        ocio_config_path = project_path / "config.ocio"
+
+        # Sanity check the fixture exists before doing any Maya work.
+        assert ocio_config_path.is_file(), f"OCIO config fixture missing at {ocio_config_path}"
+
+        # Clean up sticky setting
+        self._cleanup_sticky_settings(scene_location, script_location)
+
+        os.makedirs(job_history_dir, exist_ok=True)
+        os.makedirs(output_path, exist_ok=True)
+
+        cmds.workspace(project_path, openWorkspace=True)
+        cmds.workspace(fileRule=["images", output_path])
+
+        cmds.file(scene_location, open=True, force=True)
+
+        cmds.setAttr("defaultResolution.width", 960)
+        cmds.setAttr("defaultResolution.height", 540)
+        cmds.setAttr("defaultRenderGlobals.imageFilePrefix", file_prefix, type="string")
+        cmds.optionVar(iv=("renderSetup_includeAllLights", 0))
+
+        # The crux of this test: apply a custom OCIO config to Maya's
+        # color management preferences. Scene.ocio_config_file() reads
+        # this back via colorManagementPrefs(query=True, configFilePath=True).
+        cmds.colorManagementPrefs(e=True, cmEnabled=True)
+        cmds.colorManagementPrefs(e=True, configFilePath=str(ocio_config_path))
+
+        widget = show_maya_render_submitter(None)
+
+        settings = widget.job_settings_type()
+        widget.shared_job_settings.update_settings(settings)
+        widget.job_settings.update_settings(settings)
+
+        settings.view_layer_selection = "All Renderable Layers"
+        settings.camera_selection = "All Renderable Cameras"
+        settings.description = ""
+        settings.include_adaptor_wheels = False
+        settings.override_frame_range = True
+        settings.frame_list = frame_list
+
+        widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+            {"name": "deadline:targetTaskRunStatus", "value": "READY"}
+        )
+        widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+            {"name": "deadline:maxFailedTasksCount", "value": 20}
+        )
+        widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+            {"name": "deadline:maxRetriesPerTask", "value": 5}
+        )
+        widget.shared_job_settings.shared_job_properties_box.set_parameter_value(
+            {"name": "deadline:priority", "value": 50}
+        )
+
+        on_create_job_bundle_callback(
+            widget,
+            job_history_dir,
+            settings,
+            widget.shared_job_settings.get_parameters(),
+            widget.job_attachments.get_asset_references(),
+            widget.host_requirements.get_requirements(),
+            purpose="export",
+        )
+        widget.close()
+
+        # Template must be valid Open Job Description.
+        assert is_valid_template(job_history_dir / "template.yaml")
+
+        # Template should be identical to the mtoa_test template — the
+        # OCIO state lives in parameter_values, not in the template.
+        with (
+            open(
+                script_location / asset_folder / "expected_job_bundle" / "template.yaml"
+            ) as expected,
+            open(job_history_dir / "template.yaml") as actual,
+        ):
+            assert yaml.safe_load(expected) == yaml.safe_load(actual)
+
+        # Expected parameter values include OCIOConfigFile (the bug fix
+        # under test) and ArnoldErrorOnLicenseFailure (because we use
+        # the Arnold-based mtoa scene as the OCIO test base).
+        expected_parameter_values = {
+            "parameterValues": [
+                {"name": "MayaSceneFile", "value": str(scene_location)},
+                {"name": "OutputFilePrefix", "value": file_prefix},
+                {"name": "Frames", "value": frame_list},
+                {"name": "ImageWidth", "value": 960},
+                {"name": "ImageHeight", "value": 540},
+                {"name": "ProjectPath", "value": str(project_path) + "/"},
+                {"name": "OutputFilePath", "value": str(output_path)},
+                {"name": "RenderSetupIncludeLights", "value": "false"},
+                {"name": "OCIOConfigFile", "value": str(ocio_config_path)},
+                {"name": "ArnoldErrorOnLicenseFailure", "value": "false"},
+                {"name": "deadline:targetTaskRunStatus", "value": "READY"},
+                {"name": "deadline:maxFailedTasksCount", "value": 20},
+                {"name": "deadline:maxRetriesPerTask", "value": 5},
+                {"name": "deadline:priority", "value": 50},
+            ]
+        }
+
+        are_parameter_values_similar(job_history_dir, expected_parameter_values)
+
+        # Asset references match the mtoa_test pattern, plus the OCIO
+        # config file. Once colorManagementPrefs(configFilePath=...) is
+        # set, Maya's filePathEditor reports the OCIO config as a scene
+        # reference, so AssetIntrospector.parse_scene_assets() picks it
+        # up and adds it to inputs.filenames. We use the
+        # expected_scene_file_paths regex parameter to match it
+        # dynamically rather than hard-coding the absolute path (which
+        # may be canonicalized differently on the runner).
+        # Note: the OCIOConfigFile PATH job parameter independently
+        # delivers the file via Job Attachments — having the config in
+        # both places is benign (the Job Attachments dataFlow:IN PATH
+        # parameter and inputs.filenames both end up uploaded once).
+        expected_asset_references: dict[str, dict[str, Any]] = {
+            "assetReferences": {
+                "inputs": {
+                    "directories": [],
+                    "filenames": {str(scene_location)},
+                },
+                "outputs": {
+                    "directories": [str(output_path)],
+                },
+                "referencedPaths": [],
+            }
+        }
+
+        are_asset_references_similar(job_history_dir, expected_asset_references, [r"config\.ocio$"])

--- a/test/integ/test_scripts/ocio_test/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/ocio_test/expected_job_bundle/template.yaml
@@ -1,0 +1,188 @@
+specificationVersion: jobtemplate-2023-09
+name: test.ma
+parameterDefinitions:
+- name: MayaSceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Maya Scene File
+    groupLabel: Maya Settings
+    fileFilters:
+    - label: Maya Scene Files
+      patterns:
+      - '*.mb'
+      - '*.ma'
+    - label: All Files
+      patterns:
+      - '*'
+  description: The Maya scene file to render.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Maya Settings
+  description: The frames to render. E.g. 1-3,8,11-15
+  minLength: 1
+- name: ProjectPath
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: NONE
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Project Path
+    groupLabel: Maya Settings
+  description: The Maya project path.
+- name: OutputFilePath
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output File Path
+    groupLabel: Maya Settings
+  description: The render output path.
+- name: RenderSetupIncludeLights
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Include All Lights
+    groupLabel: Maya Settings
+  description: Include all lights in the render.
+  default: 'true'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: StrictErrorChecking
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Strict Error Checking
+    groupLabel: Maya Settings
+  description: Fail when errors occur.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+- name: OCIOConfigFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: HIDDEN
+  description: The OCIO configuration file path (auto-detected from scene).
+  default: ''
+- name: OutputFilePrefix
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Prefix
+    groupLabel: Maya Settings
+  description: The output filename prefix.
+- name: ImageWidth
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Width
+    groupLabel: Maya Settings
+  minValue: 1
+  description: The image width of the output.
+- name: ImageHeight
+  type: INT
+  userInterface:
+    control: SPIN_BOX
+    label: Image Height
+    groupLabel: Maya Settings
+  minValue: 1
+  description: The image height of the output.
+- name: ArnoldErrorOnLicenseFailure
+  type: STRING
+  userInterface:
+    control: CHECK_BOX
+    label: Error on License Failure
+    groupLabel: Arnold Renderer Settings
+  description: Whether to produce an error when there is an Arnold license failure.
+  default: 'false'
+  allowedValues:
+  - 'true'
+  - 'false'
+steps:
+- name: masterLayer
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+    - name: Camera
+      type: STRING
+      range:
+      - persp
+  stepEnvironments:
+  - name: Maya
+    description: Runs Maya in the background.
+    script:
+      embeddedFiles:
+      - name: initData
+        filename: init-data.yaml
+        type: TEXT
+        data: |
+          renderer: arnold
+          render_layer: masterLayer
+          scene_file: '{{Param.MayaSceneFile}}'
+          project_path: '{{Param.ProjectPath}}'
+          output_file_path: '{{Param.OutputFilePath}}'
+          render_setup_include_lights: {{Param.RenderSetupIncludeLights}}
+          strict_error_checking: {{Param.StrictErrorChecking}}
+          ocio_config_file: '{{Param.OCIOConfigFile}}'
+          output_file_prefix: '{{Param.OutputFilePrefix}}'
+          image_width: {{Param.ImageWidth}}
+          image_height: {{Param.ImageHeight}}
+          cache_pathmapping: true
+          error_on_arnold_license_fail: {{Param.ArnoldErrorOnLicenseFailure}}
+      actions:
+        onEnter:
+          command: MayaAdaptor
+          args:
+          - daemon
+          - start
+          - --path-mapping-rules
+          - file://{{Session.PathMappingRulesFile}}
+          - --connection-file
+          - '{{Session.WorkingDirectory}}/connection.json'
+          - --init-data
+          - file://{{Env.File.initData}}
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 87000
+        onExit:
+          command: MayaAdaptor
+          args:
+          - daemon
+          - stop
+          - --connection-file
+          - '{{ Session.WorkingDirectory }}/connection.json'
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+          timeout: 600
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+        camera: '{{Task.Param.Camera}}'
+    actions:
+      onRun:
+        command: MayaAdaptor
+        args:
+        - daemon
+        - run
+        - --connection-file
+        - '{{ Session.WorkingDirectory }}/connection.json'
+        - --run-data
+        - file://{{ Task.File.runData }}
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE

--- a/test/integ/test_scripts/ocio_test/scene/config.ocio
+++ b/test/integ/test_scripts/ocio_test/scene/config.ocio
@@ -1,0 +1,43 @@
+ocio_profile_version: 2
+
+description: |
+  Minimal OCIO v2 config for the deadline-cloud-for-maya OCIO submitter
+  integration test. Defines just enough to be a valid, parseable config
+  so that Maya's colorManagementPrefs(configFilePath=...) accepts it
+  without errors. Not intended for production use.
+
+search_path: ""
+strictparsing: false
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: linear
+  reference: linear
+  scene_linear: linear
+  rendering: linear
+  color_picking: linear
+  color_timing: linear
+  compositing_log: linear
+  data: linear
+  matte_paint: linear
+  texture_paint: linear
+
+displays:
+  sRGB:
+    - !<View> {name: Raw, colorspace: linear}
+
+active_displays: [sRGB]
+active_views: [Raw]
+
+colorspaces:
+  - !<ColorSpace>
+    name: linear
+    family: scene
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Scene-linear color space. The sole colorspace defined in this
+      minimal test config; all roles point at it.
+    isdata: false
+    allocation: lg2
+    allocationvars: [-15, 6]

--- a/test/integ/test_scripts/ocio_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/ocio_test/scene/test.deadline_render_settings.json
@@ -1,0 +1,15 @@
+{
+ "name": "test.ma",
+ "description": "",
+ "priority": 50,
+ "initial_status": "READY",
+ "max_failed_tasks_count": 20,
+ "max_retries_per_task": 5,
+ "max_worker_count": -1,
+ "override_frame_range": true,
+ "frame_list": "1",
+ "input_filenames": [],
+ "input_directories": [],
+ "output_directories": [],
+ "include_adaptor_wheels": false
+}

--- a/test/integ/test_scripts/ocio_test/scene/test.ma
+++ b/test/integ/test_scripts/ocio_test/scene/test.ma
@@ -1,0 +1,513 @@
+//Maya ASCII 2025ff03 scene
+//Name: test.ma
+//Last modified: Thu, Feb 12, 2026 07:29:42 AM
+//Codeset: UTF-8
+requires maya "2025ff03";
+requires -nodeType "VRaySettingsNode" -dataType "VRaySunParams" -dataType "vrayFloatVectorData"
+		 -dataType "vrayFloatVectorData" -dataType "vrayIntData" "vrayformaya" "7";
+requires -nodeType "aiOptions" -nodeType "aiAOVDriver" -nodeType "aiAOVFilter" -nodeType "aiSkyDomeLight"
+		 -nodeType "aiPhysicalSky" "mtoa" "5.4.5";
+requires -nodeType "RedshiftOptions" -nodeType "RedshiftPostEffects" "redshift4maya" "2025.6.0";
+requires -nodeType "renderSetup" "renderSetup.py" "1.0";
+requires "stereoCamera" "10.0";
+requires "stereoCamera" "10.0";
+currentUnit -l centimeter -a degree -t film;
+fileInfo "application" "maya";
+fileInfo "product" "Maya 2025";
+fileInfo "version" "2025";
+fileInfo "cutIdentifier" "202409190603-cbdc5a7e54";
+fileInfo "osv" "Linux 6.1.161-183.298.amzn2023.x86_64 #1 SMP PREEMPT_DYNAMIC Tue Jan 27 05:01:22 UTC 2026 x86_64";
+fileInfo "UUID" "6BFAB3C0-0000-D82A-698D-8166000002BF";
+fileInfo "vrayBuild" "7.10.00 4783db8";
+createNode transform -s -n "persp";
+	rename -uid "7EF88DA8-4ABC-F598-B672-AA8DBABBAF1D";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 17.707419377048666 5.498259259170478 9.2247713537181966 ;
+	setAttr ".r" -type "double3" -15.848417602988716 61.934713156576073 -6.7602716234072613e-14 ;
+	setAttr ".rp" -type "double3" 1.1102230246251565e-16 2.7755575615628914e-17 0 ;
+	setAttr ".rpt" -type "double3" -5.6387616056943156e-17 1.8497578943066338e-16 -6.4410761521205603e-17 ;
+createNode camera -s -n "perspShape" -p "persp";
+	rename -uid "449247E5-4517-F96F-A14B-479A1003783B";
+	setAttr -k off ".v" no;
+	setAttr ".fl" 34.999999999999979;
+	setAttr ".coi" 25.189913580637679;
+	setAttr ".imn" -type "string" "persp";
+	setAttr ".den" -type "string" "persp_depth";
+	setAttr ".man" -type "string" "persp_mask";
+	setAttr ".tp" -type "double3" -3.6755283412864799 -1.3809365802986253 -2.1760162364953608 ;
+	setAttr ".hc" -type "string" "viewSet -p %camera";
+createNode transform -s -n "top";
+	rename -uid "2B47BF4B-48F8-7DB1-BA17-9B833F0258CA";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 0 1000.1 0 ;
+	setAttr ".r" -type "double3" -90 0 0 ;
+createNode camera -s -n "topShape" -p "top";
+	rename -uid "2512D429-4286-A93D-16CA-CE8E1C0AB22C";
+	setAttr -k off ".v" no;
+	setAttr ".rnd" no;
+	setAttr ".coi" 1000.1;
+	setAttr ".ow" 30;
+	setAttr ".imn" -type "string" "top";
+	setAttr ".den" -type "string" "top_depth";
+	setAttr ".man" -type "string" "top_mask";
+	setAttr ".hc" -type "string" "viewSet -t %camera";
+	setAttr ".o" yes;
+	setAttr ".ai_translator" -type "string" "orthographic";
+createNode transform -s -n "front";
+	rename -uid "6A64EDC1-42F4-DE55-D43B-1E9DBAB083EF";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 0 0 1000.1 ;
+createNode camera -s -n "frontShape" -p "front";
+	rename -uid "B6F2D014-4DEB-6961-E75B-1989515C7F1E";
+	setAttr -k off ".v" no;
+	setAttr ".rnd" no;
+	setAttr ".coi" 1000.1;
+	setAttr ".ow" 30;
+	setAttr ".imn" -type "string" "front";
+	setAttr ".den" -type "string" "front_depth";
+	setAttr ".man" -type "string" "front_mask";
+	setAttr ".hc" -type "string" "viewSet -f %camera";
+	setAttr ".o" yes;
+	setAttr ".ai_translator" -type "string" "orthographic";
+createNode transform -s -n "side";
+	rename -uid "B792C309-4FAD-9013-450B-2BA7BF955E97";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 1000.1 0 0 ;
+	setAttr ".r" -type "double3" 0 90 0 ;
+createNode camera -s -n "sideShape" -p "side";
+	rename -uid "6DB8B516-4649-D000-FA52-5C950A861645";
+	setAttr -k off ".v" no;
+	setAttr ".rnd" no;
+	setAttr ".coi" 1000.1;
+	setAttr ".ow" 30;
+	setAttr ".imn" -type "string" "side";
+	setAttr ".den" -type "string" "side_depth";
+	setAttr ".man" -type "string" "side_mask";
+	setAttr ".hc" -type "string" "viewSet -s %camera";
+	setAttr ".o" yes;
+	setAttr ".ai_translator" -type "string" "orthographic";
+createNode transform -n "pCube1";
+	rename -uid "7FFA91CA-4CF6-7FFB-0657-778DA2209B67";
+	setAttr ".r" -type "double3" 64.965505797371875 12.441957706779846 31.582947321214178 ;
+createNode mesh -n "pCubeShape1" -p "pCube1";
+	rename -uid "8AC95A8A-403B-2E93-0675-198E81D1C60D";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+createNode transform -n "pTorus1";
+	rename -uid "CE7CD0C3-491D-899D-9C66-4DBF1A4617B4";
+	setAttr ".t" -type "double3" -3.0022850203283724 2.4197672685153968 0 ;
+	setAttr ".r" -type "double3" -41.558151520895038 -59.466719560871105 -55.135026496665304 ;
+createNode mesh -n "pTorusShape1" -p "pTorus1";
+	rename -uid "0B7D07FC-4070-689D-B973-DAA3928113E7";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+createNode transform -n "pCone1";
+	rename -uid "08FA64C6-481C-1BF7-C781-5D9FA27B3C7A";
+	setAttr ".t" -type "double3" -0.73347171341000816 0 3.5921186051575194 ;
+	setAttr ".r" -type "double3" -149.62408749740425 -58.819848183445885 18.266874786973098 ;
+createNode mesh -n "pConeShape1" -p "pCone1";
+	rename -uid "B31436BF-4881-D460-EDD2-2BAE74C74A2E";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+createNode transform -n "pSphere1";
+	rename -uid "2D10855F-4FAA-C836-1DAF-8D9672E97AB0";
+	setAttr ".t" -type "double3" 0 -2.556208348613433 -2.7773803716141097 ;
+createNode mesh -n "pSphereShape1" -p "pSphere1";
+	rename -uid "4641C066-47B2-B126-DDCD-5889E59A140A";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+createNode transform -n "aiSkyDomeLight1";
+	rename -uid "F69B7F2A-4243-9760-45EE-BD9945D9F5DC";
+createNode aiSkyDomeLight -n "aiSkyDomeLightShape1" -p "aiSkyDomeLight1";
+	rename -uid "398333B7-4A65-5656-D57E-C1B087659EC4";
+	addAttr -ci true -h true -sn "aal" -ln "attributeAliasList" -dt "attributeAlias";
+	setAttr -k off ".v";
+	setAttr ".csh" no;
+	setAttr ".rcsh" no;
+	setAttr ".intensity" 2.2435896396636963;
+	setAttr ".aal" -type "attributeAlias" 2 "exposure" "aiExposure" ;
+createNode lightLinker -s -n "lightLinker1";
+	rename -uid "6BFAB3C0-0000-D82A-698D-80FB000002A4";
+	setAttr -s 2 ".lnk";
+	setAttr -s 2 ".slnk";
+createNode shapeEditorManager -n "shapeEditorManager";
+	rename -uid "6BFAB3C0-0000-D82A-698D-80FB000002A5";
+createNode poseInterpolatorManager -n "poseInterpolatorManager";
+	rename -uid "6BFAB3C0-0000-D82A-698D-80FB000002A6";
+createNode displayLayerManager -n "layerManager";
+	rename -uid "6BFAB3C0-0000-D82A-698D-80FB000002A7";
+createNode displayLayer -n "defaultLayer";
+	rename -uid "629E750F-46E5-4183-E0F6-F0ADB6EF9419";
+	setAttr ".ufem" -type "stringArray" 0  ;
+createNode renderLayerManager -n "renderLayerManager";
+	rename -uid "6BFAB3C0-0000-D82A-698D-80FB000002A9";
+createNode renderLayer -n "defaultRenderLayer";
+	rename -uid "8C4BD2CF-4473-E174-9014-5691D58F89AD";
+	setAttr ".g" yes;
+createNode polyCube -n "polyCube1";
+	rename -uid "75B1910D-4ABF-825A-598C-0EB013287109";
+	setAttr ".cuv" 4;
+createNode polyTorus -n "polyTorus1";
+	rename -uid "402253CC-4CE6-8108-4A0B-16A13669D0DE";
+createNode polyCone -n "polyCone1";
+	rename -uid "E35D3E6D-4142-FA99-8FF5-0192A327C880";
+	setAttr ".cuv" 3;
+createNode polySphere -n "polySphere1";
+	rename -uid "5D5274CD-41F7-DAA9-BB8D-7BB9F125A154";
+createNode aiOptions -s -n "defaultArnoldRenderOptions";
+	rename -uid "3E924C02-4FC5-1DF2-72AD-188276C60AB2";
+	addAttr -ci true -sn "ARV_options" -ln "ARV_options" -dt "string";
+	setAttr ".abort_on_license_fail" no;
+	setAttr ".version" -type "string" "5.1.0";
+createNode aiAOVFilter -s -n "defaultArnoldFilter";
+	rename -uid "5004C0E6-4641-036C-919F-ADAC4F5E2C55";
+	setAttr ".ai_translator" -type "string" "gaussian";
+createNode aiAOVDriver -s -n "defaultArnoldDriver";
+	rename -uid "AA9347D2-45C2-A8C5-28B5-7781D3C8CCDC";
+	setAttr ".ai_translator" -type "string" "png";
+	setAttr ".color_management" 1;
+createNode aiAOVDriver -s -n "defaultArnoldDisplayDriver";
+	rename -uid "4B9E8C0D-4144-79BA-F618-09BF0F5AF648";
+	setAttr ".ai_translator" -type "string" "maya";
+	setAttr ".output_mode" 0;
+createNode aiPhysicalSky -n "aiPhysicalSky1";
+	rename -uid "E94F5828-46DA-C1F2-89A4-089B04BB07CC";
+createNode aiPhysicalSky -n "aiPhysicalSky2";
+	rename -uid "6322621B-43E1-A96B-928B-6C92E653F64B";
+	setAttr ".sun_size" 2.8125;
+createNode script -n "uiConfigurationScriptNode";
+	rename -uid "DA70D2C3-493E-870D-8C33-C1993B0561D7";
+	setAttr ".b" -type "string" (
+		"// Maya Mel UI Configuration File.\n//\n//  This script is machine generated.  Edit at your own risk.\n//\n//\n\nglobal string $gMainPane;\nif (`paneLayout -exists $gMainPane`) {\n\n\tglobal int $gUseScenePanelConfig;\n\tint    $useSceneConfig = $gUseScenePanelConfig;\n\tint    $nodeEditorPanelVisible = stringArrayContains(\"nodeEditorPanel1\", `getPanel -vis`);\n\tint    $nodeEditorWorkspaceControlOpen = (`workspaceControl -exists nodeEditorPanel1Window` && `workspaceControl -q -visible nodeEditorPanel1Window`);\n\tint    $menusOkayInPanels = `optionVar -q allowMenusInPanels`;\n\tint    $nVisPanes = `paneLayout -q -nvp $gMainPane`;\n\tint    $nPanes = 0;\n\tstring $editorName;\n\tstring $panelName;\n\tstring $itemFilterName;\n\tstring $panelConfig;\n\n\t//\n\t//  get current state of the UI\n\t//\n\tsceneUIReplacement -update $gMainPane;\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Top View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Top View\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"|top\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 16384\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n"
+		+ "            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n"
+		+ "            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -bluePencil 1\n            -greasePencils 0\n            -excludeObjectPreset \"All\" \n            -shadows 0\n            -captureSequenceNumber -1\n            -width 1\n            -height 1\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Side View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Side View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"|side\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n"
+		+ "            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 16384\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n"
+		+ "            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -bluePencil 1\n            -greasePencils 0\n            -excludeObjectPreset \"All\" \n"
+		+ "            -shadows 0\n            -captureSequenceNumber -1\n            -width 1\n            -height 1\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Front View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Front View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"|front\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n"
+		+ "            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 16384\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n"
+		+ "            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n"
+		+ "            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -bluePencil 1\n            -greasePencils 0\n            -excludeObjectPreset \"All\" \n            -shadows 0\n            -captureSequenceNumber -1\n            -width 1\n            -height 1\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Persp View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Persp View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n"
+		+ "            -camera \"|persp\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 16384\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n"
+		+ "            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n"
+		+ "            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -bluePencil 1\n            -greasePencils 0\n            -excludeObjectPreset \"All\" \n            -shadows 0\n            -captureSequenceNumber -1\n            -width 1109\n            -height 597\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n"
+		+ "\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"outlinerPanel\" (localizedPanelLabel(\"ToggledOutliner\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\toutlinerPanel -edit -l (localizedPanelLabel(\"ToggledOutliner\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        outlinerEditor -e \n            -docTag \"isolOutln_fromSeln\" \n            -showShapes 0\n            -showAssignedMaterials 0\n            -showTimeEditor 1\n            -showReferenceNodes 1\n            -showReferenceMembers 1\n            -showAttributes 0\n            -showConnected 0\n            -showAnimCurvesOnly 0\n            -showMuteInfo 0\n            -organizeByLayer 1\n            -organizeByClip 1\n            -showAnimLayerWeight 1\n            -autoExpandLayers 1\n            -autoExpand 0\n            -showDagOnly 1\n            -showAssets 1\n            -showContainedOnly 1\n            -showPublishedAsConnected 0\n            -showParentContainers 0\n            -showContainerContents 1\n"
+		+ "            -ignoreDagHierarchy 0\n            -expandConnections 0\n            -showUpstreamCurves 1\n            -showUnitlessCurves 1\n            -showCompounds 1\n            -showLeafs 1\n            -showNumericAttrsOnly 0\n            -highlightActive 1\n            -autoSelectNewObjects 0\n            -doNotSelectNewObjects 0\n            -dropIsParent 1\n            -transmitFilters 0\n            -setFilter \"defaultSetFilter\" \n            -showSetMembers 1\n            -allowMultiSelection 1\n            -alwaysToggleSelect 0\n            -directSelect 0\n            -isSet 0\n            -isSetMember 0\n            -showUfeItems 1\n            -displayMode \"DAG\" \n            -expandObjects 0\n            -setsIgnoreFilters 1\n            -containersIgnoreFilters 0\n            -editAttrName 0\n            -showAttrValues 0\n            -highlightSecondary 0\n            -showUVAttrsOnly 0\n            -showTextureNodesOnly 0\n            -attrAlphaOrder \"default\" \n            -animLayerFilterOptions \"allAffecting\" \n            -sortOrder \"none\" \n"
+		+ "            -longNames 0\n            -niceNames 1\n            -showNamespace 1\n            -showPinIcons 0\n            -mapMotionTrails 0\n            -ignoreHiddenAttribute 0\n            -ignoreOutlinerColor 0\n            -renderFilterVisible 0\n            -renderFilterIndex 0\n            -selectionOrder \"chronological\" \n            -expandAttribute 0\n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"outlinerPanel\" (localizedPanelLabel(\"Outliner\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\toutlinerPanel -edit -l (localizedPanelLabel(\"Outliner\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        outlinerEditor -e \n            -showShapes 0\n            -showAssignedMaterials 0\n            -showTimeEditor 1\n            -showReferenceNodes 0\n            -showReferenceMembers 0\n            -showAttributes 0\n            -showConnected 0\n            -showAnimCurvesOnly 0\n            -showMuteInfo 0\n"
+		+ "            -organizeByLayer 1\n            -organizeByClip 1\n            -showAnimLayerWeight 1\n            -autoExpandLayers 1\n            -autoExpand 0\n            -showDagOnly 1\n            -showAssets 1\n            -showContainedOnly 1\n            -showPublishedAsConnected 0\n            -showParentContainers 0\n            -showContainerContents 1\n            -ignoreDagHierarchy 0\n            -expandConnections 0\n            -showUpstreamCurves 1\n            -showUnitlessCurves 1\n            -showCompounds 1\n            -showLeafs 1\n            -showNumericAttrsOnly 0\n            -highlightActive 1\n            -autoSelectNewObjects 0\n            -doNotSelectNewObjects 0\n            -dropIsParent 1\n            -transmitFilters 0\n            -setFilter \"defaultSetFilter\" \n            -showSetMembers 1\n            -allowMultiSelection 1\n            -alwaysToggleSelect 0\n            -directSelect 0\n            -showUfeItems 1\n            -displayMode \"DAG\" \n            -expandObjects 0\n            -setsIgnoreFilters 1\n"
+		+ "            -containersIgnoreFilters 0\n            -editAttrName 0\n            -showAttrValues 0\n            -highlightSecondary 0\n            -showUVAttrsOnly 0\n            -showTextureNodesOnly 0\n            -attrAlphaOrder \"default\" \n            -animLayerFilterOptions \"allAffecting\" \n            -sortOrder \"none\" \n            -longNames 0\n            -niceNames 1\n            -showNamespace 1\n            -showPinIcons 0\n            -mapMotionTrails 0\n            -ignoreHiddenAttribute 0\n            -ignoreOutlinerColor 0\n            -renderFilterVisible 0\n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"graphEditor\" (localizedPanelLabel(\"Graph Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Graph Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"OutlineEd\");\n            outlinerEditor -e \n                -showShapes 1\n"
+		+ "                -showAssignedMaterials 0\n                -showTimeEditor 1\n                -showReferenceNodes 0\n                -showReferenceMembers 0\n                -showAttributes 1\n                -showConnected 1\n                -showAnimCurvesOnly 1\n                -showMuteInfo 0\n                -organizeByLayer 1\n                -organizeByClip 1\n                -showAnimLayerWeight 1\n                -autoExpandLayers 1\n                -autoExpand 1\n                -showDagOnly 0\n                -showAssets 1\n                -showContainedOnly 0\n                -showPublishedAsConnected 0\n                -showParentContainers 0\n                -showContainerContents 0\n                -ignoreDagHierarchy 0\n                -expandConnections 1\n                -showUpstreamCurves 1\n                -showUnitlessCurves 1\n                -showCompounds 0\n                -showLeafs 1\n                -showNumericAttrsOnly 1\n                -highlightActive 0\n                -autoSelectNewObjects 1\n                -doNotSelectNewObjects 0\n"
+		+ "                -dropIsParent 1\n                -transmitFilters 1\n                -setFilter \"0\" \n                -showSetMembers 0\n                -allowMultiSelection 1\n                -alwaysToggleSelect 0\n                -directSelect 0\n                -showUfeItems 1\n                -displayMode \"DAG\" \n                -expandObjects 0\n                -setsIgnoreFilters 1\n                -containersIgnoreFilters 0\n                -editAttrName 0\n                -showAttrValues 0\n                -highlightSecondary 0\n                -showUVAttrsOnly 0\n                -showTextureNodesOnly 0\n                -attrAlphaOrder \"default\" \n                -animLayerFilterOptions \"allAffecting\" \n                -sortOrder \"none\" \n                -longNames 0\n                -niceNames 1\n                -showNamespace 1\n                -showPinIcons 1\n                -mapMotionTrails 1\n                -ignoreHiddenAttribute 0\n                -ignoreOutlinerColor 0\n                -renderFilterVisible 0\n                $editorName;\n"
+		+ "\n\t\t\t$editorName = ($panelName+\"GraphEd\");\n            animCurveEditor -e \n                -displayValues 0\n                -snapTime \"integer\" \n                -snapValue \"none\" \n                -showPlayRangeShades \"on\" \n                -lockPlayRangeShades \"off\" \n                -smoothness \"fine\" \n                -resultSamples 1\n                -resultScreenSamples 0\n                -resultUpdate \"delayed\" \n                -showUpstreamCurves 1\n                -tangentScale 1\n                -tangentLineThickness 1\n                -keyMinScale 1\n                -stackedCurvesMin -1\n                -stackedCurvesMax 1\n                -stackedCurvesSpace 0.2\n                -preSelectionHighlight 0\n                -limitToSelectedCurves 0\n                -constrainDrag 0\n                -valueLinesToggle 1\n                -highlightAffectedCurves 0\n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"dopeSheetPanel\" (localizedPanelLabel(\"Dope Sheet\")) `;\n"
+		+ "\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Dope Sheet\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"OutlineEd\");\n            outlinerEditor -e \n                -showShapes 1\n                -showAssignedMaterials 0\n                -showTimeEditor 1\n                -showReferenceNodes 0\n                -showReferenceMembers 0\n                -showAttributes 1\n                -showConnected 1\n                -showAnimCurvesOnly 1\n                -showMuteInfo 0\n                -organizeByLayer 1\n                -organizeByClip 1\n                -showAnimLayerWeight 1\n                -autoExpandLayers 1\n                -autoExpand 1\n                -showDagOnly 0\n                -showAssets 1\n                -showContainedOnly 0\n                -showPublishedAsConnected 0\n                -showParentContainers 0\n                -showContainerContents 0\n                -ignoreDagHierarchy 0\n                -expandConnections 1\n"
+		+ "                -showUpstreamCurves 1\n                -showUnitlessCurves 0\n                -showCompounds 0\n                -showLeafs 1\n                -showNumericAttrsOnly 1\n                -highlightActive 0\n                -autoSelectNewObjects 0\n                -doNotSelectNewObjects 1\n                -dropIsParent 1\n                -transmitFilters 0\n                -setFilter \"0\" \n                -showSetMembers 0\n                -allowMultiSelection 1\n                -alwaysToggleSelect 0\n                -directSelect 0\n                -showUfeItems 1\n                -displayMode \"DAG\" \n                -expandObjects 0\n                -setsIgnoreFilters 1\n                -containersIgnoreFilters 0\n                -editAttrName 0\n                -showAttrValues 0\n                -highlightSecondary 0\n                -showUVAttrsOnly 0\n                -showTextureNodesOnly 0\n                -attrAlphaOrder \"default\" \n                -animLayerFilterOptions \"allAffecting\" \n                -sortOrder \"none\" \n"
+		+ "                -longNames 0\n                -niceNames 1\n                -showNamespace 1\n                -showPinIcons 0\n                -mapMotionTrails 1\n                -ignoreHiddenAttribute 0\n                -ignoreOutlinerColor 0\n                -renderFilterVisible 0\n                $editorName;\n\n\t\t\t$editorName = ($panelName+\"DopeSheetEd\");\n            dopeSheetEditor -e \n                -displayValues 0\n                -snapTime \"none\" \n                -snapValue \"none\" \n                -outliner \"dopeSheetPanel1OutlineEd\" \n                -hierarchyBelow 0\n                -selectionWindow 0 0 0 0 \n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"timeEditorPanel\" (localizedPanelLabel(\"Time Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Time Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n"
+		+ "\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"clipEditorPanel\" (localizedPanelLabel(\"Trax Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Trax Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = clipEditorNameFromPanel($panelName);\n            clipEditor -e \n                -displayValues 0\n                -snapTime \"none\" \n                -snapValue \"none\" \n                -initialized 0\n                -manageSequencer 0 \n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"sequenceEditorPanel\" (localizedPanelLabel(\"Camera Sequencer\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Camera Sequencer\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = sequenceEditorNameFromPanel($panelName);\n            clipEditor -e \n                -displayValues 0\n"
+		+ "                -snapTime \"none\" \n                -snapValue \"none\" \n                -initialized 0\n                -manageSequencer 1 \n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"hyperGraphPanel\" (localizedPanelLabel(\"Hypergraph Hierarchy\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Hypergraph Hierarchy\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"HyperGraphEd\");\n            hyperGraph -e \n                -graphLayoutStyle \"hierarchicalLayout\" \n                -orientation \"horiz\" \n                -mergeConnections 0\n                -zoom 1\n                -animateTransition 0\n                -showRelationships 1\n                -showShapes 0\n                -showDeformers 0\n                -showExpressions 0\n                -showConstraints 0\n                -showConnectionFromSelected 0\n                -showConnectionToSelected 0\n"
+		+ "                -showConstraintLabels 0\n                -showUnderworld 0\n                -showInvisible 0\n                -transitionFrames 1\n                -opaqueContainers 0\n                -freeform 0\n                -imagePosition 0 0 \n                -imageScale 1\n                -imageEnabled 0\n                -graphType \"DAG\" \n                -heatMapDisplay 0\n                -updateSelection 1\n                -updateNodeAdded 1\n                -useDrawOverrideColor 0\n                -limitGraphTraversal -1\n                -range 0 0 \n                -iconSize \"smallIcons\" \n                -showCachedConnections 0\n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"hyperShadePanel\" (localizedPanelLabel(\"Hypershade\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Hypershade\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n"
+		+ "\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"visorPanel\" (localizedPanelLabel(\"Visor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Visor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"nodeEditorPanel\" (localizedPanelLabel(\"Node Editor\")) `;\n\tif ($nodeEditorPanelVisible || $nodeEditorWorkspaceControlOpen) {\n\t\tif (\"\" == $panelName) {\n\t\t\tif ($useSceneConfig) {\n\t\t\t\t$panelName = `scriptedPanel -unParent  -type \"nodeEditorPanel\" -l (localizedPanelLabel(\"Node Editor\")) -mbv $menusOkayInPanels `;\n\n\t\t\t$editorName = ($panelName+\"NodeEditorEd\");\n            nodeEditor -e \n                -allAttributes 0\n                -allNodes 0\n                -autoSizeNodes 1\n                -consistentNameSize 1\n                -createNodeCommand \"nodeEdCreateNodeCommand\" \n                -connectNodeOnCreation 0\n"
+		+ "                -connectOnDrop 0\n                -copyConnectionsOnPaste 0\n                -connectionStyle \"bezier\" \n                -defaultPinnedState 0\n                -additiveGraphingMode 0\n                -connectedGraphingMode 1\n                -settingsChangedCallback \"nodeEdSyncControls\" \n                -traversalDepthLimit -1\n                -keyPressCommand \"nodeEdKeyPressCommand\" \n                -nodeTitleMode \"name\" \n                -gridSnap 0\n                -gridVisibility 1\n                -crosshairOnEdgeDragging 0\n                -popupMenuScript \"nodeEdBuildPanelMenus\" \n                -showNamespace 1\n                -showShapes 1\n                -showSGShapes 0\n                -showTransforms 1\n                -useAssets 1\n                -syncedSelection 1\n                -extendToShapes 1\n                -showUnitConversions 0\n                -editorMode \"default\" \n                -hasWatchpoint 0\n                $editorName;\n\t\t\t}\n\t\t} else {\n\t\t\t$label = `panel -q -label $panelName`;\n"
+		+ "\t\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Node Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"NodeEditorEd\");\n            nodeEditor -e \n                -allAttributes 0\n                -allNodes 0\n                -autoSizeNodes 1\n                -consistentNameSize 1\n                -createNodeCommand \"nodeEdCreateNodeCommand\" \n                -connectNodeOnCreation 0\n                -connectOnDrop 0\n                -copyConnectionsOnPaste 0\n                -connectionStyle \"bezier\" \n                -defaultPinnedState 0\n                -additiveGraphingMode 0\n                -connectedGraphingMode 1\n                -settingsChangedCallback \"nodeEdSyncControls\" \n                -traversalDepthLimit -1\n                -keyPressCommand \"nodeEdKeyPressCommand\" \n                -nodeTitleMode \"name\" \n                -gridSnap 0\n                -gridVisibility 1\n                -crosshairOnEdgeDragging 0\n                -popupMenuScript \"nodeEdBuildPanelMenus\" \n                -showNamespace 1\n"
+		+ "                -showShapes 1\n                -showSGShapes 0\n                -showTransforms 1\n                -useAssets 1\n                -syncedSelection 1\n                -extendToShapes 1\n                -showUnitConversions 0\n                -editorMode \"default\" \n                -hasWatchpoint 0\n                $editorName;\n\t\t\tif (!$useSceneConfig) {\n\t\t\t\tpanel -e -l $label $panelName;\n\t\t\t}\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"createNodePanel\" (localizedPanelLabel(\"Create Node\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Create Node\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"polyTexturePlacementPanel\" (localizedPanelLabel(\"UV Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"UV Editor\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"renderWindowPanel\" (localizedPanelLabel(\"Render View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Render View\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"shapePanel\" (localizedPanelLabel(\"Shape Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tshapePanel -edit -l (localizedPanelLabel(\"Shape Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"posePanel\" (localizedPanelLabel(\"Pose Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tposePanel -edit -l (localizedPanelLabel(\"Pose Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n"
+		+ "\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"dynRelEdPanel\" (localizedPanelLabel(\"Dynamic Relationships\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Dynamic Relationships\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"relationshipPanel\" (localizedPanelLabel(\"Relationship Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Relationship Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"referenceEditorPanel\" (localizedPanelLabel(\"Reference Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Reference Editor\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"dynPaintScriptedPanelType\" (localizedPanelLabel(\"Paint Effects\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Paint Effects\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"scriptEditorPanel\" (localizedPanelLabel(\"Script Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Script Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"profilerPanel\" (localizedPanelLabel(\"Profiler Tool\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Profiler Tool\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"contentBrowserPanel\" (localizedPanelLabel(\"Content Browser\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Content Browser\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"Stereo\" (localizedPanelLabel(\"Stereo\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Stereo\")) -mbv $menusOkayInPanels  $panelName;\n{ string $editorName = ($panelName+\"Editor\");\n            stereoCameraView -e \n                -camera \"|persp\" \n                -useInteractiveMode 0\n                -displayLights \"default\" \n                -displayAppearance \"wireframe\" \n                -activeOnly 0\n                -ignorePanZoom 0\n                -wireframeOnShaded 0\n"
+		+ "                -headsUpDisplay 1\n                -holdOuts 1\n                -selectionHiliteDisplay 1\n                -useDefaultMaterial 0\n                -bufferMode \"double\" \n                -twoSidedLighting 1\n                -backfaceCulling 0\n                -xray 0\n                -jointXray 0\n                -activeComponentsXray 0\n                -displayTextures 0\n                -smoothWireframe 0\n                -lineWidth 1\n                -textureAnisotropic 0\n                -textureHilight 1\n                -textureSampling 2\n                -textureDisplay \"modulate\" \n                -textureMaxSize 16384\n                -fogging 0\n                -fogSource \"fragment\" \n                -fogMode \"linear\" \n                -fogStart 0\n                -fogEnd 100\n                -fogDensity 0.1\n                -fogColor 0.5 0.5 0.5 1 \n                -depthOfFieldPreview 1\n                -maxConstantTransparency 1\n                -objectFilterShowInHUD 1\n                -isFiltered 0\n                -colorResolution 4 4 \n"
+		+ "                -bumpResolution 4 4 \n                -textureCompression 0\n                -transparencyAlgorithm \"frontAndBackCull\" \n                -transpInShadows 0\n                -cullingOverride \"none\" \n                -lowQualityLighting 0\n                -maximumNumHardwareLights 0\n                -occlusionCulling 0\n                -shadingModel 0\n                -useBaseRenderer 0\n                -useReducedRenderer 0\n                -smallObjectCulling 0\n                -smallObjectThreshold -1 \n                -interactiveDisableShadows 0\n                -interactiveBackFaceCull 0\n                -sortTransparent 1\n                -controllers 1\n                -nurbsCurves 1\n                -nurbsSurfaces 1\n                -polymeshes 1\n                -subdivSurfaces 1\n                -planes 1\n                -lights 1\n                -cameras 1\n                -controlVertices 1\n                -hulls 1\n                -grid 1\n                -imagePlane 1\n                -joints 1\n                -ikHandles 1\n"
+		+ "                -deformers 1\n                -dynamics 1\n                -particleInstancers 1\n                -fluids 1\n                -hairSystems 1\n                -follicles 1\n                -nCloths 1\n                -nParticles 1\n                -nRigids 1\n                -dynamicConstraints 1\n                -locators 1\n                -manipulators 1\n                -pluginShapes 1\n                -dimensions 1\n                -handles 1\n                -pivots 1\n                -textures 1\n                -strokes 1\n                -motionTrails 1\n                -clipGhosts 1\n                -bluePencil 1\n                -greasePencils 0\n                -shadows 0\n                -captureSequenceNumber -1\n                -width 0\n                -height 0\n                -sceneRenderFilter 0\n                -displayMode \"centerEye\" \n                -viewColor 0 0 0 1 \n                -useCustomBackground 1\n                $editorName;\n            stereoCameraView -e -viewSelected 0 $editorName;\n            stereoCameraView -e \n"
+		+ "                -pluginObjects \"gpuCacheDisplayFilter\" 1 \n                $editorName; };\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\tif ($useSceneConfig) {\n        string $configName = `getPanel -cwl (localizedPanelLabel(\"Current Layout\"))`;\n        if (\"\" != $configName) {\n\t\t\tpanelConfiguration -edit -label (localizedPanelLabel(\"Current Layout\")) \n\t\t\t\t-userCreated false\n\t\t\t\t-defaultImage \"vacantCell.xP:/\"\n\t\t\t\t-image \"\"\n\t\t\t\t-sc false\n\t\t\t\t-configString \"global string $gMainPane; paneLayout -e -cn \\\"single\\\" -ps 1 100 100 $gMainPane;\"\n\t\t\t\t-removeAllPanels\n\t\t\t\t-ap false\n\t\t\t\t\t(localizedPanelLabel(\"Persp View\")) \n\t\t\t\t\t\"modelPanel\"\n"
+		+ "\t\t\t\t\t\"$panelName = `modelPanel -unParent -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels `;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"default\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 0\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 16384\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -bluePencil 1\\n    -greasePencils 0\\n    -excludeObjectPreset \\\"All\\\" \\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 1109\\n    -height 597\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    $editorName\"\n"
+		+ "\t\t\t\t\t\"modelPanel -edit -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels  $panelName;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"default\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 0\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 16384\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -bluePencil 1\\n    -greasePencils 0\\n    -excludeObjectPreset \\\"All\\\" \\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 1109\\n    -height 597\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    $editorName\"\n"
+		+ "\t\t\t\t$configName;\n\n            setNamedPanelLayout (localizedPanelLabel(\"Current Layout\"));\n        }\n\n        panelHistory -e -clear mainPanelHistory;\n        sceneUIReplacement -clear;\n\t}\n\n\ngrid -spacing 5 -size 12 -divisions 5 -displayAxes yes -displayGridLines yes -displayDivisionLines yes -displayPerspectiveLabels no -displayOrthographicLabels no -displayAxesBold yes -perspectiveLabelPosition axis -orthographicLabelPosition edge;\nviewManip -drawCompass 0 -compassAngle 0 -frontParameters \"\" -homeParameters \"\" -selectionLockParameters \"\";\n}\n");
+	setAttr ".st" 3;
+createNode script -n "sceneConfigurationScriptNode";
+	rename -uid "D94E38F3-4FF6-8C5A-3CB4-09B9202004CF";
+	setAttr ".b" -type "string" "playbackOptions -min 1 -max 120 -ast 1 -aet 200 ";
+	setAttr ".st" 6;
+createNode VRaySettingsNode -s -n "vraySettings";
+	rename -uid "3B5A83C0-0000-D2E7-698D-7FFD000002B7";
+	setAttr ".sver" 2;
+	setAttr ".gi" yes;
+	setAttr ".rfc" yes;
+	setAttr ".pe" 2;
+	setAttr ".se" 3;
+	setAttr ".cmph" 60;
+	setAttr ".csdu" 0;
+	setAttr ".csdp" 1;
+	setAttr ".cfile" -type "string" "";
+	setAttr ".cfile2" -type "string" "";
+	setAttr ".casf" -type "string" "";
+	setAttr ".casf2" -type "string" "";
+	setAttr ".st" 3;
+	setAttr ".msr" 6;
+	setAttr ".aaft" 3;
+	setAttr ".aafs" 2;
+	setAttr ".dma" 24;
+	setAttr ".dam" 1;
+	setAttr ".dac" 1.5;
+	setAttr ".pt" 0.0099999997764825821;
+	setAttr ".pmt" 0;
+	setAttr ".sd" 1000;
+	setAttr ".ss" 0.01;
+	setAttr ".pfts" 20;
+	setAttr ".ufg" yes;
+	setAttr ".fnm" -type "string" "";
+	setAttr ".lcfnm" -type "string" "";
+	setAttr ".asf" -type "string" "";
+	setAttr ".lcasf" -type "string" "";
+	setAttr ".urtrshd" yes;
+	setAttr ".rtrshd" 2;
+	setAttr ".lightCacheType" 1;
+	setAttr ".ifile" -type "string" "";
+	setAttr ".ifile2" -type "string" "";
+	setAttr ".iasf" -type "string" "";
+	setAttr ".iasf2" -type "string" "";
+	setAttr ".pmfile" -type "string" "";
+	setAttr ".pmfile2" -type "string" "";
+	setAttr ".pmasf" -type "string" "";
+	setAttr ".pmasf2" -type "string" "";
+	setAttr ".dmcstd" yes;
+	setAttr ".dmculs" no;
+	setAttr ".dmcsat" 0.004999999888241291;
+	setAttr ".cmtp" 6;
+	setAttr ".cmao" 2;
+	setAttr ".cg" 2.2000000476837158;
+	setAttr ".mtah" yes;
+	setAttr ".rgbcs" -1;
+	setAttr ".suv" 0;
+	setAttr ".srflc" 1;
+	setAttr ".seu" yes;
+	setAttr ".gomsb" yes;
+	setAttr ".gormio" yes;
+	setAttr ".gocle" yes;
+	setAttr ".gopl" 2;
+	setAttr ".gopv" yes;
+	setAttr ".gopvgs" 1;
+	setAttr ".wi" 960;
+	setAttr ".he" 540;
+	setAttr ".aspr" 1.7777780294418335;
+	setAttr ".productionGPUResizeTextures" 0;
+	setAttr ".autolt" 0;
+	setAttr ".jpegq" 100;
+	setAttr ".vfbOn" yes;
+	setAttr ".vfbSA" -type "Int32Array" 1115 0 4450 1 4438 0 1
+		 4430 1700143739 1869181810 825893486 1632379436 1936876921 578501154 1936876886 577662825 573321530 1935764579 574235251
+		 1953460082 1881287714 1701867378 1701409906 2067407475 1919252002 1852795251 741423650 1835101730 574235237 1696738338 1818386798
+		 1949966949 744846706 1886938402 577007201 1818322490 573334899 1634760805 1650549870 975332716 1702195828 1931619453 1814913653
+		 1919252833 1530536563 1818436219 577991521 1751327290 779317089 1886611812 1132028268 1701999215 1869182051 573317742 1886351984
+		 1769239141 975336293 1702240891 1869181810 825893486 1634607660 975332717 1936278562 2036427888 1919894304 1952671090 577662825
+		 1852121644 1701601889 1920219682 573334901 1634760805 975332462 1702195828 2019893804 1684955504 1701601889 1920219682 573334901
+		 1718579824 577072233 573321786 1869641829 1701999987 774912546 1931619376 1600484961 1600284530 1835627120 1986622569 975336293
+		 1936482662 1864510565 1601136995 1701603686 790772258 796029813 1869903201 1802724708 2036428079 842019425 1701982005 1920298867
+		 796091747 1330201423 1852793645 1936157030 2036419887 842019425 1701063986 1819631974 1868771188 1734960750 1768124206 573317743
+		 1869177711 1819239263 1886614127 577069921 573322554 1869177711 1936286815 2036427888 1769366884 975332707 1864510512 1601136995
+		 2003134838 1851880052 1919903347 809116269 1668227628 1935634281 1768257121 1634560366 975332711 1936482662 1763847269 1717527395
+		 577072233 740434490 1667459362 1869770847 1701603686 1952539743 1849303649 745303157 1667459362 1852142175 1953392996 578055781
+		 573321274 1886088290 1852793716 1715085942 1702063201 1931619453 1814913653 1919252833 1530536563 1818436219 577991521 1751327290
+		 779317089 778462578 1920298867 1868981603 1919247468 1881287714 1701867378 1701409906 2067407475 1919252002 1852795251 741423650
+		 1835101730 574235237 1920298835 540697955 574768978 1852121644 1701601889 1920219682 573334901 1634760805 975332462 1936482662
+		 1696738405 1851879544 1818386788 1715085925 1702063201 1818370604 1600417381 1701080941 741358114 1634758434 2037672291 774978082
+		 1931619376 1601662824 1986359920 578250089 1970435130 1931619429 1952408434 577073273 746401850 1651864354 2036427821 577991269
+		 578509626 1935764579 574235251 1868654691 1701981811 1768697446 1836345447 740456553 1869770786 1953654128 577987945 1981971258
+		 1769173605 975335023 1847733297 577072481 1766597178 1299474535 740456553 1634624802 577072226 1818322490 573334899 1634760805
+		 975332462 1936482662 1696738405 1851879544 1818386788 1949966949 2103801202 1970479660 1634479458 1936876921 1566259746 578497661
+		 1935764579 574235251 1868654691 1701981811 1868770918 1936683117 577074281 1919951404 1919250543 1936025972 578501154 1936876918
+		 577662825 573321530 1701667182 1126316578 1869639023 1702127987 1696738338 1818386798 1715085925 1702063201 2019893804 1684955504
+		 1634089506 744846188 1886938402 1633971809 577072226 1970435130 1646406757 1684956524 1685024095 809116261 1886331436 1953063777
+		 825893497 573321262 2003789939 1701998687 2003134838 1920219682 746415477 1651864354 2036427821 577991269 2103270202 2066513245
+		 1634493218 975336307 1634231074 1882092399 1701064293 1936289646 740455013 1869770786 1953654128 577987945 1981971258 1769173605
+		 975335023 1847733297 577072481 1698964026 1936289646 540701285 1986096757 1634494817 577072226 1852121644 1701601889 1634089506
+		 744846188 1886938402 577007201 1818322490 573334899 1634760805 1650549870 975332716 1702195828 1818370604 1600417381 1701080941
+		 741358114 1634758434 2037672291 774978082 1931619376 1601662824 1986359920 578250089 1970435130 1629629541 1986622563 1715085925
+		 1702063201 1919951404 1952805733 741489186 1920234274 1952935525 825893480 573321262 1768186226 975336309 808333361 2003313196
+		 1701012289 1634887020 975332724 1702195828 1701061164 1936289646 1834971749 577070191 746402106 1651864354 2036427821 577991269
+		 2103270202 1663204140 1936941420 1663187490 1936679272 778399790 1918986355 778986864 1920298082 1881287714 1701867378 1701409906
+		 2067407475 1919252002 1852795251 741423650 1835101730 574235237 1918986323 795764080 1920298050 1696738338 1818386798 1715085925
+		 1702063201 2019893804 1684955504 1634089506 744846188 1886938402 1633971809 577072226 1970435130 1646406757 1684956524 1685024095
+		 809116261 1886331436 1953063777 825893497 573321262 2003789939 1701998687 2003134838 1920219682 573334901 1918986355 1601070448
+		 1920298082 1836016479 1702131056 1634089506 744846188 1634235170 1852141682 1869439327 578055797 808333626 1752375852 1701868129
+		 1634885486 1937074532 774912546 1646406709 1601336684 1768186226 975336309 858992177 808464432 959591472 746403121 1651864354
+		 2036427821 577991269 2103270202 1663204140 1936941420 1663187490 1936679272 778399790 1936614764 740456550 1869770786 1953654128
+		 577987945 1981971258 1769173605 975335023 1847733297 577072481 1699488314 1159754606 1667589734 740455284 1634624802 577072226
+		 1818322490 573334899 1634760805 975332462 1936482662 1696738405 1851879544 1818386788 1949966949 744846706 1701601826 1834968174
+		 577070191 573321786 1667330159 578385001 808333626 1752375852 1885304687 1769366898 975337317 1702195828 1818698284 1600483937
+		 975335023 1936482662 1730292837 1701994860 2053731167 859447909 741355056 1634494242 2002740594 1751607653 825893492 573321262
+		 1869573218 1702322029 1952999273 774912546 808464436 808464432 741751093 1634494242 1952408946 1936028264 1684828008 774978082
+		 1713515568 1702128745 1869766514 1769234804 975335023 741355056 1952543522 1952543349 577662825 808333626 1634214444 1635214450
+		 1633641842 1818583907 1952543333 975332453 1702195828 1868767788 2002740332 577598049 1818322490 573334899 1702129257 1952670066
+		 577074793 1970435130 1931619429 1600484961 1918987367 1949966949 744846706 1801544226 1818713957 1600483937 1734960503 975336552
+		 1936482662 1663183973 1952540018 1717919589 1952671078 1701994355 1953265011 1634231135 1818586734 1634089506 744846188 1634624802
+		 1600482402 1684106338 975336293 1702195828 1769153068 577987940 573322810 1684106338 1918858085 1952543855 577662825 775237946
+		 1931619376 1634038388 1818386283 975336053 808594992 808464432 959590448 1965173816 1734305139 1769234802 975333230 1936482662
+		 1730292837 1769234802 1683973998 1769172581 975337844 808333365 1919361580 1852404833 1701601127 1752459118 808532514 573321262
+		 1952543335 1600613993 1836019578 775240226 1730292784 1769234802 1935632238 1701867372 774912546 1730292784 1769234802 1935632238
+		 1852142196 577270887 808333626 1937056300 1668243301 1937075299 577662825 1818322490 573334899 1818452847 1869181813 2037604206
+		 1952804205 576940402 1970435130 1864510565 1970037603 1852795251 1919250527 1953391971 808598050 573321262 1818452847 1869181813
+		 1869766510 1769234804 975335023 741355056 1667460898 1769174380 1633644143 975332210 774910001 1965173808 1935631731 1952543331
+		 975333475 1936482662 1931619429 1935635043 1701670265 1667854964 1920219682 573334901 1601332083 1953784176 577663589 573321274
+		 1601332083 1953265005 1634494313 1667196274 1953396079 741423650 1919120162 1852138591 2037672307 808794658 573321262 1601332083
+		 1735288172 975333492 808333365 1668489772 1819500402 1600483439 1769103734 1701015137 774912546 1931619376 2002743907 1752458345
+		 1918989919 1668178281 809116261 573321262 1601332083 1684366707 741358114 1919120162 1869576799 842670701 573321262 1601332083
+		 1635020658 1852795252 774912546 1931619376 1935635043 1852142196 577270887 808333626 1937056300 1969512293 975336563 1936482662
+		 1679961189 1601467253 1953784176 577663589 573321274 1953723748 1852138591 2037672307 808794658 573321262 1953723748 1684107871
+		 1601402217 1769103734 1701015137 774912546 1679961136 1601467253 1953786218 975336037 741355056 1937073186 1870290804 975334767
+		 741355058 1937073186 1869766516 1769234804 975335023 741355056 1937073186 1953718132 1735288178 975333492 741355057 1634494242
+		 1969186162 1868522867 1635021666 1600482403 1734438249 1715085925 1702063201 1818698284 1600483937 1953718895 1701602145 1634560351
+		 1885300071 577270881 740434490 1935830818 1835622260 1600481121 1836019578 774978082 1864510512 1601467234 1734438249 1869766501
+		 1769234804 975335023 741355056 1935830818 1835622260 1600481121 1701999731 1752459118 774978082 1965173808 1717527923 1702128745
+		 1835622258 577070945 1818322490 573334899 1918987367 1835622245 1600481121 1752457584 572668450 1937056300 1751342949 1634561906
+		 1600350580 1919246945 1769234802 975335023 1936482662 1663183973 1836020328 1667855457 1700946271 1952543346 577662825 825110586
+		 808464432 825241648 573323572 1701667171 1952407922 577073273 573321274 1919251571 1834970981 577070191 746401850 1651864354
+		 2036427821 577991269 2103270202 2066513245 1634493218 975336307 1634231074 1865315183 1819436406 1932425569 1886216564 1881287714
+		 1701867378 1701409906 2067407475 1919252002 1852795251 741423650 1835101730 574235237 1835103315 573317744 1650552421 975332716
+		 1936482662 1696738405 1851879544 1715085924 1702063201 2019893804 1684955504 1701601889 1920219682 573334901 1835103347 1869111152
+		 1601857906 1734962273 825893486 1953702444 1601203553 1953654134 1768710495 975335015 573321779 1835103347 1868783472 577924972
+		 774986554 774974512 774974512 573332784 1835103347 1868980080 975336558 1702240891 1869181810 825893486 1869619756 1601465961
+		 1702521203 808532514 1634083372 2037148013 741358114 2037674786 975332716 1998728240 1751607653 809116276 1634083372 975332707
+		 1769095458 2099407969 1953702444 1601203553 1769108595 975333230 1702240891 1869181810 825893486 1634869804 1953718135 1735289202
+		 572668450 1768301100 1600938350 1769108595 975333230 2105352738 1970479660 1634479458 1936876921 1566259746 746413437 1734693410
+		 1198419817 975335013 1702240891 1869181810 825893486 1869423148 1600484213 1819045734 1700755311 1818386798 975332453 1936482662
+		 1830956133 1702065519 1819240031 1601662828 1852403568 1869373300 1684368227 1634089506 744846188 1970236706 1717527923 1869376623
+		 1869635447 1601465961 809116280 1869423148 1600484213 1819045734 1885304687 1953393007 975337823 573340976 1684956498 1767273061
+		 975337317 1702240891 1869181810 825893486 1852121644 1701601889 1852142175 1601332580 1768383858 975335023 1936482662 1914842213
+		 1869178725 1869438830 975332708 573323060 1684956530 1918857829 1869178725 813195118 825047586 573321262 1684956530 1918857829
+		 1869178725 813260654 825047586 573321262 1684956530 1918857829 1869178725 829972334 825047586 573321262 1684956530 1918857829
+		 1869178725 830037870 825047586 573321262 2037149552 1734701663 1936617321 578501154 1936876918 577662825 573322042 2037149552
+		 1936617319 1566259746 1981951101 1601660265 577004914 1970435130 1981951077 1601660265 1701147239 1949966958 744846706 1701410338
+		 1818386295 975332725 1702195828 1769349676 1834973029 577728111 1818322490 573334899 1869377379 1818451826 1601203553 1701080941
+		 959855138 1868767788 1601335148 1835101283 1852792688 1920219682 573334901 1600484213 1702390128 1935761260 1952671088 577662815
+		 1818322490 573334899 1600484213 1869504880 1634558322 1701410399 1852792695 1634089506 744846188 2020175906 1767861349 1601136238
+		 1801678700 975332453 1936482662 1881287781 1818589289 1718511967 1868783471 1667592818 1600415092 1869377379 975336306 1936482662
+		 1931619429 1701995892 1869438831 975332708 1814178864 1601467233 1684956530 2002743909 1752458345 741358114 1935764514 1701994356
+		 1919247470 1768253535 578054247 746401850 1952661794 1936617321 578501154 1936876918 577662825 573321530 1937072496 1380993381
+		 1701339999 1684368227 1634089506 744846188 1936028706 1936020084 1684107871 975335273 573321525 1953719668 1601398098 1667590243
+		 577004907 1818322490 573334899 1969382756 1634227047 1735289188 1684107871 975335273 573322805 1969382756 1634227047 1735289188
+		 1701339999 1684368227 1634089506 744846188 1702130466 1299146098 1600480367 1768186226 926556783 1931619384 1701995892 1685015919
+		 1751342949 1701536613 1715085924 1702063201 32125 ;
+	setAttr ".vfbSyncM" yes;
+	setAttr ".mSceneName" -type "string" "/home/ec2-user/Downloads/deadline-cloud-for-maya/test/integ/test_scripts/mtoa_test/scene/test.ma";
+	setAttr ".rt_cpuRayBundleSize" 4;
+	setAttr ".rt_gpuRayBundleSize" 256;
+	setAttr ".rt_gpuRaysPerPixel" 2;
+	setAttr ".rt_maxPaths" 10000;
+	setAttr ".rt_engineType" 3;
+	setAttr ".rt_gpuResizeTextures" 0;
+createNode RedshiftOptions -s -n "redshiftOptions";
+	rename -uid "3B5A83C0-0000-D2E7-698D-7FFE000002B8";
+	setAttr ".version" 9;
+	setAttr ".denoiseOIDNQuality" 2;
+	setAttr ".primaryGIEngine" 4;
+	setAttr ".secondaryGIEngine" 2;
+	setAttr ".numGIBounces" 4;
+	setAttr ".causticsEnable" yes;
+createNode RedshiftPostEffects -n "defaultRedshiftPostEffects";
+	rename -uid "3B5A83C0-0000-D2E7-698D-7FFE000002B9";
+	setAttr ".v" 2;
+	setAttr -s 2 ".cr[1]" -type "float2" 1 1;
+	setAttr -s 2 ".cg[1]" -type "float2" 1 1;
+	setAttr -s 2 ".cb[1]" -type "float2" 1 1;
+	setAttr -s 2 ".cl[1]" -type "float2" 1 1;
+createNode renderSetup -n "renderSetup";
+	rename -uid "3B5A83C0-0000-D2E7-698D-8000000002BE";
+select -ne :time1;
+	setAttr ".o" 1;
+	setAttr ".unw" 1;
+select -ne :hardwareRenderingGlobals;
+	setAttr ".otfna" -type "stringArray" 22 "NURBS Curves" "NURBS Surfaces" "Polygons" "Subdiv Surface" "Particles" "Particle Instance" "Fluids" "Strokes" "Image Planes" "UI" "Lights" "Cameras" "Locators" "Joints" "IK Handles" "Deformers" "Motion Trails" "Components" "Hair Systems" "Follicles" "Misc. UI" "Ornaments"  ;
+	setAttr ".otfva" -type "Int32Array" 22 0 1 1 1 1 1
+		 1 1 1 0 0 0 0 0 0 0 0 0
+		 0 0 0 0 ;
+	setAttr ".dli" 1;
+	setAttr ".fprt" yes;
+	setAttr ".rtfm" 1;
+select -ne :renderPartition;
+	setAttr -s 2 ".st";
+select -ne :renderGlobalsList1;
+select -ne :defaultShaderList1;
+	setAttr -s 5 ".s";
+select -ne :postProcessList1;
+	setAttr -s 2 ".p";
+select -ne :defaultRenderUtilityList1;
+select -ne :defaultRenderingList1;
+select -ne :lightList1;
+select -ne :standardSurface1;
+	setAttr ".bc" -type "float3" 0.40000001 0.40000001 0.40000001 ;
+	setAttr ".sr" 0.40000000596046448;
+select -ne :initialShadingGroup;
+	setAttr -s 4 ".dsm";
+	setAttr ".ro" yes;
+select -ne :initialParticleSE;
+	setAttr ".ro" yes;
+select -ne :defaultRenderGlobals;
+	addAttr -ci true -h true -sn "dss" -ln "defaultSurfaceShader" -dt "string";
+	setAttr ".ren" -type "string" "arnold";
+	setAttr ".outf" 51;
+	setAttr ".imfkey" -type "string" "png";
+	setAttr ".ifp" -type "string" "arnoldmayascene";
+	setAttr ".dss" -type "string" "lambert1";
+select -ne :defaultResolution;
+	setAttr ".pa" 1;
+select -ne :defaultLightSet;
+select -ne :defaultColorMgtGlobals;
+	setAttr ".cfe" yes;
+	setAttr ".cfp" -type "string" "<MAYA_RESOURCES>/OCIO-configs/Maya2022-default/config.ocio";
+	setAttr ".vtn" -type "string" "ACES 1.0 SDR-video (sRGB)";
+	setAttr ".vn" -type "string" "ACES 1.0 SDR-video";
+	setAttr ".dn" -type "string" "sRGB";
+	setAttr ".wsn" -type "string" "ACEScg";
+	setAttr ".otn" -type "string" "ACES 1.0 SDR-video (sRGB)";
+	setAttr ".potn" -type "string" "ACES 1.0 SDR-video (sRGB)";
+select -ne :hardwareRenderGlobals;
+	setAttr ".ctrs" 256;
+	setAttr ".btrs" 512;
+connectAttr "polyCube1.out" "pCubeShape1.i";
+connectAttr "polyTorus1.out" "pTorusShape1.i";
+connectAttr "polyCone1.out" "pConeShape1.i";
+connectAttr "polySphere1.out" "pSphereShape1.i";
+connectAttr "aiPhysicalSky2.out" "aiSkyDomeLightShape1.sc";
+relationship "link" ":lightLinker1" ":initialShadingGroup.message" ":defaultLightSet.message";
+relationship "link" ":lightLinker1" ":initialParticleSE.message" ":defaultLightSet.message";
+relationship "shadowLink" ":lightLinker1" ":initialShadingGroup.message" ":defaultLightSet.message";
+relationship "shadowLink" ":lightLinker1" ":initialParticleSE.message" ":defaultLightSet.message";
+connectAttr "layerManager.dli[0]" "defaultLayer.id";
+connectAttr "renderLayerManager.rlmi[0]" "defaultRenderLayer.rlid";
+connectAttr ":defaultArnoldDisplayDriver.msg" ":defaultArnoldRenderOptions.drivers"
+		 -na;
+connectAttr ":defaultArnoldFilter.msg" ":defaultArnoldRenderOptions.filt";
+connectAttr ":defaultArnoldDriver.msg" ":defaultArnoldRenderOptions.drvr";
+connectAttr "defaultRedshiftPostEffects.msg" ":redshiftOptions.postEffects";
+connectAttr "defaultRedshiftPostEffects.msg" ":defaultRenderUtilityList1.u" -na;
+connectAttr "defaultRenderLayer.msg" ":defaultRenderingList1.r" -na;
+connectAttr "aiSkyDomeLightShape1.ltd" ":lightList1.l" -na;
+connectAttr "pCubeShape1.iog" ":initialShadingGroup.dsm" -na;
+connectAttr "pTorusShape1.iog" ":initialShadingGroup.dsm" -na;
+connectAttr "pConeShape1.iog" ":initialShadingGroup.dsm" -na;
+connectAttr "pSphereShape1.iog" ":initialShadingGroup.dsm" -na;
+connectAttr "aiSkyDomeLight1.iog" ":defaultLightSet.dsm" -na;
+// End of test.ma

--- a/test/unit/deadline_submitter_for_maya/scripts/test_submission_api.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_submission_api.py
@@ -349,3 +349,239 @@ class TestGetQueueParameters:
             pytest.raises(DeadlineOperationError),
         ):
             get_queue_parameters()
+
+
+class TestOCIOInJobBundle:
+    """OCIO Config File coverage for the submission flow.
+
+    Regression coverage for the 0.15.13 OCIO submission failure that
+    was fixed in 0.15.14: customers without an OCIO config in their
+    Maya scene experienced "Job bundle validation failed" errors
+    because the HIDDEN PATH ``OCIOConfigFile`` parameter relied on its
+    empty-string default and that default was rejected by older
+    versions of ``openjd-model-for-python``. This was fixed by
+    upgrading the dependency in 0.15.14, but the developer test suite
+    didn't exercise the customer-default code path. These tests close
+    that gap by covering each branch of the OCIO submission code path
+    end-to-end.
+    """
+
+    @staticmethod
+    def _build_settings():
+        """Build a RenderSubmitterUISettings populated for parameter generation."""
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "test_job"
+        settings.description = ""
+        settings.override_frame_range = True
+        settings.frame_list = "1"
+        settings.project_path = "/tmp/project"
+        settings.output_path = "/tmp/output"
+        return settings
+
+    @staticmethod
+    def _patch_scene(ocio_return_value):
+        """Patch the Scene module-level reference and supporting helpers used
+        by ``_get_parameter_values`` so we can drive its branching logic
+        without a live Maya scene.
+        """
+        scene_mock = Mock()
+        scene_mock.name.return_value = "/tmp/scene/test.ma"
+        scene_mock.ocio_config_file.return_value = ocio_return_value
+        scene_mock.error_on_arnold_license_fail.return_value = True
+
+        return [
+            patch("deadline.maya_submitter.maya_render_submitter.Scene", scene_mock),
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.render_setup_include_all_lights",
+                return_value=True,
+            ),
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.get_width",
+                return_value=1920,
+            ),
+            patch(
+                "deadline.maya_submitter.maya_render_submitter.get_height",
+                return_value=1080,
+            ),
+        ]
+
+    def test_no_ocio_omits_value_but_keeps_definition(self):
+        """Maya scene without OCIO config. The submitter MUST omit
+        ``OCIOConfigFile`` from parameter_values so the parameter falls
+        back to its empty-string default. The job template MUST still
+        declare the parameter as a HIDDEN PATH with default=''. This
+        is the customer state that triggered the 0.15.13 regression.
+        """
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_job_template_for_submission,
+            get_parameter_values_for_submission,
+        )
+
+        settings = self._build_settings()
+        # Use mayaSoftware so the Arnold-specific branch is skipped.
+        context = _make_context([_make_render_layer(renderer_name="mayaSoftware", frame_range="1")])
+
+        patches = self._patch_scene(ocio_return_value=None)
+        for p in patches:
+            p.start()
+        try:
+            template = get_job_template_for_submission(settings, context=context)
+            param_values = get_parameter_values_for_submission(settings, context=context)
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        # The OCIOConfigFile parameter definition stays in the template.
+        ocio_def = next(
+            (p for p in template["parameterDefinitions"] if p["name"] == "OCIOConfigFile"),
+            None,
+        )
+        assert ocio_def is not None, "OCIOConfigFile parameter definition is missing"
+        assert ocio_def["type"] == "PATH"
+        assert ocio_def["userInterface"]["control"] == "HIDDEN"
+        assert ocio_def["default"] == ""
+
+        # And the value is omitted (the default is what the worker will see).
+        assert not any(
+            v["name"] == "OCIOConfigFile" for v in param_values
+        ), "OCIOConfigFile must NOT be added to parameter_values when the scene has no OCIO config"
+
+    def test_ocio_present_adds_value_to_parameter_values(self):
+        """Maya scene with a custom OCIO config. The submitter MUST
+        add ``OCIOConfigFile`` to parameter_values with the path
+        returned by ``Scene.ocio_config_file()``.
+        """
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_parameter_values_for_submission,
+        )
+
+        ocio_path = "/projects/show/aces_1.3/config.ocio"
+        settings = self._build_settings()
+        context = _make_context([_make_render_layer(renderer_name="mayaSoftware", frame_range="1")])
+
+        patches = self._patch_scene(ocio_return_value=ocio_path)
+        for p in patches:
+            p.start()
+        try:
+            param_values = get_parameter_values_for_submission(settings, context=context)
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        ocio_value = next((v for v in param_values if v["name"] == "OCIOConfigFile"), None)
+        assert ocio_value is not None, "OCIOConfigFile must be added to parameter_values"
+        assert ocio_value["value"] == ocio_path
+
+    def test_hidden_path_with_empty_default_validates(self):
+        """HIDDEN PATH JobParameter handling with default=''.
+
+        This is the exact failure mode from the 0.15.13 regression — when a HIDDEN
+        PATH parameter declares ``default: ''`` and ``deadline-cloud``
+        attempts to validate the bundle, older versions raised "Job
+        bundle validation failed". This test runs the actual validation
+        code path that's used by the Submit dialog.
+        """
+        from deadline.client.job_bundle.parameters import validate_job_parameter
+
+        ocio_definition = {
+            "name": "OCIOConfigFile",
+            "type": "PATH",
+            "objectType": "FILE",
+            "dataFlow": "IN",
+            "userInterface": {"control": "HIDDEN"},
+            "description": "The OCIO configuration file path (auto-detected from scene).",
+            "default": "",
+        }
+
+        # validate_job_parameter raises ValueError/TypeError on bad definitions.
+        # Must succeed cleanly with the default empty string.
+        result = validate_job_parameter(ocio_definition, type_required=True)
+        assert result["name"] == "OCIOConfigFile"
+        assert result["default"] == ""
+
+    def test_default_template_yaml_ocio_param_validates(self):
+        """The bundled default_maya_job_template.yaml must always declare
+        an ``OCIOConfigFile`` parameter that passes deadline-cloud's
+        bundle parameter validation. This protects the contract that
+        broke in the 0.15.13 regression (HIDDEN PATH with empty default) so future
+        edits to the template can't silently regress it.
+        """
+        from pathlib import Path
+
+        import yaml
+        from deadline.client.job_bundle.parameters import validate_job_parameter
+
+        # Resolve the path to default_maya_job_template.yaml relative to
+        # this test file so it works in any checkout layout.
+        repo_root = Path(__file__).resolve().parents[4]
+        template_path = repo_root / "src/deadline/maya_submitter/default_maya_job_template.yaml"
+        assert template_path.is_file(), f"Template file not found at {template_path}"
+
+        with open(template_path, encoding="utf8") as f:
+            template = yaml.safe_load(f)
+
+        # The OCIO parameter must be declared with the exact contract the
+        # adaptor's set_ocio_config_file relies on.
+        ocio_def = next(
+            (p for p in template["parameterDefinitions"] if p["name"] == "OCIOConfigFile"),
+            None,
+        )
+        assert ocio_def is not None, "OCIOConfigFile parameter is missing from default template"
+        assert ocio_def["type"] == "PATH"
+        assert ocio_def["userInterface"]["control"] == "HIDDEN"
+        assert ocio_def["default"] == ""
+
+        # Every parameter definition (not just OCIO) must validate so the
+        # default template is always submittable as-is.
+        for param_def in template["parameterDefinitions"]:
+            validate_job_parameter(param_def, type_required=True)
+
+    def test_full_bundle_with_no_ocio_passes_parameter_validation(self):
+        """End-to-end no-OCIO regression: build the full job template
+        and parameter_values for a scene without an OCIO config (the
+        customer state that broke), then run every parameter through
+        deadline-cloud's bundle parameter validation. This is the
+        highest-fidelity reproduction of the 0.15.13 regression in unit form.
+        """
+        from deadline.client.job_bundle.parameters import (
+            validate_job_parameter,
+            validate_job_parameter_value,
+        )
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_job_template_for_submission,
+            get_parameter_values_for_submission,
+        )
+
+        settings = self._build_settings()
+        context = _make_context([_make_render_layer(renderer_name="mayaSoftware", frame_range="1")])
+
+        patches = self._patch_scene(ocio_return_value=None)
+        for p in patches:
+            p.start()
+        try:
+            template = get_job_template_for_submission(settings, context=context)
+            param_values = get_parameter_values_for_submission(settings, context=context)
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+        # Validate every parameter definition — equivalent to what the
+        # Submit dialog does before sending the bundle to the service.
+        validated_defs = {
+            p["name"]: validate_job_parameter(p, type_required=True)
+            for p in template["parameterDefinitions"]
+        }
+
+        # Validate every supplied value against its definition.
+        for v in param_values:
+            if v["name"] in validated_defs:
+                validate_job_parameter_value(validated_defs[v["name"]], v["value"])
+
+        # The defining assertion: OCIOConfigFile is declared with default=''
+        # and not overridden by parameter_values. If the bundle assembled
+        # this way ever fails to validate again, this test will fail —
+        # which is precisely what was missing when 0.15.13 shipped.
+        assert validated_defs["OCIOConfigFile"]["default"] == ""
+        assert not any(v["name"] == "OCIOConfigFile" for v in param_values)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In `0.15.13`, customers without a custom OCIO config in their Maya scene experienced "Job bundle validation failed" submission errors. Their `OCIOConfigFile` job parameter relied on its empty-string default, which was rejected by the version of `openjd-model-for-python` shipped at the time (HIDDEN PATH parameters were not allowed to have empty-string defaults).

The bug was fixed in `0.15.14` by upgrading the dependency, but the developer test suite never exercised the customer-default code path — every existing scene fixture had Maya's default `<MAYA_RESOURCES>/...` color management value, which `Scene.ocio_config_file()` correctly resolves to `None`, so `OCIOConfigFile` is not added to `parameter_values` and the parameter falls back to its empty-string default. The bug was therefore invisible to existing tests.

This PR adds the missing regression coverage so a future regression of the same shape is caught by CI.

### What was the solution? (How)

**Unit tests** in `test/unit/deadline_submitter_for_maya/scripts/test_submission_api.py`, new `TestOCIOInJobBundle` class:

| Test | Covers |
|---|---|
| `test_scenario_1_no_ocio_omits_value_but_keeps_definition` | Scene without OCIO config — `OCIOConfigFile` is omitted from `parameter_values`, parameter definition keeps `default: ''` |
| `test_scenario_2_ocio_present_adds_value_to_parameter_values` | Scene with OCIO config — value populated from `Scene.ocio_config_file()` |
| `test_scenario_3_hidden_path_with_empty_default_validates` | HIDDEN PATH with empty default validates via `deadline-cloud`'s `validate_job_parameter` (the function that surfaces "Job bundle validation failed" errors) |
| `test_default_template_yaml_ocio_param_validates` | Loads the bundled `default_maya_job_template.yaml` and asserts every parameter validates — guards against future template edits regressing the OCIO contract |
| `test_full_bundle_with_no_ocio_passes_parameter_validation` | Full bundle assembly + parameter validation end-to-end — the closest unit-level reproduction of the original failure |

**Integration test** in `test/integ/test_maya_submitters.py` — new `test_scene_submitter_with_ocio_config` method, with fixture under `test/integ/test_scripts/ocio_test/`:

* `scene/test.ma` — Arnold-based scene (copy of the existing `mtoa_test`)
* `scene/config.ocio` — minimal valid OCIO v2 config (single linear colorspace, no LUTs)
* `expected_job_bundle/template.yaml` — identical to `mtoa_test`'s template (the OCIO state lives in `parameter_values`, not the template)

The test programmatically applies a custom OCIO config via `cmds.colorManagementPrefs(e=True, configFilePath=...)` post-scene-open (simulating a customer with a studio-wide OCIO config in Maya's preferences) and asserts `OCIOConfigFile` is present in the resulting `parameter_values` with the expected path.

The four pre-existing parametrized integration tests (`Minimal Maya Test`, `Redshift Test`, `Arnold Test`, `VRay Test`) implicitly cover the customer-default Scenario 1 case — their scenes use the `<MAYA_RESOURCES>/...` default which `Scene.ocio_config_file()` correctly returns `None` for. The new dedicated method completes the matrix with Scenario 2.

### What is the impact of this change?

Tests-only change. No `src/` code is modified, so no runtime behaviour changes.

**Side observation** surfaced while writing the integration test: once `colorManagementPrefs(configFilePath=...)` is set, Maya's `filePathEditor` reports the OCIO config file as a scene-referenced file, so `AssetIntrospector.parse_scene_assets()` adds it to `inputs.filenames` in addition to the dedicated `OCIOConfigFile` `dataFlow:IN` PATH parameter. Job Attachments deduplicates by content hash so this results in a single S3 upload, but the OCIO config is referenced twice in the bundle representation. This is pre-existing behaviour, not introduced by this PR — the integration test now codifies it.

### How was this change tested?

```
$ hatch run test
============================== 183 passed in 5.50s ==============================

$ hatch run lint
ruff check . — All checks passed!
black --check --diff . — All done! ✨ 🍰 ✨ — 81 files would be left unchanged.
mypy src test maya_submitter_plugin/plug-ins — Success: no issues found in 72 source files
```

#### Integ test result

Integration tests pass on Linux and Windows (CodeBuild reserved-capacity fleets, manual `workflow_dispatch`):

```
========================== short test summary info ===========================
Captured:
- test_minimal_scene_adaptor passed
- test_redshift_scene_adaptor passed
- test_mtoa_scene_adaptor passed
- test_vray_scene_adaptor passed
- test_scene_submitter[Minimal Maya Test] passed
- test_scene_submitter[Redshift Test] passed
- test_scene_submitter[Arnold Test] passed
- test_scene_submitter[VRay Test] passed
- test_scene_submitter_with_ocio_config passed   <-- new
======================= 9 passed, 4 warnings in ~2:14 ========================
```

#### Installer test result

Not applicable — `installer/` was not modified.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Not applicable. This PR places the integration fixture under `test/integ/test_scripts/` (the path used by the automated CI integration tests on CodeBuild) rather than `job_bundle_output_tests/` (the in-Maya `TEST` shelf workflow). The same OCIO scenario could be added to `job_bundle_output_tests/` in a follow-up if the dev workflow needs it; it is not required to land the regression coverage that motivated this PR.

### Was this change documented?

No documentation changes are needed — this PR adds tests; public APIs and adaptor schemas are not modified. The `CHANGELOG.md` does not need a hand-edited entry (semantic-release classifies `test:` commits as no-version-bump).

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/maya_adaptor/MayaAdaptor/adaptor.py` and update the test constants?
   - [ ] Yes
   - [ ] No

### Is this a breaking change?

No. Tests-only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
