### PR TITLE
chore: Remove ManualTestGate stage from release_publish workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -34,13 +34,6 @@ jobs:
     with:
       tag: ${{ needs.TagRelease.outputs.tag }}
 
-  ManualTestGate:
-    needs: [TagRelease, BuildInstaller]
-    runs-on: ubuntu-latest
-    environment: release-gate
-    steps:
-      - run: echo "Manual testing approved for ${{ needs.TagRelease.outputs.tag }}"
-
   PreRelease:
       needs: [TagRelease, UnitTests]
       uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
@@ -84,7 +77,7 @@ jobs:
          :
   
   ReleaseInstaller:
-    needs: [TagRelease, IsCondaReady, ManualTestGate]
+    needs: [TagRelease, IsCondaReady]
     uses: aws-deadline/.github/.github/workflows/reusable_release_installers.yml@mainline
     secrets: inherit
     permissions:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We don't run manual tests on releases, but we are still pausing for some

### What was the solution? (How)

remove ManualTestGate

### What is the impact of this change?

Two less button clicks to perform a release. We still have the IsCondaReady check to prevent releasing a broken installer.

### How was this change tested?

N/A

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*