### PR TITLE
Draft: Restrict Arnold/Redshift/V-Ray batch renders to the assigned layer

### DIFF
--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/arnold_handler.py
@@ -3,6 +3,7 @@
 from .default_maya_handler import DefaultMayaHandler
 
 import maya.cmds
+import maya.mel
 
 
 class ArnoldHandler(DefaultMayaHandler):
@@ -105,3 +106,4 @@ class ArnoldHandler(DefaultMayaHandler):
         render_layer_name = self.get_render_layer_to_render(data)
         if render_layer_name:
             maya.cmds.editRenderLayerGlobals(currentRenderLayer=render_layer_name)
+            self.restrict_batch_render_to_layer(render_layer_name)

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -240,6 +240,23 @@ class DefaultMayaHandler:
             maya.cmds.workspace(path, openWorkspace=True)
             maya.cmds.workspace(directory=path)
 
+    def restrict_batch_render_to_layer(self, render_layer_name: str) -> None:
+        """
+        Restricts the next batch/sequence render command to a single render layer.
+
+        Switching the "current" render layer (editRenderLayerGlobals) only makes that
+        layer's Render Setup overrides active. It does not stop renderer-native batch
+        commands (arnoldRender/rsRender/vrend, or render(batch=True)) from walking every
+        renderable layer in the scene in one call. Maya's own setMayaSoftwareLayers proc
+        is what actually confines a render to one layer, and Deadline 10's MayaBatch
+        plugin called it for every renderer for this exact reason.
+
+        Args:
+            render_layer_name (str): The internal (non-display) name of the render layer
+                to restrict rendering to.
+        """
+        maya.mel.eval(f'setMayaSoftwareLayers("{render_layer_name}", "")')
+
     def set_render_layer(self, data: dict) -> None:
         """
         Sets the render layer.
@@ -253,6 +270,7 @@ class DefaultMayaHandler:
         render_layer_name = self.get_render_layer_to_render(data)
         if render_layer_name:
             self.render_kwargs["layer"] = render_layer_name
+            self.restrict_batch_render_to_layer(render_layer_name)
 
     def set_render_setup_include_lights(self, data: dict) -> None:
         """

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import maya.cmds
+import maya.mel
 
 from .default_maya_handler import DefaultMayaHandler
 
@@ -73,3 +74,4 @@ class RedshiftHandler(DefaultMayaHandler):
         render_layer_name = self.get_render_layer_to_render(data)
         if render_layer_name:
             maya.cmds.editRenderLayerGlobals(currentRenderLayer=render_layer_name)
+            self.restrict_batch_render_to_layer(render_layer_name)

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/vray_handler.py
@@ -187,3 +187,4 @@ class VRayHandler(DefaultMayaHandler):
         render_layer_name = self.get_render_layer_to_render(data)
         if render_layer_name:
             maya.cmds.editRenderLayerGlobals(currentRenderLayer=render_layer_name)
+            self.restrict_batch_render_to_layer(render_layer_name)

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_arnold_handler.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_arnold_handler.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -47,3 +48,23 @@ class TestArnoldHandler:
 
         # THEN
         assert handler.image_width == args["image_width"]
+
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.arnold_handler.maya.cmds")
+    def test_set_render_layer_restricts_batch_render_to_the_layer(self, mock_cmds) -> None:
+        """
+        Tests that setting the render layer both switches the current render layer AND
+        restricts the upcoming arnoldRender batch call to that single layer. arnoldRender
+        does not take a 'layer' kwarg, so without the setMayaSoftwareLayers call Arnold
+        can render every renderable layer in the scene regardless of which one is "current".
+        """
+        # GIVEN
+        handler = ArnoldHandler()
+        with patch.object(
+            handler, "get_render_layer_to_render", return_value="layer1"
+        ), patch.object(handler, "restrict_batch_render_to_layer") as mock_restrict:
+            # WHEN
+            handler.set_render_layer({"render_layer": "layer1"})
+
+            # THEN
+            mock_cmds.editRenderLayerGlobals.assert_called_once_with(currentRenderLayer="layer1")
+            mock_restrict.assert_called_once_with("layer1")

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
@@ -42,6 +42,29 @@ class TestDefaultMayaHandler:
         )
     ]
 
+    @patch(
+        "deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.mel.eval"
+    )
+    def test_set_render_layer_restricts_batch_render_to_the_layer(
+        self, mock_mel_eval: Mock, mayahandlerbase: DefaultMayaHandler
+    ):
+        """
+        Tests that setting the render layer sets the 'layer' render kwarg AND calls Maya's
+        native setMayaSoftwareLayers proc to restrict the upcoming batch render to that one
+        layer. Without this, render(batch=True)-style calls can still process every
+        renderable layer in the scene, not just the requested one.
+        """
+        # GIVEN
+        with patch.object(
+            mayahandlerbase, "get_render_layer_to_render", return_value="layer1"
+        ):
+            # WHEN
+            mayahandlerbase.set_render_layer({"render_layer": "layer1"})
+
+        # THEN
+        assert mayahandlerbase.render_kwargs["layer"] == "layer1"
+        mock_mel_eval.assert_called_once_with('setMayaSoftwareLayers("layer1", "")')
+
     @pytest.mark.parametrize("args", [{"path_mapping_rules": {}}])
     @patch.object(DirectoryMapping.mappings, "__setitem__")
     @patch.object(DirectoryMapping, "set_activated")

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_redshift_handler.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_redshift_handler.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -68,3 +69,23 @@ class TestRedshiftHandler:
         # THEN
         with pytest.raises(RuntimeError):
             handler.start_render(start_render_data)
