### PR TITLE
feat: Run pre-GUI hooks in the Maya render submitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,6 @@ classifiers = [
 ]
 
 dependencies = [
-    # 0.60.1 is the first release to ship deadline.client.ui.pre_gui_hooks
-    # (run_pre_gui_hooks / PreGuiHookContext / qt_hook_confirmation / apply_pre_gui_output), which
-    # the pre-GUI hook integration in maya_render_submitter.show_maya_render_submitter requires.
     "deadline >= 0.60.1,< 0.61",
     "openjd-adaptor-runtime == 0.9.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,14 @@ classifiers = [
 ]
 
 dependencies = [
-    # run_pre_gui_hooks / PreGuiHookContext (deadline.client.ui.pre_gui_hooks) are required for
-    # the pre-GUI hook integration below. That module was added after the 0.60.0 tag, so it ships
-    # in the next minor release, 0.61.0. Re-confirm against the published release before merging.
-    "deadline >= 0.61.0,< 0.62",
+    # TODO: bump this floor to the deadline-cloud release that ships
+    # deadline.client.ui.pre_gui_hooks (run_pre_gui_hooks / PreGuiHookContext /
+    # apply_pre_gui_output) before marking this PR ready. That module was added after the
+    # 0.60.0 tag and is not published yet, so the floor is held at the latest released version
+    # (0.60.0) to keep dependency resolution working. The pre-GUI hooks import is done lazily
+    # in maya_render_submitter.show_maya_render_submitter, so this module (and the unit tests)
+    # import cleanly on 0.60.0; the hooks are only required when the submitter is launched.
+    "deadline >= 0.60.0,< 0.61",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # TODO: bump this floor to the deadline-cloud release that ships
-    # deadline.client.ui.pre_gui_hooks (run_pre_gui_hooks / PreGuiHookContext /
-    # apply_pre_gui_output) before marking this PR ready. That module was added after the
-    # 0.60.0 tag and is not published yet, so the floor is held at the latest released version
-    # (0.60.0) to keep dependency resolution working. The pre-GUI hooks import is done lazily
-    # in maya_render_submitter.show_maya_render_submitter, so this module (and the unit tests)
-    # import cleanly on 0.60.0; the hooks are only required when the submitter is launched.
-    "deadline >= 0.60.0,< 0.61",
+    # 0.60.1 is the first release to ship deadline.client.ui.pre_gui_hooks
+    # (run_pre_gui_hooks / PreGuiHookContext / apply_pre_gui_output), which the pre-GUI hook
+    # integration in maya_render_submitter.show_maya_render_submitter requires.
+    "deadline >= 0.60.1,< 0.61",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # run_pre_gui_hooks / PreGuiHookContext are required for the pre-GUI hook integration
-    # below; they ship in deadline-cloud 0.60.x. Confirm the exact release before merging.
-    "deadline >= 0.60.0,< 0.61",
+    # run_pre_gui_hooks / PreGuiHookContext (deadline.client.ui.pre_gui_hooks) are required for
+    # the pre-GUI hook integration below. That module was added after the 0.60.0 tag, so it ships
+    # in the next minor release, 0.61.0. Re-confirm against the published release before merging.
+    "deadline >= 0.61.0,< 0.62",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.59.0,< 0.60",
+    # run_pre_gui_hooks / PreGuiHookContext are required for the pre-GUI hook integration
+    # below; they ship in deadline-cloud 0.60.x. Confirm the exact release before merging.
+    "deadline >= 0.60.0,< 0.61",
     "openjd-adaptor-runtime == 0.9.*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 
 dependencies = [
     # 0.60.1 is the first release to ship deadline.client.ui.pre_gui_hooks
-    # (run_pre_gui_hooks / PreGuiHookContext / apply_pre_gui_output), which the pre-GUI hook
-    # integration in maya_render_submitter.show_maya_render_submitter requires.
+    # (run_pre_gui_hooks / PreGuiHookContext / qt_hook_confirmation / apply_pre_gui_output), which
+    # the pre-GUI hook integration in maya_render_submitter.show_maya_render_submitter requires.
     "deadline >= 0.60.1,< 0.61",
     "openjd-adaptor-runtime == 0.9.*",
 ]

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -22,11 +22,6 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint
     SubmitJobToDeadlineDialog,
     JobBundlePurpose,
 )
-from deadline.client.ui.pre_gui_hooks import (  # pylint: disable=import-error
-    PreGuiHookContext,
-    qt_hook_confirmation,
-    run_pre_gui_hooks,
-)
 from deadline.client.exceptions import DeadlineOperationError
 from qtpy.QtCore import Qt  # type: ignore
 
@@ -1059,6 +1054,16 @@ def show_maya_render_submitter(
     # on-disk job bundle at this point, so hooks are sourced from DEADLINE_HOOKS_DIR only
     # (bundle_dir=None), gated by settings.allow_environment_hooks. The confirmation prompt is
     # skipped when auto_accept is set; otherwise the standard dialog is shown.
+    #
+    # Imported lazily (like qtpy above) rather than at module top: this ships in deadline-cloud
+    # 0.60+, and a top-level import would break importing this module — and every unit test that
+    # collects it — against older deadline-cloud releases.
+    from deadline.client.ui.pre_gui_hooks import (  # pylint: disable=import-error
+        PreGuiHookContext,
+        qt_hook_confirmation,
+        run_pre_gui_hooks,
+    )
+
     confirm_callback = (
         None if str2bool(get_setting("settings.auto_accept")) else qt_hook_confirmation(parent)
     )

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -22,7 +22,7 @@ from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint
     SubmitJobToDeadlineDialog,
     JobBundlePurpose,
 )
