### PR TITLE
chore: Upgrade multiple dependencies

### DIFF
--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -29,6 +29,7 @@ Running this script on the above CHANGELOG.md should return the following conten
 
 ```
 """
+
 import re
 
 h2 = r"^##\s.*$"

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -4,6 +4,7 @@
 Sets Maya's bin on PATH and renderer environment variables so the adaptor's
 subprocess can find mayapy and renderer plugins.
 """
+
 import os
 import platform
 import subprocess

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -11,6 +11,7 @@ Use --renderers to select which renderers to install (default: none).
 On Windows, installs the pywin32 support DLLs so child processes (mayapy) can
 load win32file. This mirrors the pattern used by deadline-cloud-for-3ds-max.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -27,7 +28,6 @@ from typing import Sequence, TypedDict
 
 import boto3
 from botocore.config import Config
-
 
 # ---------------------------------------------------------------------------
 # Configuration types

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,11 +1,15 @@
-coverage[toml] >= 7.10.7
-pytest == 8.*
+coverage[toml] >= 7.10.7; python_version < "3.10"
+coverage[toml] >= 7.14.3; python_version >= "3.10"
+pytest == 8.*; python_version < "3.10"
+pytest == 9.*; python_version >= "3.10"
 pytest-cov == 7.*
 pytest-xdist == 3.*
 twine == 5.*
-mypy == 1.*
-black == 25.*
+mypy == 1.*; python_version < "3.10"
+mypy == 2.*; python_version >= "3.10"
+black == 25.*; python_version < "3.10"
+black == 26.*; python_version >= "3.10"
 ruff == 0.15.*
 moto[s3,sts] == 5.*
-pipgrip == 0.12.*
+pipgrip == 0.13.*
 types-pyyaml == 6.*

--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Optional
 
-
 ADAPTOR_ONLY_DEPENDENCIES = {"openjd-adaptor-runtime"}
 
 

--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -12,7 +12,6 @@ import boto3
 
 from common import UnsupportedOSError
 
-
 _INSTALL_BUILDER_ARCHIVE_FILENAME = {
     "Windows": "VMware-InstallBuilder-Professional-windows.tar.gz",
     "Linux": "VMware-InstallBuilder-Professional-linux.tar.gz",

--- a/src/deadline/maya_submitter/__init__.py
+++ b/src/deadline/maya_submitter/__init__.py
@@ -3,6 +3,7 @@
 """
 Top level packages for the Deadline Integrated Submitter
 """
+
 from .logging import get_logger
 from .scene import Animation, Scene
 

--- a/src/deadline/maya_submitter/file_path_editor.py
+++ b/src/deadline/maya_submitter/file_path_editor.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 import os
 
 from dataclasses import dataclass
-from distutils.util import strtobool
 from typing import Optional
 
 import maya.cmds
 
-"""
-Module contain a wrapper around Maya's filepatheditor mel command
-"""
+from .utils import strtobool
 
 
 @dataclass

--- a/src/deadline/maya_submitter/job_bundle_output_test_runner.py
+++ b/src/deadline/maya_submitter/job_bundle_output_test_runner.py
@@ -3,6 +3,7 @@
 """
 Defines the Render submitter command which is registered in Maya.
 """
+
 from contextlib import contextmanager
 import os
 import tempfile
@@ -27,7 +28,6 @@ from deadline.client.ui import gui_error_handler
 from deadline.client.ui.dialogs import submit_job_to_deadline_dialog
 from deadline.client.exceptions import DeadlineOperationError
 from .maya_render_submitter import show_maya_render_submitter
-
 
 # The following functions expose a DCC interface to the job bundle output test logic.
 

--- a/src/deadline/maya_submitter/logging.py
+++ b/src/deadline/maya_submitter/logging.py
@@ -3,6 +3,7 @@
 """
 Functionality for creating a global logger for the maya submitter.
 """
+
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/deadline/maya_submitter/mel_commands.py
+++ b/src/deadline/maya_submitter/mel_commands.py
@@ -3,6 +3,7 @@
 """
 Defines the Render submitter command which is registered in Maya.
 """
+
 import maya.api.OpenMaya as om  # pylint: disable=import-error
 import maya.cmds
 from qtpy.QtCore import Qt  # type: ignore

--- a/src/deadline/maya_submitter/render_layers.py
+++ b/src/deadline/maya_submitter/render_layers.py
@@ -3,6 +3,7 @@
 """
 Functionality for interacting with Maya's Render Layers
 """
+
 from contextlib import contextmanager
 from enum import IntEnum
 from typing import List

--- a/src/deadline/maya_submitter/shelf.py
+++ b/src/deadline/maya_submitter/shelf.py
@@ -3,6 +3,7 @@
 """
 Creates or updates the AWS Deadline shelf.
 """
+
 import os
 from contextlib import contextmanager
 

--- a/src/deadline/maya_submitter/utils.py
+++ b/src/deadline/maya_submitter/utils.py
@@ -3,6 +3,7 @@
 """
 Minor utility functions
 """
+
 from __future__ import annotations
 
 import os
@@ -12,6 +13,16 @@ from functools import wraps
 from typing import Callable
 
 from maya.app.general.fileTexturePathResolver import _patternToRegex
+
+
+def strtobool(val: str) -> bool:
+    """Replaces distutils.util.strtobool, removed in Python 3.12."""
+    v = val.lower()
+    if v in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    if v in ("n", "no", "f", "false", "off", "0"):
+        return False
+    raise ValueError(f"invalid truth value {val!r}")
 
 
 def join_paths(first: str, *remainder: str) -> str:


### PR DESCRIPTION
Fixes:
* https://github.com/aws-deadline/deadline-cloud-for-maya/pull/431
* https://github.com/aws-deadline/deadline-cloud-for-maya/pull/429
* https://github.com/aws-deadline/deadline-cloud-for-maya/pull/428
* https://github.com/aws-deadline/deadline-cloud-for-maya/pull/427
* https://github.com/aws-deadline/deadline-cloud-for-maya/pull/369

### What was the problem/requirement? (What/Why)
We have multiple PRs created by dependabot that need manual intervention.

### What was the solution? (How)
* Configure dependency requirements using python 3.10 as anchor to address incompatibility issues.

### What is the impact of this change?
Upgrade dependencies.

### How was this change tested?
* `hatch env prune && hatch build && hatch run fmt && hatch run test && hatch run all:test`
* Run integ tests.

#### Integ test result
```
2026/07/06 17:03:10-07:00 test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
2026/07/06 17:03:10-07:00 [gw0][36m [ 20%] [0m[32mPASSED[0m test/integ/test_maya_adaptors.py::TestAdaptors::test_minimal_scene_adaptor 
2026/07/06 17:03:57-07:00 test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
2026/07/06 17:03:57-07:00 [gw0][36m [ 40%] [0m[32mPASSED[0m test/integ/test_maya_adaptors.py::TestAdaptors::test_redshift_scene_adaptor 
2026/07/06 17:04:13-07:00 test/integ/test_maya_adaptors.py::TestAdaptors::test_mtoa_scene_adaptor 
2026/07/06 17:04:13-07:00 [gw0][36m [ 60%] [0m[32mPASSED[0m test/integ/test_maya_adaptors.py::TestAdaptors::test_mtoa_scene_adaptor 
2026/07/06 17:04:34-07:00 test/integ/test_maya_adaptors.py::TestAdaptors::test_vray_scene_adaptor 
2026/07/06 17:04:34-07:00 [gw0][36m [ 80%] [0m[32mPASSED[0m test/integ/test_maya_adaptors.py::TestAdaptors::test_vray_scene_adaptor 
2026/07/06 17:04:39-07:00 test/integ/test_maya_adaptors.py::TestTaskRunTimeout::test_task_run_timeout_is_enforced 
2026/07/06 17:04:39-07:00 [gw0][36m [100%] [0m[32mPASSED[0m test/integ/test_maya_adaptors.py::TestTaskRunTimeout::test_task_run_timeout_is_enforced 

2026/07/06 17:02:44-07:00 test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
2026/07/06 17:02:44-07:00 [gw0][36m [ 20%] [0m[32mPASSED[0m test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Minimal Maya Test] 
2026/07/06 17:02:55-07:00 test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 
2026/07/06 17:02:55-07:00 [gw0][36m [ 40%] [0m[32mPASSED[0m test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Redshift Test] 
2026/07/06 17:02:56-07:00 test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Arnold Test] 
2026/07/06 17:02:56-07:00 [gw0][36m [ 60%] [0m[32mPASSED[0m test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[Arnold Test] 
2026/07/06 17:02:57-07:00 test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[VRay Test] 
2026/07/06 17:02:57-07:00 [gw0][36m [ 80%] [0m[32mPASSED[0m test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter[VRay Test] 
2026/07/06 17:02:58-07:00 test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter_with_ocio_config 
2026/07/06 17:02:59-07:00 [gw0][36m [100%] [0m[32mPASSED[0m test/integ/test_maya_submitters.py::TestSubmitters::test_scene_submitter_with_ocio_config 
```

### Was this change documented?
N/A

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
