### PR TITLE
fix: Submitter loads sticky settings on every dialog reopen

### DIFF
--- a/src/deadline/maya_submitter/mel_commands.py
+++ b/src/deadline/maya_submitter/mel_commands.py
@@ -64,14 +64,12 @@ class DeadlineCloudSubmitterCmd(om.MPxCommand):
                 if check_and_show_update_dialog():
                     return
 
-                # Create a new submitter dialog. If this is the first time the submitter is
-                # opened, load the sticky settings. If this is not the first time, close
-                # the existing dialog and create a new one without loading the sticky
-                # settings.
+                # Recreate the dialog so scene-derived state (cameras, layers) refreshes,
+                # and load sticky settings so user-set job parameters persist across reopens.
                 if DeadlineCloudSubmitterCmd.dialog:
                     DeadlineCloudSubmitterCmd.dialog.close()
                     DeadlineCloudSubmitterCmd.dialog = show_maya_render_submitter(
-                        parent=mainwin, f=Qt.Tool, load_sticky_setting=False
+                        parent=mainwin, f=Qt.Tool, load_sticky_setting=True
                     )
                 else:
                     DeadlineCloudSubmitterCmd.dialog = show_maya_render_submitter(

--- a/test/unit/deadline_submitter_for_maya/test_mel_commands.py
+++ b/test/unit/deadline_submitter_for_maya/test_mel_commands.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import (  # type: ignore
 @patch("deadline.maya_submitter.mel_commands.check_and_show_update_dialog", return_value=False)
 @patch.object(QApplication, "instance")
 @patch.object(om.MGlobal, "mayaState")
-def test_deadline_cloud_submitter_cmd_sticky_setting_load_only_once(
+def test_deadline_cloud_submitter_cmd_sticky_setting_loaded_on_every_open(
     mock_maya_state: Mock,
     mock_q_app: Mock,
     mock_update_check: Mock,
@@ -36,6 +36,6 @@ def test_deadline_cloud_submitter_cmd_sticky_setting_load_only_once(
     DeadlineCloudSubmitterCmd.doIt(Mock())
 
     mock_show_maya_render_submitter.assert_called_with(
-        parent=maya_widget, f=Qt.Tool, load_sticky_setting=False
+        parent=maya_widget, f=Qt.Tool, load_sticky_setting=True
     )
     submitter_dialog.close.assert_called_once()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Sticky job parameters reset to defaults every time the user closed and reopened the submitter on the same scene. First open loaded sticky settings; subsequent opens did not.

### What was the solution? (How)
- Set load_sticky_setting=True on both branches of the dialog-create path in mel_commands.py. Safe because sticky load is field-filtered — only fields tagged metadata={"sticky": True} are restored, and scene-volatile fields aren't tagged. 

### What is the impact of this change?
- Sticky-marked fields (priority, frame range, timeouts, attachments, etc.) persist across dialog reopens on the same scene. No change to job bundles, the adaptor, or scene-refresh behavior.

### How was this change tested?
- Inverted the unit test that encoded the buggy behavior. Verified locally with an A/B/C swap: passes with the fix, fails when the flag is reverted, passes again when restored.
- Manual smoke test in Maya 2026 (Windows): set Priority to 99, submitted, closed, reopened — Priority persisted. Switched scenes with dialog closed and reopened; cameras refreshed correctly.

#### Integ test result
- N/A — change is in dialog lifecycle, not job-bundle output.

#### Installer test result
- N/A — installer/ unmodified.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
- No. The fix doesn't alter inputs to job bundle generation; same inputs still produce identical bundles.

### Was this change documented?
- Inline comment in `mel_commands.py` updated. No README/DEVELOPMENT changes needed.

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?
- No