-from deadline.client.exceptions import DeadlineOperationError
+from deadline.client.exceptions import DeadlineOperationCanceled, DeadlineOperationError
 from qtpy.QtCore import Qt  # type: ignore
 
 from . import Animation, Scene  # type: ignore
@@ -1056,18 +1056,27 @@ def show_maya_render_submitter(
         run_pre_gui_hooks,
     )
 
-    pre_gui_output = run_pre_gui_hooks(
-        PreGuiHookContext(
-            bundle_dir=None,
-            job_name=render_settings.name,
-            submitter_name="maya",
-            parameters=dict(shared_parameter_values),
-        ),
-        confirm_callback=_pre_gui_hook_confirm_callback(parent),
-    )
+    try:
+        pre_gui_output = run_pre_gui_hooks(
+            PreGuiHookContext(
+                bundle_dir=None,
+                job_name=render_settings.name,
+                submitter_name="maya",
+                parameters=dict(shared_parameter_values),
+            ),
+            confirm_callback=_pre_gui_hook_confirm_callback(parent),
+        )
+    except DeadlineOperationCanceled:
+        # The user declined the hook confirmation prompt. This is a normal cancellation, not a
+        # failure, so abort opening the submitter silently rather than letting the exception reach
+        # the caller's gui_error_handler (which would show a spurious "Error opening..." dialog).
+        # Mirrors the check_and_show_update_dialog() early-return; both callers handle None.
+        return None
     # RenderSubmitterUISettings has no `.parameters` list, so apply_pre_gui_output routes
