### PR TITLE
feat(telemetry): standardize exception_scope to 'caught'

### DIFF
--- a/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
+++ b/src/deadline/maya_adaptor/MayaAdaptor/adaptor.py
@@ -535,7 +535,8 @@ class MayaAdaptor(Adaptor[AdaptorConfiguration]):
             #  waiting for the next command. If the thread finished, then we cannot continue
             exit_code = self._maya_client.returncode
             self._get_deadline_telemetry_client().record_error(
-                {"exit_code": exit_code, "exception_scope": "on_run"}, str(RuntimeError)
+                {"exit_code": exit_code, "exception_scope": "caught", "error_operation": "on_run"},
+                str(RuntimeError),
             )
             raise RuntimeError(
                 "Maya exited early and did not render successfully, please check render logs. "


### PR DESCRIPTION
Fixes: N/A (internal telemetry improvement)

### What was the problem/requirement? (What/Why)

The `exception_scope` field in telemetry error events was using lifecycle-specific values like `"on_run"` rather than standardized values. This makes it difficult to distinguish uncaught exceptions from handled errors in telemetry analysis, since the field describes *where* the error occurred rather than *how* it was caught.

### What was the solution? (How)

Standardized `exception_scope` to `"caught"` for all handled exceptions and preserved the previous lifecycle-specific value in a new `error_operation` field. This allows telemetry queries to cleanly filter by catch semantics (`"caught"` vs `"uncaught"`) while still providing drill-down capability by operation phase.

### What is the impact of this change?

No customer-facing impact. This is an internal telemetry change that improves the accuracy of error classification in our observability dashboards. The telemetry payload gains a new `error_operation` field and the `exception_scope` value changes from a lifecycle name to the standardized `"caught"`.

### How was this change tested?

- Verified the telemetry client's `record_error` call site accepts the updated `event_details` dict structure
- Confirmed existing CloudWatch Logs Insights dashboard queries have been updated (in a separate change) to match both old and new event formats via OR clauses, ensuring no data gap during rollout

#### Integ test result

N/A — the change only modifies the metadata dict passed to a telemetry `record_error` call within `on_run`. No adaptor behavior, IPC contract, or render logic is affected.

#### Installer test result

N/A — `installer/` was not modified.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Not applicable — this change does not touch submitter logic or job bundle generation. The modified code path is in the adaptor's telemetry error reporting only.

### Was this change documented?

No documentation updates required. This is an internal telemetry field change with no impact on public APIs, CLI behavior, docstrings, or adaptor schemas.

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/maya_adaptor/MayaAdaptor/adaptor.py` and update the test constants?
   - [ ] Yes
   - [x] No

### Is this a breaking change?

No. The adaptor's init-data and run-data schemas are unchanged. The telemetry payload is internal and not part of the public contract, so a job submitted with an older Maya submitter plug-in will continue to work with this version of the adaptor.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*