### PR TITLE
feat: add Python Script job type to Maya submitter and adaptor

### DIFF
--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -93,7 +93,7 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:
-        return SemanticVersion(major=0, minor=2)
+        return SemanticVersion(major=0, minor=3)
 
     @staticmethod
     def _get_timer(timeout: int | float) -> Callable[[], bool]:
@@ -414,7 +414,10 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
         else:
             os.environ["PYTHONPATH"] = python_path_addition
 
-        if self.init_data["renderer"] == "arnold":
+        if (
+            self.init_data.get("job_type", "render") == "render"
+            and self.init_data.get("renderer") == "arnold"
+        ):
             self._setup_arnold_pathmapping()
 
         self._maya_client = LoggingSubprocess(
@@ -430,10 +433,14 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
         _MAYA_INIT_KEYS set to be added to the action queue.
         """
 
-        # Set up the renderer
-        self._action_queue.enqueue_action(
-            Action("renderer", {"renderer": self.init_data["renderer"]})
-        )
+        job_type = self.init_data.get("job_type", "render")
+
+        # Set up the renderer (render jobs only — python-script jobs do not
+        # require a renderer to be configured up front).
+        if job_type == "render":
+            self._action_queue.enqueue_action(
+                Action("renderer", {"renderer": self.init_data["renderer"]})
+            )
 
         # Set up all pathmapping rules
         self._action_queue.enqueue_action(
@@ -457,15 +464,18 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
         for action_name in _FIRST_MAYA_ACTIONS:
             self._action_queue.enqueue_action(self._action_from_action_item(action_name))
 
-        for action_name in _MAYA_INIT_KEYS:
-            if action_name in self.init_data:
-                self._action_queue.enqueue_action(self._action_from_action_item(action_name))
+        # Render-specific init actions are skipped for python-script jobs since
+        # the user's script controls render settings (or doesn't render at all).
+        if job_type == "render":
+            for action_name in _MAYA_INIT_KEYS:
+                if action_name in self.init_data:
+                    self._action_queue.enqueue_action(self._action_from_action_item(action_name))
 
-        # RenderMan's texture manager bypasses Maya's dirmap, so we need to
-        # manually apply path mapping to RenderMan texture node attributes
-        # after the scene is loaded.
-        if self.init_data["renderer"] == "renderman" and self.path_mapping_rules:
-            self._action_queue.enqueue_action(Action("renderman_texture_pathmapping", {}))
+            # RenderMan's texture manager bypasses Maya's dirmap, so we need to
+            # manually apply path mapping to RenderMan texture node attributes
+            # after the scene is loaded.
+            if self.init_data["renderer"] == "renderman" and self.path_mapping_rules:
+                self._action_queue.enqueue_action(Action("renderman_texture_pathmapping", {}))
 
     def on_start(self) -> None:
         """
@@ -517,6 +527,10 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
         """
         This starts a render in Maya for the given frame and performs a busy wait until the render
         completes.
+
+        For Python-script jobs, this enqueues an `execute_script` action instead and waits for
+        completion using the same in-progress flag — handlers must clear `_maya_is_rendering`
+        when they finish.
         """
         if not self._maya_is_running:
             raise MayaNotRunningError("Cannot render because Maya is not running.")
@@ -526,7 +540,10 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
         validators = AdaptorDataValidators.for_adaptor(schema_dir)
         validators.run_data.validate(run_data)
         self._maya_is_rendering = True
-        self._action_queue.enqueue_action(Action("start_render", run_data))
+        if "script_file" in run_data:
+            self._action_queue.enqueue_action(Action("execute_script", run_data))
+        else:
+            self._action_queue.enqueue_action(Action("start_render", run_data))
         while self._maya_is_rendering and not self._has_exception:
             time.sleep(0.1)  # wait for the render to finish
 

--- a/src/deadline/maya_adaptor/MayaAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/maya_adaptor/MayaAdaptor/schemas/init_data.schema.json
@@ -2,6 +2,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
+        "job_type": {
+            "enum": ["render", "python_script"],
+            "default": "render",
+            "description": "The kind of job to run. 'render' (default) performs a Maya render. 'python_script' executes a user-supplied Python script inside Maya."
+        },
         "camera": { "type": "string" },
         "error_on_arnold_license_fail": { "type": "boolean" },
         "image_height": { "type": "number" },
@@ -30,8 +35,19 @@
     },
     "required": [
         "project_path",
-        "render_layer",
-        "renderer",
         "scene_file"
+    ],
+    "allOf": [
+        {
+            "if": {
+                "anyOf": [
+                    { "not": { "required": ["job_type"] } },
+                    { "properties": { "job_type": { "const": "render" } } }
+                ]
+            },
+            "then": {
+                "required": ["renderer", "render_layer"]
+            }
+        }
     ]
 }