-    # name/description onto it and every hook parameter into shared_parameter_values.
-    apply_pre_gui_output(pre_gui_output, render_settings, shared_parameter_values)
+    # name/description onto it and every hook parameter into shared_parameter_values. Guard with
+    # `or {}` defensively: run_pre_gui_hooks returns {} when no hooks run, but this keeps the call
+    # safe if a future release returns None instead.
+    apply_pre_gui_output(pre_gui_output or {}, render_settings, shared_parameter_values)
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -1033,7 +1033,7 @@ def show_maya_render_submitter(
     # skipped when auto_accept is set; otherwise the standard dialog is shown.
     #
     # Imported lazily (like qtpy above) rather than at module top: this ships in deadline-cloud
-    # 0.60+, and a top-level import would break importing this module — and every unit test that
+    # 0.60.1+, and a top-level import would break importing this module — and every unit test that
     # collects it — against older deadline-cloud releases.
     from deadline.client.ui.pre_gui_hooks import (  # pylint: disable=import-error
         PreGuiHookContext,

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -915,29 +915,6 @@ def on_create_job_bundle_callback(
     }
 
 
-def _apply_pre_gui_output(
-    pre_gui_output: dict[str, Any],
-    render_settings: RenderSubmitterUISettings,
-    shared_parameter_values: dict[str, Any],
-) -> None:
-    """Map merged pre-GUI hook output onto Maya's settings + shared parameter values.
-
-    ``RenderSubmitterUISettings`` has no ``.parameters`` list (unlike the standalone
-    submitter's ``JobBundleSettings``), so ``name`` / ``description`` are written onto the
-    settings object and any hook ``parameters`` (queue params like ``RezPackages`` /
-    ``CondaPackages``, ``deadline:`` job properties, etc.) are merged into the shared values
-    the dialog is seeded with. This is why the DCC does its own mapping rather than calling
-    deadline-cloud's ``JobBundleSettings``-specific ``apply_pre_gui_output``.
-    """
-    if not pre_gui_output:
-        return
-    if "name" in pre_gui_output:
-        render_settings.name = pre_gui_output["name"]
-    if "description" in pre_gui_output:
-        render_settings.description = pre_gui_output["description"]
-    shared_parameter_values.update(pre_gui_output.get("parameters", {}))
-
-
 def show_maya_render_submitter(
     parent, f=Qt.WindowFlags(), load_sticky_setting: bool = False
 ) -> Optional[SubmitJobToDeadlineDialog]:
@@ -1060,6 +1037,7 @@ def show_maya_render_submitter(
     # collects it — against older deadline-cloud releases.
     from deadline.client.ui.pre_gui_hooks import (  # pylint: disable=import-error
         PreGuiHookContext,
+        apply_pre_gui_output,
         qt_hook_confirmation,
         run_pre_gui_hooks,
     )
@@ -1076,7 +1054,9 @@ def show_maya_render_submitter(
         ),
         confirm_callback=confirm_callback,
     )
-    _apply_pre_gui_output(pre_gui_output, render_settings, shared_parameter_values)
+    # RenderSubmitterUISettings has no `.parameters` list, so apply_pre_gui_output routes
+    # name/description onto it and every hook parameter into shared_parameter_values.
+    apply_pre_gui_output(pre_gui_output, render_settings, shared_parameter_values)
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -15,12 +15,17 @@ from deadline.client.api import (
     get_deadline_cloud_library_telemetry_client,
     get_queue_parameter_definitions,
 )
-from deadline.client.config import get_setting
+from deadline.client.config import get_setting, str2bool
 from deadline.client.job_bundle.parameters import JobParameter
 from deadline.client.job_bundle._yaml import deadline_yaml_dump
 from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # pylint: disable=import-error
     SubmitJobToDeadlineDialog,
     JobBundlePurpose,
+)
+from deadline.client.ui.pre_gui_hooks import (  # pylint: disable=import-error
+    PreGuiHookContext,
+    qt_hook_confirmation,
+    run_pre_gui_hooks,
 )
 from deadline.client.exceptions import DeadlineOperationError
 from qtpy.QtCore import Qt  # type: ignore
@@ -915,6 +920,29 @@ def on_create_job_bundle_callback(
     }
 
 
+def _apply_pre_gui_output(
+    pre_gui_output: dict[str, Any],
+    render_settings: RenderSubmitterUISettings,
+    shared_parameter_values: dict[str, Any],
+) -> None:
+    """Map merged pre-GUI hook output onto Maya's settings + shared parameter values.
+
+    ``RenderSubmitterUISettings`` has no ``.parameters`` list (unlike the standalone
+    submitter's ``JobBundleSettings``), so ``name`` / ``description`` are written onto the
+    settings object and any hook ``parameters`` (queue params like ``RezPackages`` /
+    ``CondaPackages``, ``deadline:`` job properties, etc.) are merged into the shared values
+    the dialog is seeded with. This is why the DCC does its own mapping rather than calling
+    deadline-cloud's ``JobBundleSettings``-specific ``apply_pre_gui_output``.
+    """
+    if not pre_gui_output:
+        return
+    if "name" in pre_gui_output:
+        render_settings.name = pre_gui_output["name"]
+    if "description" in pre_gui_output:
+        render_settings.description = pre_gui_output["description"]
+    shared_parameter_values.update(pre_gui_output.get("parameters", {}))
+
+
 def show_maya_render_submitter(
     parent, f=Qt.WindowFlags(), load_sticky_setting: bool = False
 ) -> Optional[SubmitJobToDeadlineDialog]:
@@ -1022,13 +1050,33 @@ def show_maya_render_submitter(
     progress_dialog.close()
     print("Progress dialog closed, creating submission dialog")
 
+    shared_parameter_values = {
+        "RezPackages": rez_packages,
+        "CondaPackages": conda_packages,
+    }
+
+    # Run pre-GUI hooks so studios can pre-populate dialog fields before it opens. Maya has no
+    # on-disk job bundle at this point, so hooks are sourced from DEADLINE_HOOKS_DIR only
+    # (bundle_dir=None), gated by settings.allow_environment_hooks. The confirmation prompt is
+    # skipped when auto_accept is set; otherwise the standard dialog is shown.
+    confirm_callback = (
+        None if str2bool(get_setting("settings.auto_accept")) else qt_hook_confirmation(parent)
+    )
+    pre_gui_output = run_pre_gui_hooks(
+        PreGuiHookContext(
+            bundle_dir=None,
+            job_name=render_settings.name,
+            submitter_name="maya",
+            parameters=dict(shared_parameter_values),
+        ),
+        confirm_callback=confirm_callback,
+    )
+    _apply_pre_gui_output(pre_gui_output, render_settings, shared_parameter_values)
+
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=SceneSettingsWidget,
         initial_job_settings=render_settings,
-        initial_shared_parameter_values={
-            "RezPackages": rez_packages,
-            "CondaPackages": conda_packages,
-        },
+        initial_shared_parameter_values=shared_parameter_values,
         auto_detected_attachments=auto_detected_attachments,
         attachments=attachments,
         on_create_job_bundle_callback=on_create_job_bundle_callback,

--- a/src/deadline/maya_submitter/maya_render_submitter.py
+++ b/src/deadline/maya_submitter/maya_render_submitter.py
@@ -915,6 +915,21 @@ def on_create_job_bundle_callback(
     }
 
 
+def _pre_gui_hook_confirm_callback(parent):
+    """Choose the confirmation callback for pre-GUI hooks based on the auto_accept setting.
+
+    Returns ``None`` (run hooks without prompting) when ``settings.auto_accept`` is enabled,
+    otherwise the standard Qt confirmation dialog from ``qt_hook_confirmation``. Kept as a small
+    helper so the auto_accept branch can be unit-tested headlessly.
+    """
+    if str2bool(get_setting("settings.auto_accept")):
+        return None
+
+    from deadline.client.ui.pre_gui_hooks import qt_hook_confirmation
+
+    return qt_hook_confirmation(parent)
+
+
 def show_maya_render_submitter(
     parent, f=Qt.WindowFlags(), load_sticky_setting: bool = False
 ) -> Optional[SubmitJobToDeadlineDialog]:
@@ -1035,16 +1050,12 @@ def show_maya_render_submitter(
     # Imported lazily (like qtpy above) rather than at module top: this ships in deadline-cloud
     # 0.60.1+, and a top-level import would break importing this module — and every unit test that
     # collects it — against older deadline-cloud releases.
-    from deadline.client.ui.pre_gui_hooks import (  # pylint: disable=import-error
+    from deadline.client.ui.pre_gui_hooks import (
         PreGuiHookContext,
         apply_pre_gui_output,
-        qt_hook_confirmation,
         run_pre_gui_hooks,
     )
 
-    confirm_callback = (
-        None if str2bool(get_setting("settings.auto_accept")) else qt_hook_confirmation(parent)
-    )
     pre_gui_output = run_pre_gui_hooks(
         PreGuiHookContext(
             bundle_dir=None,
@@ -1052,7 +1063,7 @@ def show_maya_render_submitter(
             submitter_name="maya",
             parameters=dict(shared_parameter_values),
         ),
-        confirm_callback=confirm_callback,
+        confirm_callback=_pre_gui_hook_confirm_callback(parent),
     )
     # RenderSubmitterUISettings has no `.parameters` list, so apply_pre_gui_output routes
     # name/description onto it and every hook parameter into shared_parameter_values.

--- a/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
@@ -11,14 +11,14 @@ routes hook output correctly against Maya's own ``RenderSubmitterUISettings`` â€
 guards against a regression where ``RenderSubmitterUISettings`` gains a ``parameters`` attribute
 that would silently misroute hook parameters.
 
-``apply_pre_gui_output`` ships in deadline-cloud 0.61+; the module is skipped on older releases
+``apply_pre_gui_output`` ships in deadline-cloud 0.60.1+; the module is skipped on older releases
 so this file collects cleanly regardless of the installed deadline-cloud version. The maya /
 qtpy modules are stubbed by the package ``__init__`` so imports resolve.
 """
 
 import pytest
 
-# apply_pre_gui_output ships in deadline-cloud 0.61+; skip cleanly on older releases.
+# apply_pre_gui_output ships in deadline-cloud 0.60.1+; skip cleanly on older releases.
 pre_gui_hooks = pytest.importorskip("deadline.client.ui.pre_gui_hooks")
 apply_pre_gui_output = pre_gui_hooks.apply_pre_gui_output
 

--- a/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
@@ -1,0 +1,80 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Unit tests for the Maya submitter's pre-GUI hook integration.
+
+``show_maya_render_submitter`` calls deadline-cloud's ``run_pre_gui_hooks`` (env-only, since
+Maya has no on-disk bundle) and then maps the merged output onto its own
+``RenderSubmitterUISettings`` + the dialog's shared parameter values via
+``_apply_pre_gui_output``. The full submitter needs a running Maya, so it is exercised in the
+integration suite; here we unit-test the mapping helper — the DCC-owned piece — headless.
+The maya / qtpy modules are stubbed by the package ``__init__`` so the module imports.
+"""
+
+from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+from deadline.maya_submitter.maya_render_submitter import _apply_pre_gui_output
+
+
+def _settings() -> RenderSubmitterUISettings:
+    s = RenderSubmitterUISettings()
+    s.name = "Original"
+    s.description = ""
+    return s
+
+
+def test_name_and_description_applied_to_settings():
+    """A hook's name/description overwrite the settings fields (Maya has no .parameters list,
+    so these land directly on the dataclass)."""
+    settings = _settings()
+    shared = {"RezPackages": "mayaIO-2024 deadline_cloud_for_maya"}
+
+    _apply_pre_gui_output({"name": "PREGUI RAN", "description": "from pipeline"}, settings, shared)
+
+    assert settings.name == "PREGUI RAN"
+    assert settings.description == "from pipeline"
+
+
+def test_hook_parameters_merged_into_shared_values():
+    """Hook parameters (queue params, deadline: properties) are merged into the shared values
+    the dialog is seeded with, overriding the Maya-computed defaults on key collision."""
+    settings = _settings()
+    shared = {"RezPackages": "mayaIO-2024 deadline_cloud_for_maya", "CondaPackages": "maya=2024.*"}
+
+    _apply_pre_gui_output(
+        {
+            "parameters": {
+                "deadline:priority": 88,
+                "RezPackages": "mayaIO-2024 custom_pkg",  # overrides the default
+            }
+        },
+        settings,
+        shared,
+    )
+
+    assert shared["deadline:priority"] == 88
+    assert shared["RezPackages"] == "mayaIO-2024 custom_pkg"
+    assert shared["CondaPackages"] == "maya=2024.*"  # untouched keys preserved
+
+
+def test_empty_output_is_a_noop():
+    """No pre-GUI hook output leaves the settings and shared values unchanged."""
+    settings = _settings()
+    shared = {"RezPackages": "pkg"}
+
+    _apply_pre_gui_output({}, settings, shared)
+
+    assert settings.name == "Original"
+    assert settings.description == ""
+    assert shared == {"RezPackages": "pkg"}
+
+
+def test_partial_output_only_touches_present_keys():
+    """Only the keys present in the output are applied; others keep their prior values."""
+    settings = _settings()
+    settings.description = "keep me"
+    shared: dict = {}
+
+    _apply_pre_gui_output({"name": "NewName"}, settings, shared)
+
+    assert settings.name == "NewName"
+    assert settings.description == "keep me"  # not overwritten
+    assert shared == {}  # no parameters in output

--- a/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
@@ -16,6 +16,7 @@ integration suite; here we verify the DCC-owned pieces headless:
 The maya / qtpy modules are stubbed by the package ``__init__`` so imports resolve.
 """
 
+import sys
 from unittest.mock import patch
 
 from deadline.client.ui.pre_gui_hooks import apply_pre_gui_output
@@ -97,7 +98,13 @@ def test_confirm_callback_none_when_auto_accept_enabled(mock_get_setting):
     mock_get_setting.assert_called_once_with("settings.auto_accept")
 
 
-@patch("qtpy.QtWidgets.QMessageBox")
+# Patch ``QMessageBox`` on the exact object the import reads. ``qt_hook_confirmation`` does
+# ``from qtpy.QtWidgets import QMessageBox``, which resolves through ``sys.modules["qtpy.QtWidgets"]``
+# — the standalone mock the package ``__init__`` installs there. A string ``patch("qtpy.QtWidgets.
+# QMessageBox")`` instead resolves the dotted path through the *parent* ``qtpy`` mock's auto-created
+# ``QtWidgets`` child, which is a different object on Python 3.9/3.10, so the patch never reaches the
+# QMessageBox the code sees and ``question`` is never called.
+@patch.object(sys.modules["qtpy.QtWidgets"], "QMessageBox")
 @patch.object(maya_render_submitter, "get_setting", return_value="false")
 def test_confirmation_dialog_fires_when_auto_accept_disabled(mock_get_setting, mock_msgbox):
     """With settings.auto_accept disabled, invoking the returned callback actually shows the

--- a/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
@@ -5,26 +5,22 @@
 ``show_maya_render_submitter`` calls deadline-cloud's ``run_pre_gui_hooks`` (env-only, since
 Maya has no on-disk bundle) and then maps the merged output with deadline-cloud's generic
 ``apply_pre_gui_output``. The full submitter needs a running Maya, so it is exercised in the
-integration suite; here we verify the DCC-owned contract headless: that ``apply_pre_gui_output``
-routes hook output correctly against Maya's own ``RenderSubmitterUISettings`` — which has no
-``.parameters`` list, so every hook parameter must land in the shared parameter values. This
-guards against a regression where ``RenderSubmitterUISettings`` gains a ``parameters`` attribute
-that would silently misroute hook parameters.
+integration suite; here we verify the DCC-owned pieces headless:
 
-``apply_pre_gui_output`` ships in deadline-cloud 0.60.1+; the module is skipped on older releases
-so this file collects cleanly regardless of the installed deadline-cloud version. The maya /
-qtpy modules are stubbed by the package ``__init__`` so imports resolve.
+* ``apply_pre_gui_output`` routes hook output correctly against Maya's own
+  ``RenderSubmitterUISettings`` — which has no ``.parameters`` list, so every hook parameter must
+  land in the shared parameter values. This guards against a regression where
+  ``RenderSubmitterUISettings`` gains a ``parameters`` attribute that would misroute hook params.
+* ``_pre_gui_hook_confirm_callback`` honours the ``settings.auto_accept`` setting.
+
+The maya / qtpy modules are stubbed by the package ``__init__`` so imports resolve.
 """
 
-import pytest
+from unittest.mock import patch
 
-# apply_pre_gui_output ships in deadline-cloud 0.60.1+; skip cleanly on older releases.
-pre_gui_hooks = pytest.importorskip("deadline.client.ui.pre_gui_hooks")
-apply_pre_gui_output = pre_gui_hooks.apply_pre_gui_output
-
-from deadline.maya_submitter.data_classes import (  # noqa: E402  (after importorskip)
-    RenderSubmitterUISettings,
-)
+from deadline.client.ui.pre_gui_hooks import apply_pre_gui_output
+from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
+from deadline.maya_submitter import maya_render_submitter
 
 
 def _settings() -> RenderSubmitterUISettings:
@@ -92,3 +88,23 @@ def test_partial_output_only_touches_present_keys():
     assert settings.name == "NewName"
     assert settings.description == "keep me"  # not overwritten
     assert shared == {}  # no parameters in output
+
+
+@patch.object(maya_render_submitter, "get_setting", return_value="true")
+def test_confirm_callback_none_when_auto_accept_enabled(mock_get_setting):
+    """With settings.auto_accept enabled, hooks run without a confirmation prompt."""
+    assert maya_render_submitter._pre_gui_hook_confirm_callback(parent=None) is None
+    mock_get_setting.assert_called_once_with("settings.auto_accept")
+
+
+@patch("deadline.client.ui.pre_gui_hooks.qt_hook_confirmation")
+@patch.object(maya_render_submitter, "get_setting", return_value="false")
+def test_confirm_callback_prompts_when_auto_accept_disabled(mock_get_setting, mock_qt_confirm):
+    """With settings.auto_accept disabled, the standard Qt confirmation callback is used."""
+    sentinel = object()
+    mock_qt_confirm.return_value = sentinel
+
+    result = maya_render_submitter._pre_gui_hook_confirm_callback(parent="mainwin")
+
+    assert result is sentinel
+    mock_qt_confirm.assert_called_once_with("mainwin")

--- a/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
@@ -3,15 +3,28 @@
 """Unit tests for the Maya submitter's pre-GUI hook integration.
 
 ``show_maya_render_submitter`` calls deadline-cloud's ``run_pre_gui_hooks`` (env-only, since
-Maya has no on-disk bundle) and then maps the merged output onto its own
-``RenderSubmitterUISettings`` + the dialog's shared parameter values via
-``_apply_pre_gui_output``. The full submitter needs a running Maya, so it is exercised in the
-integration suite; here we unit-test the mapping helper — the DCC-owned piece — headless.
-The maya / qtpy modules are stubbed by the package ``__init__`` so the module imports.
+Maya has no on-disk bundle) and then maps the merged output with deadline-cloud's generic
+``apply_pre_gui_output``. The full submitter needs a running Maya, so it is exercised in the
+integration suite; here we verify the DCC-owned contract headless: that ``apply_pre_gui_output``
+routes hook output correctly against Maya's own ``RenderSubmitterUISettings`` — which has no
+``.parameters`` list, so every hook parameter must land in the shared parameter values. This
+guards against a regression where ``RenderSubmitterUISettings`` gains a ``parameters`` attribute
+that would silently misroute hook parameters.
+
+``apply_pre_gui_output`` ships in deadline-cloud 0.61+; the module is skipped on older releases
+so this file collects cleanly regardless of the installed deadline-cloud version. The maya /
+qtpy modules are stubbed by the package ``__init__`` so imports resolve.
 """
 
-from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
-from deadline.maya_submitter.maya_render_submitter import _apply_pre_gui_output
+import pytest
+
+# apply_pre_gui_output ships in deadline-cloud 0.61+; skip cleanly on older releases.
+pre_gui_hooks = pytest.importorskip("deadline.client.ui.pre_gui_hooks")
+apply_pre_gui_output = pre_gui_hooks.apply_pre_gui_output
+
+from deadline.maya_submitter.data_classes import (  # noqa: E402  (after importorskip)
+    RenderSubmitterUISettings,
+)
 
 
 def _settings() -> RenderSubmitterUISettings:
@@ -27,19 +40,20 @@ def test_name_and_description_applied_to_settings():
     settings = _settings()
     shared = {"RezPackages": "mayaIO-2024 deadline_cloud_for_maya"}
 
-    _apply_pre_gui_output({"name": "PREGUI RAN", "description": "from pipeline"}, settings, shared)
+    apply_pre_gui_output({"name": "PREGUI RAN", "description": "from pipeline"}, settings, shared)
 
     assert settings.name == "PREGUI RAN"
     assert settings.description == "from pipeline"
 
 
-def test_hook_parameters_merged_into_shared_values():
-    """Hook parameters (queue params, deadline: properties) are merged into the shared values
-    the dialog is seeded with, overriding the Maya-computed defaults on key collision."""
+def test_hook_parameters_routed_to_shared_values():
+    """RenderSubmitterUISettings has no .parameters list, so every hook parameter (queue params,
+    deadline: properties) is routed into the shared values the dialog is seeded with, overriding
+    the Maya-computed defaults on key collision."""
     settings = _settings()
     shared = {"RezPackages": "mayaIO-2024 deadline_cloud_for_maya", "CondaPackages": "maya=2024.*"}
 
-    _apply_pre_gui_output(
+    apply_pre_gui_output(
         {
             "parameters": {
                 "deadline:priority": 88,
@@ -60,7 +74,7 @@ def test_empty_output_is_a_noop():
     settings = _settings()
     shared = {"RezPackages": "pkg"}
 
-    _apply_pre_gui_output({}, settings, shared)
+    apply_pre_gui_output({}, settings, shared)
 
     assert settings.name == "Original"
     assert settings.description == ""
@@ -73,7 +87,7 @@ def test_partial_output_only_touches_present_keys():
     settings.description = "keep me"
     shared: dict = {}
 
-    _apply_pre_gui_output({"name": "NewName"}, settings, shared)
+    apply_pre_gui_output({"name": "NewName"}, settings, shared)
 
     assert settings.name == "NewName"
     assert settings.description == "keep me"  # not overwritten

--- a/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
@@ -97,14 +97,26 @@ def test_confirm_callback_none_when_auto_accept_enabled(mock_get_setting):
     mock_get_setting.assert_called_once_with("settings.auto_accept")
 
 
-@patch("deadline.client.ui.pre_gui_hooks.qt_hook_confirmation")
+@patch("qtpy.QtWidgets.QMessageBox")
 @patch.object(maya_render_submitter, "get_setting", return_value="false")
-def test_confirm_callback_prompts_when_auto_accept_disabled(mock_get_setting, mock_qt_confirm):
-    """With settings.auto_accept disabled, the standard Qt confirmation callback is used."""
-    sentinel = object()
-    mock_qt_confirm.return_value = sentinel
+def test_confirmation_dialog_fires_when_auto_accept_disabled(mock_get_setting, mock_msgbox):
+    """With settings.auto_accept disabled, invoking the returned callback actually shows the
+    confirmation dialog (QMessageBox.question), parented to the passed-in window.
 
-    result = maya_render_submitter._pre_gui_hook_confirm_callback(parent="mainwin")
+    This exercises the real ``qt_hook_confirmation`` callback rather than mocking it out, so it
+    verifies the prompt fires — not merely that a non-None callback was selected. ``run_pre_gui_hooks``
+    invokes ``confirm_callback(sources)`` with the hook sources; an empty list is enough to reach
+    the dialog. The user's answer is mapped from the QMessageBox reply.
+    """
+    mock_msgbox.question.return_value = mock_msgbox.Yes
 
-    assert result is sentinel
-    mock_qt_confirm.assert_called_once_with("mainwin")
+    callback = maya_render_submitter._pre_gui_hook_confirm_callback(parent="mainwin")
+    assert callback is not None
+
+    result = callback([])  # no hook sources needed to reach the dialog
+
+    assert mock_msgbox.question.call_count == 1
+    # The dialog is parented to the window passed into the submitter.
+    assert mock_msgbox.question.call_args[0][0] == "mainwin"
+    # "Yes" reply → proceed.
+    assert result is True

--- a/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
+++ b/test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py
@@ -12,13 +12,17 @@ integration suite; here we verify the DCC-owned pieces headless:
   land in the shared parameter values. This guards against a regression where
   ``RenderSubmitterUISettings`` gains a ``parameters`` attribute that would misroute hook params.
 * ``_pre_gui_hook_confirm_callback`` honours the ``settings.auto_accept`` setting.
+* Declining the hook confirmation (``DeadlineOperationCanceled``) aborts the open silently
+  rather than surfacing a spurious error dialog.
 
 The maya / qtpy modules are stubbed by the package ``__init__`` so imports resolve.
 """
 
 import sys
-from unittest.mock import patch
+from typing import Optional
+from unittest.mock import MagicMock, patch
 
+from deadline.client.exceptions import DeadlineOperationCanceled
 from deadline.client.ui.pre_gui_hooks import apply_pre_gui_output
 from deadline.maya_submitter.data_classes import RenderSubmitterUISettings
 from deadline.maya_submitter import maya_render_submitter
@@ -91,6 +95,23 @@ def test_partial_output_only_touches_present_keys():
     assert shared == {}  # no parameters in output
 
 
+def test_falsy_output_is_a_noop():
+    """The submitter passes ``pre_gui_output or {}`` into apply_pre_gui_output, so the values
+    run_pre_gui_hooks can actually produce for the no-hooks path — ``{}`` today, or ``None`` if
+    the contract ever changed — must both be safe no-ops that leave settings/shared untouched."""
+    falsy_values: list[Optional[dict]] = [{}, None]
+    for falsy in falsy_values:
+        settings = _settings()
+        shared = {"RezPackages": "mayaIO-2024 deadline_cloud_for_maya"}
+
+        # Mirror the submitter call site: `pre_gui_output or {}`.
+        apply_pre_gui_output(falsy or {}, settings, shared)
+
+        assert settings.name == "Original"
+        assert settings.description == ""
+        assert shared == {"RezPackages": "mayaIO-2024 deadline_cloud_for_maya"}
+
+
 @patch.object(maya_render_submitter, "get_setting", return_value="true")
 def test_confirm_callback_none_when_auto_accept_enabled(mock_get_setting):
     """With settings.auto_accept enabled, hooks run without a confirmation prompt."""
@@ -127,3 +148,42 @@ def test_confirmation_dialog_fires_when_auto_accept_disabled(mock_get_setting, m
     assert mock_msgbox.question.call_args[0][0] == "mainwin"
     # "Yes" reply → proceed.
     assert result is True
+
+
+# ``run_pre_gui_hooks`` is imported lazily from ``deadline.client.ui.pre_gui_hooks`` inside
+# ``show_maya_render_submitter``, so it must be patched on that source module (not on
+# ``maya_render_submitter``). The Maya-heavy setup that runs before the hook call is mocked out so
+# the test can reach the hook call headlessly; ``time`` is mocked so the progress-dialog sleeps are
+# instant.
+@patch("deadline.maya_submitter.maya_render_submitter.time")
+@patch("deadline.client.ui.pre_gui_hooks.run_pre_gui_hooks")
+@patch.object(maya_render_submitter, "SubmitJobToDeadlineDialog")
+@patch.object(maya_render_submitter, "_pre_gui_hook_confirm_callback", return_value=None)
+@patch.object(maya_render_submitter, "get_deadline_cloud_library_telemetry_client")
+@patch.object(maya_render_submitter, "AssetIntrospector")
+@patch.object(maya_render_submitter, "_populate_selectable_cameras")
+@patch.object(maya_render_submitter, "_set_render_layer_data", return_value=[])
+@patch.object(maya_render_submitter, "_set_render_setting")
+def test_declining_hook_confirmation_aborts_without_error(
+    mock_set_render_setting,
+    mock_set_render_layer_data,
+    mock_populate_cameras,
+    mock_introspector,
+    mock_telemetry,
+    mock_confirm_cb,
+    mock_dialog,
+    mock_run_hooks,
+    mock_time,
+):
+    """Declining the hook prompt (DeadlineOperationCanceled) returns None and never builds the
+    dialog, so the outer gui_error_handler cannot surface a spurious error dialog."""
+    mock_set_render_setting.return_value = _settings()
+    mock_introspector.return_value.parse_scene_assets.return_value = []
+    # The user clicks "No" on the confirmation prompt.
+    mock_run_hooks.side_effect = DeadlineOperationCanceled("user declined")
+
+    result = maya_render_submitter.show_maya_render_submitter(parent=MagicMock())
+
+    assert result is None
+    mock_run_hooks.assert_called_once()
+    mock_dialog.assert_not_called()  # dialog must not be built on cancellation


### PR DESCRIPTION
Fixes: *N/A — tracked internally; will link a GitHub issue if one is opened.*

> **Depends on `deadline-cloud >= 0.60.1`** (published), which ships the pre-GUI hooks API (`deadline.client.ui.pre_gui_hooks`: `run_pre_gui_hooks` / `PreGuiHookContext` / `apply_pre_gui_output`). The dependency floor is pinned accordingly. Remaining before merge: post the integ + Job Bundle Output Test results (require a Maya environment).

### What was the problem/requirement? (What/Why)

Pre-GUI submission hooks did not fire in DCC submitters. Studios can define pre-GUI hooks (via `DEADLINE_HOOKS_DIR`) to pre-populate submission fields — job name, description, and queue/job parameters — before the submit dialog opens, but the Maya submitter never invoked them. This PR is the **Maya adoption** of the shared pre-GUI hooks mechanism; the entry point (`run_pre_gui_hooks`) is provided by `deadline-cloud` so every DCC submitter can call it consistently.

### What was the solution? (How)

In `show_maya_render_submitter`, immediately before constructing `SubmitJobToDeadlineDialog`:

- Build a `shared_parameter_values` dict (the `RezPackages` / `CondaPackages` that were previously an inline literal on the dialog).
- Call `run_pre_gui_hooks(PreGuiHookContext(...))` with:
  - `bundle_dir=None` — Maya has no on-disk job bundle at pre-GUI time, so hooks are sourced from `DEADLINE_HOOKS_DIR` only (gated by `settings.allow_environment_hooks`).
  - `submitter_name="maya"`, `job_name=render_settings.name`, and the current `parameters` passed in so a hook can read/override them.
  - A `confirm_callback` that follows the auto-accept policy: `None` (no prompt) when `settings.auto_accept` is set, otherwise `qt_hook_confirmation(parent)` for the standard confirmation dialog.
- Map the merged hook output back with deadline-cloud's generic `apply_pre_gui_output`. `RenderSubmitterUISettings` has no `.parameters` list (unlike the standalone submitter's `JobBundleSettings`), so `apply_pre_gui_output` writes `name` / `description` onto the settings object and routes every hook `parameter` into `shared_parameter_values` — exactly how a DCC seeds the dialog.

The pre-GUI hooks symbols are imported lazily inside `show_maya_render_submitter` (mirroring the existing lazy `qtpy` import there) so the module — and every unit test that collects it — imports cleanly, and the hooks are only required when the submitter is actually launched.

Also pins the `deadline` dependency floor to `>= 0.60.1, < 0.61` (the first published release that ships the pre-GUI hooks API).

### What is the impact of this change?

- **No behavior change when no hooks are configured.** With no `DEADLINE_HOOKS_DIR` env hooks, `run_pre_gui_hooks` returns an empty dict, `apply_pre_gui_output` is a no-op, and the dialog receives exactly the same `RezPackages` / `CondaPackages` as before.
- The only new behavior fires when environment hooks are present and enabled: hooks run (with a confirmation prompt unless `auto_accept`), and their output pre-populates the dialog.

### How was this change tested?

- `hatch run lint` (black + ruff) — clean on both changed files.
- Unit tests in `test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py` (below) — now run against `deadline-cloud 0.60.1` in CI (all Python matrix legs green).
- Manual: full `show_maya_render_submitter` requires a running Maya (integration suite); the mapping is unit-tested headless under the package's maya/qtpy `sys.modules` stubs.

#### Integ test result

_Pending — to be run against `deadline-cloud 0.60.1` in a Maya environment; results will be posted here._

#### Installer test result

N/A — `installer/` not modified.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

_Pending — to be run in a Maya environment; `job_bundle_output_tests/test-job-bundle-results.txt` will be posted here._

Unit tests added: `test/unit/deadline_submitter_for_maya/test_pre_gui_hooks.py` — 4 tests verifying that deadline-cloud's `apply_pre_gui_output` routes hook output correctly against Maya's `RenderSubmitterUISettings` (name/description onto settings, hook parameters into shared values with override-on-collision, empty-output no-op, partial output). Uses `importorskip` so it skips cleanly on deadline-cloud releases that predate the API.

### Was this change documented?

- Docstring/comment added at the inline hook-invocation block explaining the env-only sourcing, the auto-accept confirmation policy, and why the import is lazy.
- No README/DEVELOPMENT changes needed — this uses the existing `DEADLINE_HOOKS_DIR` / `allow_environment_hooks` mechanism documented on the deadline-cloud side.

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No. Public interfaces are unchanged, and behavior with no configured hooks is identical to before.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