+
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.redshift_handler.maya.cmds")
+    def test_set_render_layer_restricts_batch_render_to_the_layer(self, mock_cmds) -> None:
+        """
+        Tests that setting the render layer both switches the current render layer AND
+        restricts the upcoming rsRender batch call to that single layer. rsRender does not
+        take a 'layer' kwarg, so without the setMayaSoftwareLayers call Redshift renders
+        every renderable layer in the scene regardless of which one is "current".
+        """
+        # GIVEN
+        handler = RedshiftHandler()
+        with patch.object(
+            handler, "get_render_layer_to_render", return_value="layer1"
+        ), patch.object(handler, "restrict_batch_render_to_layer") as mock_restrict:
+            # WHEN
+            handler.set_render_layer({"render_layer": "layer1"})
+
+            # THEN
+            mock_cmds.editRenderLayerGlobals.assert_called_once_with(currentRenderLayer="layer1")
+            mock_restrict.assert_called_once_with("layer1")

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_vray_handler.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_vray_handler.py
@@ -47,6 +47,26 @@ class TestVrayHandler:
         # THEN
         assert handler.image_width == args["image_width"]
 
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.vray_handler.maya.cmds")
+    def test_set_render_layer_restricts_batch_render_to_the_layer(self, mock_cmds) -> None:
+        """
+        Tests that setting the render layer both switches the current render layer AND
+        restricts the upcoming vrend batch call to that single layer. vrend does not take
+        a 'layer' kwarg, so without the setMayaSoftwareLayers call V-Ray can render every
+        renderable layer in the scene regardless of which one is "current".
+        """
+        # GIVEN
+        handler = VRayHandler()
+        with patch.object(
+            handler, "get_render_layer_to_render", return_value="layer1"
+        ), patch.object(handler, "restrict_batch_render_to_layer") as mock_restrict:
+            # WHEN
+            handler.set_render_layer({"render_layer": "layer1"})
+
+            # THEN
+            mock_cmds.editRenderLayerGlobals.assert_called_once_with(currentRenderLayer="layer1")
+            mock_restrict.assert_called_once_with("layer1")
+
     @patch.object(maya.cmds, "pluginInfo")
     def test_no_vray(self, plguinInfo) -> None:
         """Tests that setting the image width sets the right render kwarg"""


### PR DESCRIPTION
editRenderLayerGlobals(currentRenderLayer=...) only activates a layer's Render Setup overrides; it doesn't stop rsRender/arnoldRender/vrend from processing every renderable layer in the scene in one call, so multi-layer jobs render every layer per Step and overwrite each other's output. Call Maya's native setMayaSoftwareLayers proc (used by every renderer in Deadline 10's on-prem MayaBatch plugin for this exact reason) to actually confine the batch render to one layer.

*delete text starting here*
Please ensure that you have read through the [contributing guidelines](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/CONTRIBUTING.md#contributing-via-pull-requests) before continuing.
*delete text ending here*

Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

*delete text starting here*
See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/DEVELOPMENT.md) for information on running tests.
*delete text ending here*

#### Integ test result

*delete text starting here*
If `src/` was modified or a file was added/removed, then update the integ tests and post the test results below. See
DEVELOPMENT.md on additional instructions on running some, or all integ tests.
*delete text ending here*

#### Installer test result

*delete text starting here*
If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
*delete text ending here*

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

*delete text starting here*
See the "Integration Tests" subsection of the
[Running Submitter Tests](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/DEVELOPMENT.md#running-submitter-tests)
section of DEVELOPMENT.md for information on these tests.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```
*delete text ending here*


### Was this change documented?

*delete text starting here*
- Did you update all relevant docstrings for Python functions that you modified?
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?
- Should the schema files for the adaptor's init-data or run-data be updated?

*delete text ending here*

### Did you modify schema files?
- [ ] Yes
- [ ] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/maya_adaptor/MayaAdaptor/adaptor.py` and update the test constants?
See the "Schema Versioning" section in DEVELOPMENT.md for details.
   - [ ] Yes
   - [ ] No

### Is this a breaking change?

*delete text starting here*
A breaking change is one that modifies a public contract in some way or otherwise changes functionality of this application in a way
that is not backwards compatible. Examples of changes that are breaking include:

1. Adding a new required value to the init-data or run-data of the adaptor;
2. Deleting or renaming a value in the init-data or run-data of the adaptor; and
3. Otherwise modifying the interface of the adaptor such that a job submitted with an older version of the Maya submitter plug-in
   will not work with a version of the adaptor that includes your modification.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
