### PR TITLE
feat: enable deadline-cloud-v2 conda channel in submitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.55.1,< 0.56",
+    "deadline >= 0.59.0,< 0.60",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -1035,6 +1035,7 @@ def show_maya_render_submitter(
         parent=parent,
         f=f,
         show_host_requirements_tab=True,
+        use_deadline_cloud_v2_channel=True,
     )
     submitter_dialog.show()
     return submitter_dialog


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Deadline Cloud is migrating its service-managed Conda channel from deadline-cloud to deadline-cloud-v2. The Maya submitter should adopt the v2 channel so that jobs resolve packages from deadline-cloud-v2 (while still falling back to deadline-cloud for anything not yet hosted on v2). The actual channel rewrite is shared logic that belongs in the deadline-cloud library, not in this submitter; this change is the Maya side that opts into it.

Related changes: https://github.com/aws-deadline/deadline-cloud/pull/1211
### What was the solution? (How)
- Pass `use_deadline_cloud_v2_channel=True` when constructing `SubmitJobToDeadlineDialog` in `_show_submitter`. This is a new opt-in flag added to the deadline-cloud library: when enabled, the library prepends `deadline-cloud-v2` ahead of `deadline-cloud `in the CondaChannels queue parameter as it loads. The submitter doesn't contains channel-name logic
- Bump `deadline` in `pyproject.toml` from `>= 0.55.1, < 0.59` to `>= 0.59, < 0.60` since this option is only available in `deadline` 59 +
### What is the impact of this change?
- GUI submission for Maya now prepend `deadline-cloud-v2` ahead of `deadline-cloud` in `CondaChannels` queue parameter.
- Requires `deadline-cloud 0.59` or newer

### How was this change tested?
<img width="547" height="722" alt="Screenshot 2026-06-24 at 9 38 03 AM" src="https://github.com/user-attachments/assets/25fcdf02-2be7-42e5-be7d-f2cd951eb6a9" />


#### Unit test result
```
====================================================================== slowest 5 durations ======================================================================
0.13s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_maya_init_timeout
0.03s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_run::test_on_run_render_fail
0.02s call     test/unit/deadline_submitter_for_maya/test_mel_commands.py::test_deadline_cloud_submitter_cmd_sticky_setting_load_only_once
0.02s call     test/unit/deadline_submitter_for_maya/scripts/test_submission_api.py::TestGetJobTemplateForSubmission::test_creates_context_if_not_provided
0.02s call     test/unit/deadline_adaptor_for_maya/MayaAdaptor/test_adaptor.py::TestMayaAdaptor_on_start::test_arnold_pathmapping_called[vray-False]
====================================================================== 186 passed in 3.53s ======================================================================
```
#### Integ test result

```
===================================================================== slowest 5 durations ======================================================================
31.13s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor
22.59s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor
16.62s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_vray_scene_adaptor
15.41s call     test/integ/test_maya_adaptors.py::TestAdaptors::test_mtoa_scene_adaptor
8.22s call     test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test]
========================================================== 10 passed, 4 warnings in 111.44s (0:01:51) ===========================================================
```
#### Installer test result
No installer change

#### Was this change documented?
No documentation changes are required. No Python function signatures in this repository changed 

#### Is this a breaking change?
Not a breaking change. This is backward-compatible. It adds an opt-in argument to `CondaChannel` only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