--- a/src/deadline/maya_adaptor/MayaAdaptor/schemas/run_data.schema.json
+++ b/src/deadline/maya_adaptor/MayaAdaptor/schemas/run_data.schema.json
@@ -8,7 +8,18 @@
         "region_min_y": { "type": "number" },
         "region_max_y": { "type": "number" },
         "camera": { "type": "string" },
-        "output_file_prefix": { "type": "string" }
+        "output_file_prefix": { "type": "string" },
+        "script_file": {
+            "type": "string",
+            "description": "Path to a user-supplied Python script to execute inside Maya. When present, the adaptor enqueues an 'execute_script' action instead of 'start_render'."
+        },
+        "script_args": {
+            "type": "string",
+            "description": "Optional argument string passed to the script via the DEADLINE_SCRIPT_ARGS environment variable."
+        }
     },
-    "required": ["frame"]
+    "anyOf": [
+        { "required": ["frame"] },
+        { "required": ["script_file"] }
+    ]
 }

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -38,6 +38,7 @@ class DefaultMayaHandler:
     def __init__(self):
         self.action_dict = {
             "start_render": self.start_render,
+            "execute_script": self.execute_script,
             "camera": self.set_camera,
             "image_height": self.set_image_height,
             "image_width": self.set_image_width,
@@ -97,6 +98,85 @@ class DefaultMayaHandler:
                 )
         else:
             return None
