### PR TITLE
docs: reference AWS Deadline Cloud submission hooks in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ability to run Maya efficiently on your render farm.
 [openjd-adaptor-runtime-lifecycle]: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/blob/release/README.md#adaptor-lifecycle
 [service-managed-fleets]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html
 [default-queue-environment]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment
+[submission-hooks]: https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md
 
 ## Compatibility
 
@@ -131,6 +132,26 @@ hosts do not have any rendering applications pre-installed. The standard way of 
 You can find a list of the versions of Maya that are available by default
 [in the user guide](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment)
 if you are using the default Conda queue environment in your setup.
+
+## Submission Hooks
+
+This submitter supports AWS Deadline Cloud **submission hooks** — `preGUI`, `preSubmission`, and
+`postSubmission` scripts that let studios pre-populate the submitter dialog and run custom logic at
+submit time. Hooks are sourced from the directory named by the `DEADLINE_HOOKS_DIR` environment
+variable; enable them (off by default) with:
+
+```
+deadline config set settings.allow_environment_hooks true
+```
+
+This runs scripts from `DEADLINE_HOOKS_DIR` — an ordinary environment variable — on the workstation,
+so only enable it where that variable and the directory's contents are administratively controlled
+(e.g. read-only storage set by a launcher), not a user-writable path.
+
+Open the submitter from Maya's `AWSDeadline` shelf (the "Submit a render to Deadline Cloud" button)
+once the `DeadlineCloudForMaya` plug-in is enabled. See [Submission Hooks][submission-hooks] in the AWS
+Deadline Cloud client documentation for the `hooks.yaml` format, the hook input/output contract,
+supported fields, the confirmation prompt, and failure behavior.
 
 ## Viewing the Job Bundle that will be submitted
 


### PR DESCRIPTION
Fixes: *N/A — documentation gap follow-up to #437*

### What was the problem/requirement? (What/Why)

Submission hook support shipped for the Maya submitter (#437), but the `mainline` README didn't mention it. Per the doc owner, DCC repos should **reference** the canonical hooks documentation rather than duplicate it.

### What was the solution? (How)

Docs-only: add a short **Submission Hooks** section to `README.md` — the submitter supports `preGUI` / `preSubmission` / `postSubmission` hooks sourced from `DEADLINE_HOOKS_DIR` (enable with `settings.allow_environment_hooks`), plus the shelf launch path — and link to the canonical base doc [`deadline-cloud/docs/submission-hooks.md`](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md) for `hooks.yaml` format, the hook contract, fields, and behavior.

### What is the impact of this change?

Documentation only — no code changes.

### How was this change tested?

Verified the rendered Markdown and that the `[submission-hooks]` link resolves to the base doc on `deadline-cloud` mainline. (The base doc's stale "pre-GUI not run by DCC" note is being corrected in aws-deadline/deadline-cloud#1337.)

#### Integ test result

N/A — no `src/` changes.

#### Installer test result

N/A — no `installer/` or `src/` changes.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

Not run — documentation only.

### Was this change documented?

Yes — this PR is the documentation (updates `README.md` only).

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
