### PR TITLE
feat: timeout setting to Maya job submission 

### DIFF
--- a/src/deadline/maya_submitter/data_classes.py
+++ b/src/deadline/maya_submitter/data_classes.py
@@ -6,10 +6,33 @@ from dataclasses import dataclass, field
 from pathlib import Path
 import json
 
+from deadline.client.ui.dataclasses.timeouts import TimeoutEntry, TimeoutTableEntries
+from datetime import timedelta
 from .cameras import ALL_CAMERAS
 from .render_layers import LayerSelection  # type: ignore
 
 RENDER_SUBMITTER_SETTINGS_FILE_EXT = ".deadline_render_settings.json"
+
+
+def default_time_entries() -> TimeoutTableEntries:
+    entries = {
+        "Task Run": TimeoutEntry(
+            tooltip="Maximum duration for a task to run or for rendering a frame",
+            seconds=int(timedelta(days=2).total_seconds()),
+            is_activated=False,  # The default maya job template doesn't have timeout for task run
+        ),
+        "Maya Launch": TimeoutEntry(
+            tooltip="Maximum duration for Maya to start",
+            seconds=87000,  # comes from the default_maya_job_template
+            is_activated=True,
+        ),
+        "Maya Shutdown": TimeoutEntry(
+            tooltip="Maximum duration for Maya to shutdown",
+            seconds=600,
+            is_activated=True,  # comes from the default_maya_job_template
+        ),
+    }
+    return TimeoutTableEntries(entries=entries)
 
 
 @dataclass
@@ -36,6 +59,12 @@ class RenderSubmitterUISettings:
     project_path: str = field(default="")
     output_path: str = field(default="")
 
+    # field and property can't have the same name
+    _timeouts: TimeoutTableEntries = field(
+        default_factory=default_time_entries,
+        metadata={"sticky": True, "sticky_key": "timeouts", "sticky_save_attr": "_timeouts_sticky"},
+    )
+
     input_filenames: list[str] = field(default_factory=list, metadata={"sticky": True})
     input_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
     output_directories: list[str] = field(default_factory=list, metadata={"sticky": True})
@@ -48,6 +77,23 @@ class RenderSubmitterUISettings:
     # developer options
     include_adaptor_wheels: bool = field(default=False, metadata={"sticky": True})
 
