### PR TITLE
chore: change linux install to create a mod file rather than rely on env var

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,6 +58,11 @@ Note: Hatch uses [environments](https://hatch.pypa.io/1.12/environment/) to isol
 for this package from your system or virtual environment Python. If your build/test run is not making sense, then
 sometimes pruning (`hatch env prune`) all of these environments for the package can fix the issue.
 
+Note: Fetch tags to ensure the correct openjd version is detected:
+```bash
+git fetch --tags
+```
+
 ### Submitter Development Workflow
 
 The submitter plug-in generates job bundles to submit to AWS Deadline Cloud. Developing a change

--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -67,13 +67,6 @@
 		</stringParameter>
 	</parameterList>
     <postInstallationActionList>
-        <fnAddPathEnvironmentVariable>
-			<progressText>Registering plug-in with Maya</progressText>
-			<name>MAYA_MODULE_PATH</name>
-			<value>${maya_installdir}</value>
-			<scope>${installscope}</scope>
-			<insertAt>end</insertAt>
-		</fnAddPathEnvironmentVariable>
         <unzip>
             <destinationDirectory>${maya_installdir}/scripts</destinationDirectory>
             <zipFile>${installdir}/tmp/maya_deps/dependency_bundle/deadline_cloud_for_maya_submitter-deps.zip</zipFile>
@@ -98,6 +91,48 @@
                 <copyFile>
                     <origin>${installdir}/DeadlineCloudForMaya.mod</origin>
                     <destination>${user_home_directory}/Library/Preferences/Autodesk/maya/modules/DeadlineCloudForMaya.mod</destination>
+                </copyFile>
+            </actionList>
+        </if>
+        <if>
+            <conditionRuleList>
+                <platformTest type="linux" />
+                <compareText logic="equals" text="${installscope}" value="user"/>
+            </conditionRuleList>
+            <actionList>
+                <runProgram>
+                    <program>bash</program>
+                    <programArguments>-c "
+                        sed -E -i 's#(\+ DeadlineCloudForMaya [^ ]*) \.#\1 '"${installdir}"'#' \"${installdir}/DeadlineCloudForMaya.mod\"
+                    "</programArguments>
+                </runProgram>
+                <createDirectory>
+                    <path>${user_home_directory}/maya/modules</path>
+                </createDirectory>
+                <copyFile>
+                    <origin>${installdir}/DeadlineCloudForMaya.mod</origin>
+                    <destination>${user_home_directory}/maya/modules/DeadlineCloudForMaya.mod</destination>
+                </copyFile>
+            </actionList>
+        </if>
+        <if>
+            <conditionRuleList>
+                <platformTest type="linux" />
+                <compareText logic="equals" text="${installscope}" value="system"/>
+            </conditionRuleList>
+            <actionList>
+                <runProgram>
+                    <program>bash</program>
+                    <programArguments>-c "
+                        sed -E -i 's#(\+ DeadlineCloudForMaya [^ ]*) \.#\1 '"${installdir}"'#' \"${installdir}/DeadlineCloudForMaya.mod\"
+                    "</programArguments>
+                </runProgram>
+                <createDirectory>
+                    <path>/usr/autodesk/modules/maya</path>
+                </createDirectory>
+                <copyFile>
+                    <origin>${installdir}/DeadlineCloudForMaya.mod</origin>
+                    <destination>/usr/autodesk/modules/maya/DeadlineCloudForMaya.mod</destination>
                 </copyFile>
             </actionList>
         </if>

--- a/installer/DeadlineCloudForMayaSubmitter.xml
+++ b/installer/DeadlineCloudForMayaSubmitter.xml
@@ -247,6 +247,24 @@
                 <deleteFile path="${user_home_directory}/Library/Preferences/Autodesk/maya/modules/DeadlineCloudForMaya.mod"/>
             </actionList>
         </if>
+        <if>
+            <conditionRuleList>
+                <platformTest type="linux" />
+                <compareText logic="equals" text="${installscope}" value="user"/>
+            </conditionRuleList>
+            <actionList>
+                <deleteFile path="${user_home_directory}/maya/modules/DeadlineCloudForMaya.mod"/>
+            </actionList>
+        </if>
+        <if>
+            <conditionRuleList>
+                <platformTest type="linux" />
+                <compareText logic="equals" text="${installscope}" value="system"/>
+            </conditionRuleList>
+            <actionList>
+                <deleteFile path="/usr/autodesk/modules/maya/DeadlineCloudForMaya.mod"/>
+            </actionList>
+        </if>
     </preUninstallationActionList>
     <width>550</width>
 </project>


### PR DESCRIPTION
Fixes: #347 
Note: This is a remerge of #315 
### What was the problem/requirement? (What/Why)
Linux system install is not working. Linux user install requires customers to launch maya from command line to work

### What was the solution? (How)
Fix system install by writing the install directory to `DeadlineCloudForMaya.mod`. Make both install work with Maya open from application and terminal.

### What is the impact of this change?
Maya submitter can now be opened from application or terminal.

### How was this change tested?

**Manual Test**
- Create the submitter instealler
- Install it on Linux and MacOS with newly installed Maya 2026
  - Test run for both user and system install
- Make sure the submitter install and load correctly.
#### Integ test result
```
===End Flaky Test Report===
================================================================== slowest 5 durations ==================================================================
31.86s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
29.61s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor
17.57s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_mtoa_scene_adaptor
15.88s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_vray_scene_adaptor
8.41s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
======================================================= 8 passed, 4 warnings in 113.28s (0:01:53) =======================================================
```

#### Unit test result
```
================================================================== slowest 5 durations ==================================================================
0.12s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run_render_fail
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_cleanup::test_on_cleanup
0.02s call     test/unit/deadline_submitter_for_maya/scripts/test_submission_api.py::TestGetJobTemplateForSubmission::test_creates_context_if_not_provided
0.02s call     test/unit/deadline_submitter_for_maya/test_mel_commands.py::test_deadline_cloud_submitter_cmd_sticky_setting_load_only_once
================================================================== 178 passed in 3.18s ==================================================================
```
#### Installer test result
```
================================================================== slowest 5 durations ==================================================================
7.43s setup    test/installer/test_installer.py::TestUserInstall::test_install
7.40s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
6.90s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
2.44s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
1.75s call     test/installer/test_installer.py::test_default_location
============================================================= 4 passed, 9 skipped in 10.67s =============================================================
```



### Was this change documented?
Yes. I also updated the DEVELOPMENT.md with instruction to fetch `tags` so the open jd version load correctly.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