+
+    def execute_script(self, data: dict) -> None:
+        """
+        Executes a user-supplied Python script inside the running Maya client.
+
+        The script is executed via runpy.run_path with run_name="__main__" so the
+        user can write a normal top-level Python module. maya.cmds and maya.mel
+        are available because we run inside the Maya Python interpreter with
+        maya.standalone already initialized.
+
+        The following environment variables are set for the duration of the script:
+        - DEADLINE_TASK_FRAME: the task frame number (if provided in run_data).
+        - DEADLINE_SCRIPT_ARGS: the optional argument string from the submitter.
+
+        Args:
+            data (dict): The data given from the Adaptor. Keys expected: ['script_file'].
+                Optional: ['frame', 'script_args'].
+
+        Raises:
+            FileNotFoundError: If script_file does not point to an existing file.
+            RuntimeError: If the script raises an exception.
+        """
+        import runpy
+        import traceback
+
+        script_file = data.get("script_file", "")
+        if not script_file:
+            raise RuntimeError("MayaClient: execute_script called without 'script_file'.")
+
+        # Apply path mapping in case the run-data still carries a submitter-side path.
+        if DirectoryMapping.get_activated():
+            script_file = DirectoryMapping.convert(script_file)
+
+        if not os.path.isfile(script_file):
+            raise FileNotFoundError(f"The Python script '{script_file}' does not exist")
+
+        frame = data.get("frame")
+        script_args = data.get("script_args", "") or ""
+
+        # Inject context for the user's script via env vars; restore previous values after.
+        prev_env = {
+            "DEADLINE_TASK_FRAME": os.environ.get("DEADLINE_TASK_FRAME"),
+            "DEADLINE_SCRIPT_ARGS": os.environ.get("DEADLINE_SCRIPT_ARGS"),
+        }
+        if frame is not None:
+            os.environ["DEADLINE_TASK_FRAME"] = str(frame)
+        else:
+            os.environ.pop("DEADLINE_TASK_FRAME", None)
+        os.environ["DEADLINE_SCRIPT_ARGS"] = script_args
+
+        print(
+            f"MayaClient: Executing Python script '{script_file}' "
+            f"(frame={frame}, script_args={script_args!r})",
+            flush=True,
+        )
+
+        try:
+            runpy.run_path(script_file, run_name="__main__")
+        except SystemExit as exc:
+            # Treat clean SystemExit(0) / SystemExit() as success; non-zero is a failure.
+            code = exc.code
+            if code not in (None, 0):
+                traceback.print_exc()
+                raise RuntimeError(f"Python script '{script_file}' exited with code {code}")
+        except Exception as exc:
+            traceback.print_exc()
+            raise RuntimeError(f"Python script '{script_file}' raised an exception: {exc}")
+        finally:
+            # Restore prior env vars so successive tasks see a clean slate.
+            for k, v in prev_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+        # Emit the same completion line the adaptor's regex matches so the
+        # adaptor clears _maya_is_rendering and reports 100% progress.
+        completion_frame = frame if frame is not None else 0
+        print(f"MayaClient: Finished Rendering Frame {int(completion_frame)}\n", flush=True)
 
     def start_render(self, data: dict) -> None:
         """

--- a/src/deadline/maya_submitter/data_classes.py
+++ b/src/deadline/maya_submitter/data_classes.py
@@ -45,6 +45,16 @@ class RenderSubmitterUISettings:
     current_layer_selectable_cameras: list[str] = field(default_factory=lambda: [ALL_CAMERAS])
     camera_selection: str = field(default=ALL_CAMERAS)
 
+    # Job type selection: "render" (default — standard Maya render) or
+    # "python_script" (run a user-supplied Python script inside Maya).
+    job_type: str = field(default="render", metadata={"sticky": True})
+    # Path to the user's Python script (only used when job_type == "python_script").
+    # The path is resolved on the submitter machine and uploaded as a job attachment.
+    python_script_path: str = field(default="", metadata={"sticky": True})
+    # Optional free-form argument string passed to the script via the
+    # DEADLINE_SCRIPT_ARGS environment variable.
+    script_args: str = field(default="", metadata={"sticky": True})
+
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -676,6 +676,298 @@ def get_default_job_template() -> dict[str, Any]:
         return yaml.safe_load(fh)
 
 
+def _get_python_script_job_template(settings: RenderSubmitterUISettings) -> dict[str, Any]:
+    """Build a job template for a Python-script job.
+
+    The template has a single step (`RunPythonScript`) whose task parameter
+    space iterates over Frames. The adaptor's `daemon run` is invoked once per
+    task with run-data containing `script_file`, optional `frame`, and
+    optional `script_args`.
+
+    The user's scene file and Python script file are declared as PATH/IN
+    parameters so the Deadline Cloud job attachments system uploads them to
+    the worker and applies path mapping at runtime.
+    """
+    return {
+        "specificationVersion": "jobtemplate-2023-09",
+        "name": settings.name or "Maya Python Script Job",
+        "parameterDefinitions": [
+            {
+                "name": "MayaSceneFile",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "IN",
+                "userInterface": {
+                    "control": "CHOOSE_INPUT_FILE",
+                    "label": "Maya Scene File",
+                    "groupLabel": "Maya Settings",
+                    "fileFilters": [
+                        {
+                            "label": "Maya Scene Files",
+                            "patterns": ["*.mb", "*.ma"],
+                        },
+                        {"label": "All Files", "patterns": ["*"]},
+                    ],
+                },
+                "description": "The Maya scene file to load before running the Python script.",
+            },
+            {
+                "name": "PythonScriptFile",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "IN",
+                "userInterface": {
+                    "control": "CHOOSE_INPUT_FILE",
+                    "label": "Python Script",
+                    "groupLabel": "Maya Settings",
+                    "fileFilters": [
+                        {"label": "Python Scripts", "patterns": ["*.py"]},
+                        {"label": "All Files", "patterns": ["*"]},
+                    ],
+                },
+                "description": "The user-provided Python script that runs inside Maya per task.",
+            },
+            {
+                "name": "Frames",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "LINE_EDIT",
+                    "label": "Frames",
+                    "groupLabel": "Maya Settings",
+                },
+                "description": (
+                    "Task range. Each task runs the Python script once with "
+                    "DEADLINE_TASK_FRAME set to the value. Use '1' for a single task."
+                ),
+                "minLength": 1,
+                "default": "1",
+            },
+            {
+                "name": "ProjectPath",
+                "type": "PATH",
+                "objectType": "DIRECTORY",
+                "dataFlow": "NONE",
+                "userInterface": {
+                    "control": "CHOOSE_DIRECTORY",
+                    "label": "Project Path",
+                    "groupLabel": "Maya Settings",
+                },
+                "description": "The Maya project path.",
+            },
+            {
+                "name": "OutputFilePath",
+                "type": "PATH",
+                "objectType": "DIRECTORY",
+                "dataFlow": "OUT",
+                "userInterface": {
+                    "control": "CHOOSE_DIRECTORY",
+                    "label": "Output File Path",
+                    "groupLabel": "Maya Settings",
+                },
+                "description": "The output path.",
+            },
+            {
+                "name": "ScriptArgs",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "LINE_EDIT",
+                    "label": "Script Args",
+                    "groupLabel": "Maya Settings",
+                },
+                "description": (
+                    "Optional arguments passed to the Python script via the "
+                    "DEADLINE_SCRIPT_ARGS environment variable."
+                ),
+                "default": "",
+            },
+            {
+                "name": "StrictErrorChecking",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "CHECK_BOX",
+                    "label": "Strict Error Checking",
+                    "groupLabel": "Maya Settings",
+                },
+                "description": "Fail when errors occur.",
+                "default": "false",
+                "allowedValues": ["true", "false"],
+            },
+            {
+                "name": "OCIOConfigFile",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "IN",
+                "userInterface": {"control": "HIDDEN"},
+                "description": "The OCIO configuration file path (auto-detected from scene).",
+                "default": "",
+            },
+        ],
+        "steps": [
+            {
+                "name": "RunPythonScript",
+                "parameterSpace": {
+                    "taskParameterDefinitions": [
+                        {
+                            "name": "Frame",
+                            "type": "INT",
+                            "range": "{{Param.Frames}}",
+                        }
+                    ]
+                },
+                "stepEnvironments": [
+                    {
+                        "name": "Maya",
+                        "description": "Runs Maya in the background.",
+                        "script": {
+                            "embeddedFiles": [
+                                {
+                                    "name": "initData",
+                                    "filename": "init-data.yaml",
+                                    "type": "TEXT",
+                                    "data": (
+                                        "job_type: python_script\n"
+                                        "scene_file: '{{Param.MayaSceneFile}}'\n"
+                                        "project_path: '{{Param.ProjectPath}}'\n"
+                                        "output_file_path: '{{Param.OutputFilePath}}'\n"
+                                        "strict_error_checking: "
+                                        "{{Param.StrictErrorChecking}}\n"
+                                        "ocio_config_file: '{{Param.OCIOConfigFile}}'\n"
+                                    ),
+                                }
+                            ],
+                            "actions": {
+                                "onEnter": {
+                                    "command": "MayaAdaptor",
+                                    "args": [
+                                        "daemon",
+                                        "start",
+                                        "--path-mapping-rules",
+                                        "file://{{Session.PathMappingRulesFile}}",
+                                        "--connection-file",
+                                        "{{Session.WorkingDirectory}}/connection.json",
+                                        "--init-data",
+                                        "file://{{Env.File.initData}}",
+                                    ],
+                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 87000,
+                                },
+                                "onExit": {
+                                    "command": "MayaAdaptor",
+                                    "args": [
+                                        "daemon",
+                                        "stop",
+                                        "--connection-file",
+                                        "{{ Session.WorkingDirectory }}/connection.json",
+                                    ],
+                                    "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                                    "timeout": 600,
+                                },
+                            },
+                        },
+                    }
+                ],
+                "script": {
+                    "embeddedFiles": [
+                        {
+                            "name": "runData",
+                            "filename": "run-data.yaml",
+                            "type": "TEXT",
+                            "data": (
+                                "frame: {{Task.Param.Frame}}\n"
+                                "script_file: '{{Param.PythonScriptFile}}'\n"
+                                "script_args: '{{Param.ScriptArgs}}'\n"
+                            ),
+                        }
+                    ],
+                    "actions": {
+                        "onRun": {
+                            "command": "MayaAdaptor",
+                            "args": [
+                                "daemon",
+                                "run",
+                                "--connection-file",
+                                "{{ Session.WorkingDirectory }}/connection.json",
+                                "--run-data",
+                                "file://{{ Task.File.runData }}",
+                            ],
+                            "cancelation": {"mode": "NOTIFY_THEN_TERMINATE"},
+                        }
+                    },
+                },
+            }
+        ],
+    }
+
+
+def _get_python_script_parameter_values(
+    settings: RenderSubmitterUISettings,
+    queue_parameters: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build parameter_values for a Python-script job.
+
+    Mirrors the relevant subset of `_get_parameter_values` but for the
+    python-script template. Frames defaults to '1' when the user leaves
+    it blank, producing a single task.
+    """
+    parameter_values: list[dict[str, Any]] = [
+        {"name": "MayaSceneFile", "value": Scene.name()},
+        {"name": "PythonScriptFile", "value": settings.python_script_path},
+        {
+            "name": "Frames",
+            "value": (
+                settings.frame_list
+                if (settings.override_frame_range and settings.frame_list)
+                else (settings.frame_list or "1")
+            ),
+        },
+        {"name": "ProjectPath", "value": settings.project_path},
+        {"name": "OutputFilePath", "value": settings.output_path},
+        {"name": "ScriptArgs", "value": settings.script_args},
+        {"name": "StrictErrorChecking", "value": "false"},
+    ]
+
+    ocio_config = Scene.ocio_config_file()
+    if ocio_config:
+        parameter_values.append({"name": "OCIOConfigFile", "value": ocio_config})
+
+    # Validate against queue parameters as the render path does.
+    parameter_names = {p["name"] for p in parameter_values}
+    queue_parameter_names = {p["name"] for p in queue_parameters}
+    overlap = parameter_names.intersection(queue_parameter_names)
+    if overlap:
+        raise DeadlineOperationError(
+            "The following queue parameters conflict with the Maya job parameters:\n"
+            + f"{', '.join(overlap)}"
+        )
+
+    # Developer option: override adaptor wheels (same as render path)
+    if settings.include_adaptor_wheels:
+        wheels_path = str(Path(__file__).parent.parent.parent.parent / "wheels")
+        parameter_values.append({"name": "OverrideAdaptorWheels", "value": wheels_path})
+
+        for param in queue_parameters:
+            if param["name"] == "RezPackages":
+                current_value = param.get("value", param.get("default", ""))
+                param["value"] = " ".join(
+                    pkg
+                    for pkg in current_value.split()
+                    if not pkg.startswith("deadline_cloud_for_maya")
+                )
+            if param["name"] == "CondaPackages":
+                current_value = param.get("value", param.get("default", ""))
+                param["value"] = " ".join(
+                    pkg for pkg in current_value.split() if not pkg.startswith("maya-openjd")
+                )
+
+    parameter_values.extend(
+        {"name": param["name"], "value": param.get("value", param.get("default", ""))}
+        for param in queue_parameters
+        if "value" in param or "default" in param
+    )
+
+    return parameter_values
+
+
 def get_job_template_for_submission(
     settings: RenderSubmitterUISettings,
     host_requirements: Optional[dict[str, Any]] = None,
@@ -695,6 +987,15 @@ def get_job_template_for_submission(
     """
     if context is None:
         context = create_submission_context()
+
+    # Python-script job: build a different template entirely; render-layer
+    # specific logic does not apply.
+    if getattr(settings, "job_type", "render") == "python_script":
+        job_template = _get_python_script_job_template(settings)
+        if host_requirements:
+            for step in job_template["steps"]:
+                step["hostRequirements"] = host_requirements
+        return job_template
 
     default_job_template = get_default_job_template()
     prepared = _prepare_render_layers_for_submission(settings, context)
@@ -738,6 +1039,9 @@ def get_parameter_values_for_submission(
         context = create_submission_context()
     if queue_parameters is None:
         queue_parameters = []
+
+    if getattr(settings, "job_type", "render") == "python_script":
+        return _get_python_script_parameter_values(settings, queue_parameters)
 
     prepared = _prepare_render_layers_for_submission(settings, context)
 
@@ -883,6 +1187,19 @@ def on_create_job_bundle_callback(
             maya.cmds.file(save=True)
 
     job_bundle_path = Path(job_bundle_dir)
+
+    # For Python-script jobs, ensure the user-supplied script file is uploaded
+    # as a job attachment. The job template declares `PythonScriptFile` as a
+    # PATH/IN parameter so Deadline Cloud applies path mapping at runtime.
+    if getattr(settings, "job_type", "render") == "python_script":
+        script_path = (settings.python_script_path or "").strip()
+        if not script_path:
+            raise DeadlineOperationError(
+                "Python Script job type selected, but no Python script file was specified."
+            )
+        if not os.path.isfile(script_path):
+            raise DeadlineOperationError(f"Python script file does not exist: {script_path}")
+        asset_references.input_filenames.add(os.path.normpath(script_path))
 
     # Reuse the same context — no redundant computation
     job_template = get_job_template_for_submission(settings, host_requirements, context=context)

--- a/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
@@ -25,6 +25,17 @@ UI widgets for the Scene Settings tab.
 """
 
 
+# Job type identifiers. Kept in sync with the values written to settings.job_type
+# and consumed by the adaptor's init_data schema.
+JOB_TYPE_RENDER = "render"
+JOB_TYPE_PYTHON_SCRIPT = "python_script"
+
+_JOB_TYPE_ITEMS = [
+    (JOB_TYPE_RENDER, "Render"),
+    (JOB_TYPE_PYTHON_SCRIPT, "Python Script"),
+]
+
+
 class FileSearchLineEdit(QWidget):
     """
     Widget used to contain a line edit and a button which opens a file search box.
@@ -62,7 +73,13 @@ class FileSearchLineEdit(QWidget):
                 QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks,
             )
         else:
-            new_txt = QFileDialog.getOpenFileName(self, "Select File", self.edit.text())
+            # file_format is a Qt filter string like "Python Scripts (*.py);;All Files (*)"
+            if self.file_format:
+                new_txt, _ = QFileDialog.getOpenFileName(
+                    self, "Select File", self.edit.text(), self.file_format
+                )
+            else:
+                new_txt = QFileDialog.getOpenFileName(self, "Select File", self.edit.text())
 
         if new_txt:
             self.edit.setText(new_txt)
@@ -96,19 +113,38 @@ class SceneSettingsWidget(QWidget):
         self.all_layer_selectable_cameras = initial_settings.all_layer_selectable_cameras
         self.current_layer_selectable_cameras = initial_settings.current_layer_selectable_cameras
 
+        # Track all widgets that should only be visible in render mode so we can
+        # toggle them when the user switches job type.
+        self._render_only_rows: list[tuple[QWidget, QWidget]] = []
+        self._python_only_rows: list[tuple[QWidget, QWidget]] = []
+
         self._build_ui(initial_settings)
         self._configure_settings(initial_settings)
+        # Apply visibility based on the configured job type.
+        self._on_job_type_changed()
 
     def _build_ui(self, settings):
         lyt = QGridLayout(self)
+
+        # --- Job Type selector (always visible) ---
+        self.job_type_box = QComboBox(self)
+        for value, text in _JOB_TYPE_ITEMS:
+            self.job_type_box.addItem(text, value)
+        lyt.addWidget(QLabel("Job Type"), 0, 0)
+        lyt.addWidget(self.job_type_box, 0, 1)
+        self.job_type_box.currentIndexChanged.connect(self._on_job_type_changed)
+
+        # --- Always-visible fields ---
         self.proj_path_txt = FileSearchLineEdit(directory_only=True, parent=self)
-        lyt.addWidget(QLabel("Project Path"), 0, 0)
-        lyt.addWidget(self.proj_path_txt, 0, 1)
+        lyt.addWidget(QLabel("Project Path"), 1, 0)
+        lyt.addWidget(self.proj_path_txt, 1, 1)
 
         self.op_path_txt = FileSearchLineEdit(directory_only=True)
-        lyt.addWidget(QLabel("Output Path"), 1, 0)
-        lyt.addWidget(self.op_path_txt, 1, 1)
+        lyt.addWidget(QLabel("Output Path"), 2, 0)
+        lyt.addWidget(self.op_path_txt, 2, 1)
 
+        # --- Render-only fields ---
+        self.layers_label = QLabel("Render Layers")
         self.layers_box = QComboBox(self)
         layer_items = [
             (LayerSelection.ALL, "All Renderable Layers"),
@@ -116,28 +152,51 @@ class SceneSettingsWidget(QWidget):
         ]
         for layer_value, text in layer_items:
             self.layers_box.addItem(text, layer_value)
-        lyt.addWidget(QLabel("Render Layers"), 2, 0)
-        lyt.addWidget(self.layers_box, 2, 1)
+        lyt.addWidget(self.layers_label, 3, 0)
+        lyt.addWidget(self.layers_box, 3, 1)
         self.layers_box.currentIndexChanged.connect(self._fill_cameras_box)
+        self._render_only_rows.append((self.layers_label, self.layers_box))
 
+        self.cameras_label = QLabel("Cameras")
         self.cameras_box = QComboBox(self)
-        lyt.addWidget(QLabel("Cameras"), 3, 0)
-        lyt.addWidget(self.cameras_box, 3, 1)
+        lyt.addWidget(self.cameras_label, 4, 0)
+        lyt.addWidget(self.cameras_box, 4, 1)
+        self._render_only_rows.append((self.cameras_label, self.cameras_box))
 
+        # --- Frame range (visible in both modes; meaning differs) ---
         self.frame_override_chck = QCheckBox("Override Frame Range", self)
         self.frame_override_txt = QLineEdit(self)
         # Only allow numbers, colons, dashes, commas, and whitespace for frame ranges
         frame_pattern = QRegularExpression(r"^[0-9:\-,\s]*$")
         self.frame_override_txt.setValidator(QRegularExpressionValidator(frame_pattern))
-        lyt.addWidget(self.frame_override_chck, 4, 0)
-        lyt.addWidget(self.frame_override_txt, 4, 1)
+        lyt.addWidget(self.frame_override_chck, 5, 0)
+        lyt.addWidget(self.frame_override_txt, 5, 1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)
+
+        # --- Python-script-only fields ---
+        self.python_script_label = QLabel("Python Script")
+        self.python_script_txt = FileSearchLineEdit(
+            file_format="Python Scripts (*.py);;All Files (*)", parent=self
+        )
+        lyt.addWidget(self.python_script_label, 6, 0)
+        lyt.addWidget(self.python_script_txt, 6, 1)
+        self._python_only_rows.append((self.python_script_label, self.python_script_txt))
+
+        self.script_args_label = QLabel("Script Args")
+        self.script_args_txt = QLineEdit(self)
+        self.script_args_txt.setToolTip(
+            "Optional argument string passed to the script via the "
+            "DEADLINE_SCRIPT_ARGS environment variable."
+        )
+        lyt.addWidget(self.script_args_label, 7, 0)
+        lyt.addWidget(self.script_args_txt, 7, 1)
+        self._python_only_rows.append((self.script_args_label, self.script_args_txt))
 
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 5, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 8, 0)
 
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
 
@@ -162,7 +221,22 @@ class SceneSettingsWidget(QWidget):
             if index >= 0:
                 self.cameras_box.setCurrentIndex(index)
 
+    def _on_job_type_changed(self, *args):
+        """Toggle visibility of render-only / python-script-only widgets."""
+        is_python = self.job_type_box.currentData() == JOB_TYPE_PYTHON_SCRIPT
+        for label, widget in self._render_only_rows:
+            label.setVisible(not is_python)
+            widget.setVisible(not is_python)
+        for label, widget in self._python_only_rows:
+            label.setVisible(is_python)
+            widget.setVisible(is_python)
+
     def _configure_settings(self, settings):
+        # Job type
+        index = self.job_type_box.findData(getattr(settings, "job_type", JOB_TYPE_RENDER))
+        if index >= 0:
+            self.job_type_box.setCurrentIndex(index)
+
         self.proj_path_txt.setText(settings.project_path)
         self.op_path_txt.setText(settings.output_path)
         self.frame_override_chck.setChecked(settings.override_frame_range)
@@ -177,6 +251,10 @@ class SceneSettingsWidget(QWidget):
         if index >= 0:
             self.cameras_box.setCurrentIndex(index)
 
+        # Python script fields
+        self.python_script_txt.setText(getattr(settings, "python_script_path", ""))
+        self.script_args_txt.setText(getattr(settings, "script_args", ""))
+
         if self.developer_options:
             self.include_adaptor_wheels.setChecked(settings.include_adaptor_wheels)
 
@@ -184,6 +262,8 @@ class SceneSettingsWidget(QWidget):
         """
         Update a scene settings object with the latest values.
         """
+
+        settings.job_type = self.job_type_box.currentData()
 
         settings.project_path = self.proj_path_txt.text()
         settings.output_path = self.op_path_txt.text()
@@ -193,6 +273,9 @@ class SceneSettingsWidget(QWidget):
 
         settings.render_layer_selection = self.layers_box.currentData()
         settings.camera_selection = self.cameras_box.currentData()
+
+        settings.python_script_path = self.python_script_txt.text()
+        settings.script_args = self.script_args_txt.text()
 
         if self.developer_options:
             settings.include_adaptor_wheels = self.include_adaptor_wheels.isChecked()

--- a/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py
@@ -26,6 +26,7 @@ from deadline.maya_adaptor.MayaAdaptor.adaptor import _FIRST_MAYA_ACTIONS, MayaN
 # If the schema changes (properties added/removed/modified), this test data
 # must be updated AND the integration_data_interface_version must be bumped
 EXPECTED_INIT_DATA_PROPERTIES = {
+    "job_type": "render",
     "camera": "test_camera",
     "error_on_arnold_license_fail": True,
     "image_height": 1080,
@@ -41,8 +42,10 @@ EXPECTED_INIT_DATA_PROPERTIES = {
     "strict_error_checking": True,
 }
 
-# Required fields for init_data schema
-EXPECTED_INIT_DATA_REQUIRED = ["project_path", "render_layer", "renderer", "scene_file"]
+# Required fields for init_data schema. renderer/render_layer are conditionally
+# required when job_type == "render" (handled via the schema's allOf/if/then),
+# but they are not in the top-level "required" array.
+EXPECTED_INIT_DATA_REQUIRED = ["project_path", "scene_file"]
 
 # Test data that exercises ALL properties in run_data schema
 # If the schema changes (properties added/removed/modified), this test data
@@ -55,14 +58,18 @@ EXPECTED_RUN_DATA_PROPERTIES = {
     "region_max_y": 1080,
     "camera": "test_camera",
     "output_file_prefix": "<Scene>/<RenderLayer>",
+    "script_file": "/path/to/user_script.py",
+    "script_args": "--my-arg 42",
 }
 
-# Required fields for run_data schema
-EXPECTED_RUN_DATA_REQUIRED = ["frame"]
+# Required fields for run_data schema. The schema uses anyOf to require
+# either "frame" (render job) or "script_file" (python-script job), so the
+# top-level "required" array is empty.
+EXPECTED_RUN_DATA_REQUIRED: list[str] = []
 
 # Expected version - must be bumped when schemas change
 EXPECTED_SCHEMA_VERSION_MAJOR = 0
-EXPECTED_SCHEMA_VERSION_MINOR = 2
+EXPECTED_SCHEMA_VERSION_MINOR = 3
 
 
 @pytest.fixture()
@@ -571,7 +578,7 @@ class TestMayaAdaptor_on_start:
     def test_semantic_version(self, init_data: dict) -> None:
         """Tests that the adaptor semantic version is in the expected format"""
         adaptor = MayaAdaptor(init_data)
-        assert adaptor.integration_data_interface_version == SemanticVersion(major=0, minor=2)
+        assert adaptor.integration_data_interface_version == SemanticVersion(major=0, minor=3)
 
     def test_if_init_data_and_run_data_schema_are_changed_schema_version_is_bumped(
         self, init_data: dict
@@ -776,7 +783,10 @@ class TestMayaAdaptor_on_run:
             adaptor.on_run(run_data)
 
         # THEN
-        error_msg = " is a required property"
+        # The run_data schema now uses anyOf to require either "frame" (render
+        # job) or "script_file" (python-script job), so an empty payload fails
+        # with the anyOf validator rather than a single "required" error.
+        error_msg = "is not valid under any of the given schemas"
         assert error_msg in exc_info.value.message
 
 

--- a/test/unit/deadline_submitter_for_maya/scripts/test_submitter.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_submitter.py
@@ -17,6 +17,7 @@ def test_frame_override_has_text_validation():
         # methods being mocked out).
         class MockQWidget:
             setEnabled = Mock()
+            setVisible = Mock()
 
             def __init__(self, parent):
                 pass


### PR DESCRIPTION
## Summary

Adds a **Job Type** selector to the existing Maya submitter Scene Settings tab. Users can now choose between:
- **Render** (default — existing behavior, unchanged)
- **Python Script** — run a user-supplied Python script inside Maya per task

The user's `.py` file is uploaded as a job attachment and executed inside the persistent MayaClient via `runpy.run_path(run_name="__main__")` once per task. The script gets `DEADLINE_TASK_FRAME` and `DEADLINE_SCRIPT_ARGS` env vars.

## Why

Lets users author bespoke Maya rendering / processing logic (custom render passes, geometry processing, scene-graph manipulation, etc.) and run it on Deadline Cloud workers without needing to teach the standard render path about every special case.

## Changes

### Submitter
- `data_classes.py` — sticky fields `job_type`, `python_script_path`, `script_args`
- `ui/components/scene_settings_tab.py` — Job Type combo at top; show/hide for render-only vs python-script-only widgets; new Python Script file picker + Script Args
- `maya_render_submitter.py` — `_get_python_script_job_template()` and `_get_python_script_parameter_values()`; both `get_job_template_for_submission` and `get_parameter_values_for_submission` branch on `settings.job_type`. `on_create_job_bundle_callback` injects the script path into `asset_references.input_filenames` so Deadline Cloud uploads it.

### Adaptor
- `MayaAdaptor/schemas/init_data.schema.json` — adds optional `job_type` (`render` | `python_script`, default `render`); `renderer`/`render_layer` become conditionally required via `allOf/if/then` (render mode unchanged; python-script mode does not need them).
- `MayaAdaptor/schemas/run_data.schema.json` — adds optional `script_file`, `script_args`; replaces `required:[frame]` with `anyOf:[frame, script_file]`.
- `MayaAdaptor/adaptor.py` — `_populate_action_queue` skips renderer + render-only init when `job_type == python_script`. `on_run` dispatches to `execute_script` action when `script_file` is in run-data, otherwise unchanged. Bumps `integration_data_interface_version` 0.2 → 0.3.
- `MayaClient/render_handlers/default_maya_handler.py` — new `execute_script(data)` action: validates path (with path mapping), runs via `runpy.run_path(run_name="__main__")`, sets/restores env vars, propagates exceptions, emits the existing completion line so the adaptor's busy-wait clears.

### Tests
- Updated `EXPECTED_INIT_DATA_*` / `EXPECTED_RUN_DATA_*` constants in `test_adaptor.py` to match the new schemas and version (0.3).
- Updated the wrong-schema run_data assertion to expect the `anyOf` failure message.
- Added `setVisible` mock to `MockQWidget` in `test_submitter.py` so the new visibility toggle works under the test's Qt shim.

## Verification

| Check | Result |
|---|---|
| `ruff check .` | ✅ All checks passed |
| `black --check .` | ✅ 81 files unchanged |
| `mypy src test maya_submitter_plugin/plug-ins` | ✅ Success: no issues found in 72 source files |
| `pytest --cov-config pyproject.toml test/unit` | ✅ **178 passed**, coverage 54.54% (≥ 41% required) |

## Known limitations / follow-ups

1. `show_maya_render_submitter` still calls `_set_render_layer_data`, which raises if no layer is renderable. In practice `masterLayer` is renderable in any default scene, but a future change can defer that check to submit-time when `job_type == render`.
2. No tests added yet for the new `execute_script` handler or the python-script template branch — happy to add in a follow-up.