+    @property
+    def timeouts(self) -> TimeoutTableEntries:
+        return self._timeouts
+
+    @timeouts.setter
+    def timeouts(self, value: "TimeoutTableEntries | dict") -> None:
+        # A setter for timeouts. The value used to set timeouts can either be a TimeoutTableEntries or a dict
+        if isinstance(value, dict):
+            self._timeouts.update_from_sticky_settings(value)
+        else:
+            self._timeouts = value
+
+    @property
+    def _timeouts_sticky(self) -> dict:
+        # Serialized form used when writing sticky settings
+        return self._timeouts.to_sticky_settings_dict()
+
     def load_sticky_settings(self, scene_filename: str):
         sticky_settings_filename = Path(scene_filename).with_suffix(
             RENDER_SUBMITTER_SETTINGS_FILE_EXT
@@ -58,14 +104,15 @@ class RenderSubmitterUISettings:
                     sticky_settings = json.load(fh)
 
                 if isinstance(sticky_settings, dict):
-                    sticky_fields = {
-                        field.name: field
+                    sticky_keys = {
+                        # either get sticky_key for non_primitive that is supported by @property
+                        # or field.name for primitive
+                        field.metadata.get("sticky_key", field.name)
                         for field in dataclasses.fields(self)
                         if field.metadata.get("sticky")
                     }
                     for name, value in sticky_settings.items():
-                        # Only set fields that are defined in the dataclass
-                        if name in sticky_fields:
+                        if name in sticky_keys:
                             setattr(self, name, value)
             except (OSError, json.JSONDecodeError):
                 # If something bad happened to the sticky settings file,
@@ -84,7 +131,9 @@ class RenderSubmitterUISettings:
         )
         with open(sticky_settings_filename, "w", encoding="utf8") as fh:
             obj = {
-                field.name: getattr(self, field.name)
+                field.metadata.get("sticky_key", field.name): getattr(
+                    self, field.metadata.get("sticky_save_attr", field.name)
+                )
                 for field in dataclasses.fields(self)
                 if field.metadata.get("sticky")
             }

--- a/src/deadline/maya_submitter/default_maya_job_template.yaml
+++ b/src/deadline/maya_submitter/default_maya_job_template.yaml
@@ -111,7 +111,6 @@ steps:
           - file://{{Env.File.initData}}
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
-          timeout: 87000
         onExit:
           command: MayaAdaptor
           args:
@@ -121,7 +120,6 @@ steps:
           - '{{ Session.WorkingDirectory }}/connection.json'
           cancelation:
             mode: NOTIFY_THEN_TERMINATE
-          timeout: 600
   script:
     embeddedFiles:
     - name: runData

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -42,6 +42,7 @@ from .render_layers import (
 )
 from .cameras import get_renderable_camera_names, ALL_CAMERAS
 from ._version import version, version_tuple as adaptor_version_tuple
+from .template_timeout_patcher import add_timeouts_to_job_template
 from .ui.components.scene_settings_tab import SceneSettingsWidget
 from deadline.client.job_bundle.submission import AssetReferences
 import time
@@ -338,6 +339,8 @@ def _get_job_template(
         if "jobEnvironments" not in job_template:
             job_template["jobEnvironments"] = []
         job_template["jobEnvironments"].append(override_environment["environment"])
+
+    add_timeouts_to_job_template(job_template, settings.timeouts)
 
     return job_template
 

--- a/src/deadline/maya_submitter/template_timeout_patcher.py
+++ b/src/deadline/maya_submitter/template_timeout_patcher.py
@@ -1,0 +1,28 @@
+from deadline.client.ui.dataclasses.timeouts import TimeoutTableEntries
+
+from typing import Any
+
+
+def add_timeouts_to_job_template(template: dict[str, Any], timeouts: TimeoutTableEntries) -> None:
+    """
+    The job template may have multiple steps (one per render take).
+    Each step has 1 task run and 1 environment with 3 actions:
+    - Task run
+    - Maya launch (onEnter)
+    - Maya shutdown (onExit)
+    We apply the timeouts to all steps.
+    """
+    timeouts.validate_entries()
+    for step in template["steps"]:
+        if timeouts.entries["Task Run"].is_activated:
+            step["script"]["actions"]["onRun"]["timeout"] = timeouts.entries["Task Run"].seconds
+
+        if timeouts.entries["Maya Launch"].is_activated:
+            step["stepEnvironments"][0]["script"]["actions"]["onEnter"]["timeout"] = (
+                timeouts.entries["Maya Launch"].seconds
+            )
+
+        if timeouts.entries["Maya Shutdown"].is_activated:
+            step["stepEnvironments"][0]["script"]["actions"]["onExit"]["timeout"] = (
+                timeouts.entries["Maya Shutdown"].seconds
+            )

--- a/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
+++ b/src/deadline/maya_submitter/ui/components/scene_settings_tab.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import (  # type: ignore
 )
 from qtpy.QtGui import QRegularExpressionValidator  # type: ignore
 from deadline.client.ui import block_signals
+from deadline.client.ui.widgets.job_timeouts_widget import TimeoutTableWidget
 
 from ...render_layers import LayerSelection
 
@@ -133,11 +134,14 @@ class SceneSettingsWidget(QWidget):
         lyt.addWidget(self.frame_override_txt, 4, 1)
         self.frame_override_chck.stateChanged.connect(self.activate_frame_override_changed)
 
+        self.timeout_settings_box = TimeoutTableWidget(timeouts=settings.timeouts, parent=self)
+        lyt.addWidget(self.timeout_settings_box, 5, 0, 1, 2)
+
         if self.developer_options:
             self.include_adaptor_wheels = QCheckBox(
                 "Developer Option: Include Adaptor Wheels", self
             )
-            lyt.addWidget(self.include_adaptor_wheels, 5, 0)
+            lyt.addWidget(self.include_adaptor_wheels, 6, 0)
 
         lyt.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 10, 0)
 
@@ -193,6 +197,8 @@ class SceneSettingsWidget(QWidget):
 
         settings.render_layer_selection = self.layers_box.currentData()
         settings.camera_selection = self.cameras_box.currentData()
+
+        self.timeout_settings_box.update_settings(settings.timeouts)
 
         if self.developer_options:
             settings.include_adaptor_wheels = self.include_adaptor_wheels.isChecked()

--- a/test/integ/test_maya_adaptors.py
+++ b/test/integ/test_maya_adaptors.py
@@ -3,10 +3,11 @@
 from pathlib import Path
 
 import pytest
+import yaml
 from flaky import flaky
 
 from .helpers.output_comparison import are_images_similar
-from .helpers.test_runners import run_adaptor_test
+from .helpers.test_runners import run_adaptor_test, run_command
 
 from test.integ.test_const import (
     TEMPLATE,
@@ -120,3 +121,55 @@ class TestAdaptors:
             actual_image_directory=output_path,
             tolerance=2,
         )
+
+
+@pytest.mark.adaptor
+class TestTaskRunTimeout:
+    """
+    Verifies that the onRun (Task Run) timeout written into the job template is
+    enforced by the OpenJD session runner.
+    """
+
+    def test_task_run_timeout_is_enforced(self, script_location: Path) -> None:
+        """
+        Scene-free template whose onRun sleeps 60s but has a 5s timeout, so the
+        task must be terminated by the timeout and the run must fail. No job
+        params are required (the Frames parameter has a default) and no output
+        is produced.
+        """
+
+        template_path = script_location / "test_time_out" / EXPECTED_JOB_BUNDLE_FOLDER / TEMPLATE
+
+        with open(template_path) as f:
+            template = yaml.safe_load(f)
+
+        # Execute the step explicitly instead of through run_adaptor_test util because we want access to output
+        for step in template["steps"]:
+            output = run_command(
+                [
+                    "mayapy",
+                    "-m",
+                    "openjd",
+                    "run",
+                    str(template_path),
+                    "--step",
+                    step["name"],
+                    "--job-param",
+                    "{}",
+                ]
+            )
+
+            combined = output.stdout.decode("utf-8", errors="replace") + output.stderr.decode(
+                "utf-8", errors="replace"
+            )
+
+            # The run must fail
+            assert output.returncode != 0, (
+                "Expected the step to fail because the Task Run timeout should have "
+                f"terminated it, but it succeeded with returncode {output.returncode}."
+            )
+            # and it must fail specifically because of the Task Run timeout
+            assert "TIMEOUT" in combined, (
+                "Expected the failure to be caused by the Task Run timeout, but no "
+                f"timeout message was found in the output:\n{combined}"
+            )

--- a/test/integ/test_scripts/minimal_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/minimal_test/scene/test.deadline_render_settings.json
@@ -8,6 +8,20 @@
  "max_worker_count": -1,
  "override_frame_range": true,
  "frame_list": "1-2",
+ "timeouts": {
+  "Task Run": {
+   "is_activated": false,
+   "seconds": 172800
+  },
+  "Maya Launch": {
+   "is_activated": true,
+   "seconds": 87000
+  },
+  "Maya Shutdown": {
+   "is_activated": true,
+   "seconds": 600
+  }
+ },
  "input_filenames": [],
  "input_directories": [],
  "output_directories": [],

--- a/test/integ/test_scripts/mtoa_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/mtoa_test/scene/test.deadline_render_settings.json
@@ -8,6 +8,20 @@
  "max_worker_count": -1,
  "override_frame_range": true,
  "frame_list": "1",
+ "timeouts": {
+  "Task Run": {
+   "is_activated": false,
+   "seconds": 172800
+  },
+  "Maya Launch": {
+   "is_activated": true,
+   "seconds": 87000
+  },
+  "Maya Shutdown": {
+   "is_activated": true,
+   "seconds": 600
+  }
+ },
  "input_filenames": [],
  "input_directories": [],
  "output_directories": [],

--- a/test/integ/test_scripts/ocio_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/ocio_test/scene/test.deadline_render_settings.json
@@ -8,6 +8,20 @@
  "max_worker_count": -1,
  "override_frame_range": true,
  "frame_list": "1",
+ "timeouts": {
+  "Task Run": {
+   "is_activated": false,
+   "seconds": 172800
+  },
+  "Maya Launch": {
+   "is_activated": true,
+   "seconds": 87000
+  },
+  "Maya Shutdown": {
+   "is_activated": true,
+   "seconds": 600
+  }
+ },
  "input_filenames": [],
  "input_directories": [],
  "output_directories": [],

--- a/test/integ/test_scripts/redshift_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/redshift_test/scene/test.deadline_render_settings.json
@@ -8,6 +8,20 @@
  "max_worker_count": -1,
  "override_frame_range": true,
  "frame_list": "1",
+ "timeouts": {
+  "Task Run": {
+   "is_activated": false,
+   "seconds": 172800
+  },
+  "Maya Launch": {
+   "is_activated": true,
+   "seconds": 87000
+  },
+  "Maya Shutdown": {
+   "is_activated": true,
+   "seconds": 600
+  }
+ },
  "input_filenames": [],
  "input_directories": [],
  "output_directories": [],

--- a/test/integ/test_scripts/redshift_test/scene/test.ma
+++ b/test/integ/test_scripts/redshift_test/scene/test.ma
@@ -530,7 +530,7 @@ select -ne :defaultLightSet;
 	setAttr -s 2 ".dsm";
 select -ne :defaultColorMgtGlobals;
 	setAttr ".cfe" yes;
-	setAttr ".cfp" -type "string" "/Applications/Autodesk/maya2025/Maya.app/Contents/Resources/OCIO-configs/Maya2022-default/config.ocio";
+	setAttr ".cfp" -type "string" "<MAYA_RESOURCES>/OCIO-configs/Maya2022-default/config.ocio";
 	setAttr ".vtn" -type "string" "Un-tone-mapped (sRGB)";
 	setAttr ".vn" -type "string" "Un-tone-mapped";
 	setAttr ".dn" -type "string" "sRGB";

--- a/test/integ/test_scripts/test_time_out/expected_job_bundle/template.yaml
+++ b/test/integ/test_scripts/test_time_out/expected_job_bundle/template.yaml
@@ -1,0 +1,38 @@
+specificationVersion: jobtemplate-2023-09
+name: test_time_out
+description: |
+  Scene-free job template used to verify that the onRun (Task Run) timeout is
+  enforced by the OpenJD session runner.
+
+  The onRun action sleeps for far longer than its 5 second timeout, so the task
+  must be canceled by the timeout and the run must fail. The task intentionally
+  produces no output. No stepEnvironments are defined because Maya does not need
+  to be launched to exercise the Task Run timeout.
+parameterDefinitions:
+- name: Frames
+  type: STRING
+  description: The frames to render.
+  default: '1'
+steps:
+- name: Render
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: '{{Param.Frames}}'
+  script:
+    embeddedFiles:
+    - name: runData
+      filename: run-data.yaml
+      type: TEXT
+      data: |
+        frame: {{Task.Param.Frame}}
+    actions:
+      onRun:
+        command: mayapy
+        args:
+        - -c
+        - 'import time; time.sleep(60)'
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+        timeout: 5

--- a/test/integ/test_scripts/vray_test/scene/test.deadline_render_settings.json
+++ b/test/integ/test_scripts/vray_test/scene/test.deadline_render_settings.json
@@ -8,6 +8,20 @@
  "max_worker_count": -1,
  "override_frame_range": true,
  "frame_list": "1",
+ "timeouts": {
+  "Task Run": {
+   "is_activated": false,
+   "seconds": 172800
+  },
+  "Maya Launch": {
+   "is_activated": true,
+   "seconds": 87000
+  },
+  "Maya Shutdown": {
+   "is_activated": true,
+   "seconds": 600
+  }
+ },
  "input_filenames": [],
  "input_directories": [],
  "output_directories": [],

--- a/test/unit/deadline_submitter_for_maya/scripts/test_submission_api.py
+++ b/test/unit/deadline_submitter_for_maya/scripts/test_submission_api.py
@@ -135,6 +135,71 @@ class TestGetJobTemplateForSubmission:
 
         assert result["steps"][0]["hostRequirements"] == host_requirements
 
+    def test_timeout_injected_into_steps(self):
+        """Activated timeout entries write their seconds to the matching action of every step."""
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_job_template_for_submission,
+        )
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "test_job"
+        settings.description = ""
+        settings.override_frame_range = False
+
+        # Modify the default timeouts with non-default, distinct values so the
+        # assertions cannot accidentally pass against the default seconds.
+        settings.timeouts.entries["Task Run"].is_activated = True
+        settings.timeouts.entries["Task Run"].seconds = 111
+        settings.timeouts.entries["Maya Launch"].is_activated = True
+        settings.timeouts.entries["Maya Launch"].seconds = 222
+        settings.timeouts.entries["Maya Shutdown"].is_activated = True
+        settings.timeouts.entries["Maya Shutdown"].seconds = 333
+
+        context = _make_context()
+
+        result = get_job_template_for_submission(settings, context=context)
+
+        assert result["steps"]
+        for step in result["steps"]:
+            env_actions = step["stepEnvironments"][0]["script"]["actions"]
+            # Task Run -> step script onRun
+            assert step["script"]["actions"]["onRun"]["timeout"] == 111
+            # Maya Launch / Shutdown -> step environment onEnter / onExit
+            assert env_actions["onEnter"]["timeout"] == 222
+            assert env_actions["onExit"]["timeout"] == 333
+
+    def test_deactivated_timeout_not_written_to_step(self):
+        """An entry with is_activated=False must not add a timeout to its action."""
+        from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+        from deadline.maya_submitter.maya_render_submitter import (
+            get_job_template_for_submission,
+        )
+
+        settings = RenderSubmitterUISettings()
+        settings.name = "test_job"
+        settings.description = ""
+        settings.override_frame_range = False
+
+        # Deactivate Task Run and Maya Shutdown; keep Maya Launch activated.
+        settings.timeouts.entries["Task Run"].is_activated = False
+        settings.timeouts.entries["Maya Launch"].is_activated = True
+        settings.timeouts.entries["Maya Launch"].seconds = 222
+        settings.timeouts.entries["Maya Shutdown"].is_activated = False
+
+        context = _make_context()
+
+        result = get_job_template_for_submission(settings, context=context)
+
+        assert result["steps"]
+        for step in result["steps"]:
+            env_actions = step["stepEnvironments"][0]["script"]["actions"]
+            # Deactivated entries -> no timeout key on the action at all.
+            assert "timeout" not in step["script"]["actions"]["onRun"]
+            assert "timeout" not in env_actions["onExit"]
+            # The one activated entry is still applied.
+            assert env_actions["onEnter"]["timeout"] == 222
+
     def test_creates_context_if_not_provided(self):
         from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
         from deadline.maya_submitter.maya_render_submitter import (


### PR DESCRIPTION

Fixes: #387 

### What was the problem/requirement? (What/Why)
When submitting render jobs from Maya via the Deadline Cloud submitter, there is currently no way to configure timeout values for the job. This means users cannot control how long a task run, Maya launch, or Maya shutdown is allowed to take before being considered failed.

Without timeout settings, long-running or stuck tasks can consume worker resources indefinitely, leading to wasted compute costs and blocked queues.
### What was the solution? (How)
Add configurable timeout settings to the Maya submitter. The change mirror how C4D implemented the feature with some tweak to make it fit Maya.

### What is the impact of this change?
Artists can now view and edit Maya Launch, Maya Shutdown, and Task Run timeouts in the submitter and have them reflected in submitted jobs and exported bundles.
### How was this change tested?
- Add new submitter unit test to make sure that the timeouts are injected correctly to the job template
- Add integration test in the adaptor to make sure timeouts is enforced.
- Manually test the submitter on Maya 2026 and 2025

#### Integ test result
```
====================================================================================================================================== slowest 5 durations =======================================================================================================================================
29.70s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
25.16s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor
18.20s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_vray_scene_adaptor
16.63s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_mtoa_scene_adaptor
8.54s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
=========================================================================================================================== 10 passed, 4 warnings in 115.82s (0:01:55) ===========================================================================================================================
```
#### Installer test result

- No installer change
```
================================= slowest 5 duration============================================
8.08s setup    test/installer/test_installer.py::TestUserInstall::test_install
8.06s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
7.57s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
2.64s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
2.16s call     test/installer/test_installer.py::test_default_location
================================================================================================================================= 4 passed, 9 skipped in 11.05s ==================================================================================================================================
```
#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Timestamp: 2026-06-17T16:22:16.098919-07:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-maya/job_bundle_output_tests/layers

layers
Test succeeded

Timestamp: 2026-06-17T16:22:19.758183-07:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-maya/job_bundle_output_tests/referenced_layers

referenced_layers
Test succeeded

Timestamp: 2026-06-17T16:22:23.611271-07:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-maya/job_bundle_output_tests/renderman
Skipping test renderman because Renderman for Maya is not installed.
Timestamp: 2026-06-17T16:22:23.611481-07:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-maya/job_bundle_output_tests/cube

cube
Test succeeded

Timestamp: 2026-06-17T16:22:27.564660-07:00
Running job bundle output test: /Volumes/workplace/deadline-cloud-for-maya/job_bundle_output_tests/layers_no_variation

layers_no_variation
Test succeeded

All tests passed, ran 4 total.
Timestamp: 2026-06-17T16:22:33.492355-07:00
```

### Was this change documented?
Yes, relevant docstrings are added to Python function.

### Did you modify schema files?
- [ ] Yes
- [X] No


### Is this a breaking change?
Not a breaking change.
----
<img width="556" height="733" alt="Screenshot 2026-06-17 at 3 54 19 PM" src="https://github.com/user-attachments/assets/530bbba6-9d40-4151-85a5-f04ac15d54c7" />


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

