### PR TITLE
fix: window integ test fail when  updating deadline from 0.55.1 to 0.59

### DIFF
--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -970,6 +970,20 @@ def setup_windows(maya_versions: Sequence[str], renderers: Sequence[str]) -> Non
         print(f"Installing submitter for Maya {version}...")
         run(["hatch", "run", "install", "--maya-version", version])
 
+        print("Cleanup stale deadline, deadline-job-attachement if any for a clean environment")
+        run(
+            [
+                str(mayapy_exe),
+                "-m",
+                "pip",
+                "uninstall",
+                "-y",
+                "deadline",
+                "deadline-job-attachments",
+            ],
+            check=False,
+        )
+
         print(f"Installing integ test dependencies for Maya {version}...")
         run(
             [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Maya Windows integration tests (deadline-cloud-for-maya-mainline-windows-integ) were failing during test collection while the equivalent Linux runs passed at the same commit.
```
deadline/client/api/_telemetry.py:23: in <module>
    from ...job_attachments.progress_tracker import SummaryStatistics
E   ModuleNotFoundError: No module named 'deadline.job_attachments'
```
Root cause: starting in `deadline` 0.59, `deadline.job_attachments` was split out of the `deadline` wheel into its own distribution (`deadline-job-attachments`), making `deadline` a PEP 420 namespace package shared across two distributions. Older `deadline` (≤0.58, e.g. `0.55.1`) **bundled** `deadline/job_attachments/` and owns those paths in its install RECORD.

The Windows setup installs into Maya's bundled `mayapy` **in place** (`mayapy -m pip install …`). The Windows integration test host is reused across runs, and its `mayapy` site-packages carried an older bundled `deadline 0.55.1` from a previous run. When a run upgraded `0.55.1 → 0.59.x`, pip installed the new `deadline-job-attachments` (writing `deadline/job_attachments/`) and then uninstalled `0.55.1`, which **deleted `deadline/job_attachments/`** per `0.55.1`'s RECORD — even though pip reported both packages "successfully installed." Linux is unaffected because it installs into Maya via `pip install --target …`, which is additive and never uninstalls.

### What was the solution? (How)
In `pipeline/setup-runner.py` (`setup_windows`), uninstall the `deadline` namespace distributions from `mayapy` **before** the in-place `mayapy -m pip install` steps, so no stale bundled `deadline` is uninstalled mid-transaction and clobbers `deadline/job_attachments`

### What is the impact of this change?
Window integration test should pass.

### How was this change tested?
This behaviour is agnostic to OS, so it reproduces in a plain CPython venv with the real public wheels.
1. Reproduction:
```
python -m venv /tmp/repro
/tmp/repro/bin/python -m pip install deadline==0.55.1
/tmp/repro/bin/python -c "import deadline.job_attachments"   # OK (bundled)
/tmp/repro/bin/python -m pip install deadline==0.59.1        # in-place upgrade
/tmp/repro/bin/python -c "import deadline.job_attachments"   # -> ModuleNotFoundError
```
2. Verified the fix (uninstall-first, upgrade-from-bundled state):
```
python -m venv /tmp/fixed
/tmp/fixed/bin/python -m pip install deadline==0.55.1
/tmp/fixed/bin/python -m pip uninstall -y deadline deadline-job-attachments
/tmp/fixed/bin/python -m pip install deadline==0.59.1
/tmp/fixed/bin/python -c "import deadline.job_attachments, deadline.client; print('OK')"  # -> OK
```

### Was this change documented?
No document needed.

### Did you modify schema files?
No

### Is this a breaking change?
No this is for fixing integration test.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
