### PR TITLE
fix: normalize OCIO config path separators on Windows

### DIFF
--- a/src/deadline/maya_submitter/scene.py
+++ b/src/deadline/maya_submitter/scene.py
@@ -212,12 +212,18 @@ class Scene:
         # Get the config file path - Maya returns bool if no path set
         config_path = maya.cmds.colorManagementPrefs(query=True, configFilePath=True)
         if isinstance(config_path, str) and "<MAYA_RESOURCES>" not in config_path:
-            return config_path
+            # Normalize separators to forward slashes for cross-platform
+            # consistency with other Maya path queries (cmds.file,
+            # cmds.workspace, etc.) which return forward slashes on
+            # Windows. colorManagementPrefs preserves the input verbatim,
+            # so on Windows this would otherwise emit backslash paths
+            # into the job bundle's OCIOConfigFile parameter.
+            return config_path.replace("\\", "/")
 
         # Fall back to the OCIO environment variable
         ocio_env = os.environ.get("OCIO", "")
         if ocio_env:
-            return ocio_env
+            return ocio_env.replace("\\", "/")
 
         return None
 

--- a/test/integ/helpers/output_comparison.py
+++ b/test/integ/helpers/output_comparison.py
@@ -63,11 +63,20 @@ def are_parameter_values_similar(job_history_dir: Path, expected_parameter_value
             name = parameter_value["name"]
             value = parameter_value["value"]
 
-            # Convert to help with Windows path format
+            # Convert to help with Windows path format. Most Maya path
+            # queries (cmds.file, cmds.workspace) auto-normalize to
+            # forward slashes on Windows, but a few (e.g.
+            # cmds.colorManagementPrefs) preserve the input verbatim. To
+            # avoid coupling the test to which side normalizes, we
+            # canonicalize both expected and actual to forward slashes.
             if not isinstance(value, int):
                 value = value.replace("\\", "/")
 
-            assert value == extract_parameter_value(actual_parameter_values, name)
+            actual_value = extract_parameter_value(actual_parameter_values, name)
+            if isinstance(actual_value, str):
+                actual_value = actual_value.replace("\\", "/")
+
+            assert value == actual_value
 
 
 def are_asset_references_similar(

--- a/test/unit/deadline_submitter_for_maya/scripts/test_scene.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_scene.py
@@ -145,7 +145,13 @@ class TestOcioConfigFile:
 
     @patch("deadline.maya_submitter.scene.maya.cmds")
     def test_ocio_config_file_ocio_env_fallback(self, mock_maya_cmds: Mock) -> None:
-        """Tests that OCIO env var is used when colorManagementPrefs returns bool"""
+        """Tests that OCIO env var is used when colorManagementPrefs returns bool
+
+        Backslash separators in the env var (e.g. on Windows) are
+        normalized to forward slashes so the OCIOConfigFile parameter
+        emitted into the job bundle uses the same separator convention
+        as Maya's other path queries (cmds.file, cmds.workspace).
+        """
         # GIVEN
         mock_maya_cmds.colorManagementPrefs.side_effect = [
             True,  # cmEnabled
@@ -158,7 +164,7 @@ class TestOcioConfigFile:
             result = Scene.ocio_config_file()
 
         # THEN
-        assert result == ocio_env_path
+        assert result == "Z:/OCIO/Maya2022-default/config.ocio"
 
     @patch("deadline.maya_submitter.scene.maya.cmds")
     def test_ocio_config_file_custom_config(self, mock_maya_cmds: Mock) -> None:
@@ -175,3 +181,28 @@ class TestOcioConfigFile:
 
         # THEN
         assert result == custom_path
+
+    @patch("deadline.maya_submitter.scene.maya.cmds")
+    def test_ocio_config_file_normalizes_windows_separators(self, mock_maya_cmds: Mock) -> None:
+        """Tests that backslash separators returned by Maya on Windows are
+        normalized to forward slashes.
+
+        Unlike cmds.file and cmds.workspace which always return
+        forward-slashed paths on Windows, cmds.colorManagementPrefs
+        preserves the input path verbatim. Without normalization the
+        OCIOConfigFile job bundle parameter would use a different
+        separator convention than every other path parameter, breaking
+        tests and producing an inconsistent bundle.
+        """
+        # GIVEN
+        windows_path = "C:\\Studio\\OCIO\\config.ocio"
+        mock_maya_cmds.colorManagementPrefs.side_effect = [
+            True,  # cmEnabled
+            windows_path,  # configFilePath
+        ]
+
+        # WHEN
+        result = Scene.ocio_config_file()
+
+        # THEN
+        assert result == "C:/Studio/OCIO/config.ocio"


### PR DESCRIPTION
## Summary

Fix Windows-only failure of `test_scene_submitter_with_ocio_config` on
mainline (run [#26591239346](https://github.com/aws-deadline/deadline-cloud-for-maya/actions/runs/26591239346))
by normalizing the OCIO config path returned from
`Scene.ocio_config_file()` to forward slashes.

## Background

PR #410 added `test_scene_submitter_with_ocio_config`. The test passed
on Linux but the same test failed on Windows on its PR CodeBuild run
(build 8 / `47a541ea`). The PR was merged anyway because a re-trigger
of the workflow (run #13 / build 9) used the default `branch: mainline`
input, which made CodeBuild clone mainline-without-the-test and report
green even though the workflow file was loaded from the PR branch.
Once the PR landed, the next push-triggered run on mainline failed
on Windows with the same error.

## Root cause

`Scene.ocio_config_file()` returns the value of
`cmds.colorManagementPrefs(query=True, configFilePath=True)` verbatim.
Unlike `cmds.file` and `cmds.workspace`, which auto-normalize paths
to forward slashes on Windows, `colorManagementPrefs` preserves the
input string. On Windows, `str(Path(...))` produces a backslash path,
so the test's input flowed through Maya and came back unchanged. The
test helper `are_parameter_values_similar` only normalized the
**expected** side to forward slashes, leaving:

- expected (after `replace("\\\\", "/")`): `C:/Windows/.../config.ocio`
- actual (Maya preserved input): `C:\\Windows\\...\\config.ocio`

→ `AssertionError`. Linux didn't surface this because no path on Linux
contains backslashes.

This is also a real bundle-consistency issue: `OCIOConfigFile` would
ship as the only path parameter using backslashes while `MayaSceneFile`,
`ProjectPath`, and `OutputFilePath` all use forward slashes.

## Changes

**Production**
- `src/deadline/maya_submitter/scene.py` — `Scene.ocio_config_file()`
  normalizes both the `colorManagementPrefs` return value and the
  `OCIO` env-var fallback to forward slashes. The job bundle's
  `OCIOConfigFile` parameter now uses the same separator convention as
  every other path parameter.

**Tests**
- `test/integ/helpers/output_comparison.py` — `are_parameter_values_similar`
  now canonicalizes both expected and actual to forward slashes.
  Defensive: future Maya path queries that don't auto-normalize won't
  break Windows tests.
- `test/unit/deadline_submitter_for_maya/scripts/test_scene.py` —
  - Updated `test_ocio_config_file_ocio_env_fallback` to assert the
    normalized result for a backslash env var.
  - Added `test_ocio_config_file_normalizes_windows_separators` to
    lock in the normalization contract for the `colorManagementPrefs`
    path.

## Testing

- `hatch run test` for `test_scene.py` → 20 passed (all 6 OCIO tests +
  the new normalization test).
- `hatch run lint` → ruff, black, mypy all clean.
- Full unit suite (excluding `test/integ` which needs Maya/Qt) →
  184 passed, 9 skipped. The pre-existing `_version.py` copyright
  failure and 4 installer tests are unrelated.
- Will be validated end-to-end by the next mainline run after merge.

## Notes

There's also a workflow-syntax warning at `.github/workflows/integration_tests.yml#L41`
(literal text outside `${{ }}` in `aws-deadline/.github`'s
`reusable_integration_test.yml` line 25 — `if:` always truthy). Not
fixed here; belongs in the shared `aws-deadline/.github` repo.
