### PR TITLE
fix(ci): Allow single-platform Maya installers

### DIFF
--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -2,7 +2,13 @@
 #!/usr/bin/env python3
 """Setup runner for Maya integration tests in CodeBuild.
 
-Supports Linux and Windows with Maya 2025 and 2026.
+Supports Linux and Windows for the Maya versions in MAYA_YEAR_TO_CONFIG below.
+
+A Maya version only needs an installer for the platforms it is available on. A
+configured version with no installer for the current platform is skipped with a
+warning instead of failing the run, so a Maya version can be added to the test
+matrix as soon as one platform's installer is available. Requesting a version
+that is not in MAYA_YEAR_TO_CONFIG at all is still an error.
 
 Installs the Arnold (MtoA), V-Ray, and Redshift renderers into each Maya
 version so the renderer-specific integ tests can run.
@@ -34,19 +40,17 @@ from botocore.config import Config
 # ---------------------------------------------------------------------------
 
 
-class InstallerPaths(TypedDict):
-    linux: str
-    windows: str
+# Maya installer filenames and SHA256 checksums, keyed by platform ("linux" or
+# "windows"). A platform key may be omitted when there is no installer for that
+# platform yet; the Maya version is then skipped on that platform instead of
+# failing the whole setup run.
+InstallerPaths = dict[str, str]
+MayaChecksums = dict[str, str]
 
 
 class MayaVersionConfig(TypedDict):
     python: str
     installer: InstallerPaths
-
-
-class MayaChecksums(TypedDict):
-    linux: str
-    windows: str
 
 
 class RendererVersionConfig(TypedDict):
@@ -238,14 +242,67 @@ PLATFORM_TO_KEY: dict[str, str] = {
 }
 
 
+def maya_installer_name(version: str, plat_key: str) -> str | None:
+    """Return the Maya installer filename for a platform, or None if not configured."""
+    config = MAYA_YEAR_TO_CONFIG.get(version)
+    if config is None:
+        return None
+    return config["installer"].get(plat_key)
+
+
+def maya_checksum(version: str, plat_key: str) -> str:
+    """Return the expected Maya installer checksum, or "" when none is configured.
+
+    verify_checksum() warns and continues when given an empty checksum.
+    """
+    return MAYA_YEAR_TO_CHECKSUMS.get(version, {}).get(plat_key, "")
+
+
+def validate_versions(maya_versions: Sequence[str]) -> None:
+    """Fail fast on requested Maya versions that cannot be installed on any platform.
+
+    An unknown version means the caller and MAYA_YEAR_TO_CONFIG have drifted
+    apart (the hatch integ-ci matrix supplies --versions), and a version with an
+    empty installer map is an incomplete config entry. Neither can be satisfied
+    on any platform, so both are errors rather than skips.
+    """
+    for version in maya_versions:
+        config = MAYA_YEAR_TO_CONFIG.get(version)
+        if config is None:
+            print(f"ERROR: Unsupported Maya version: {version}")
+            print(f"Supported versions: {list(MAYA_YEAR_TO_CONFIG)}")
+            sys.exit(1)
+        if not config["installer"]:
+            print(f"ERROR: Maya {version} has no installer configured for any platform")
+            sys.exit(1)
+
+
+def select_installable_versions(
+    maya_versions: Sequence[str], plat_key: str, system: str
+) -> list[str]:
+    """Filter requested Maya versions down to those installable on this platform.
+
+    A configured version with no installer for this platform is skipped with a
+    warning rather than failing the run, so a Maya version can be added to the
+    test matrix before installers exist for every platform. Callers are expected
+    to have already rejected versions missing from MAYA_YEAR_TO_CONFIG.
+    """
+    installable: list[str] = []
+    for version in maya_versions:
+        if maya_installer_name(version, plat_key):
+            installable.append(version)
+        else:
+            print(f"SKIP: No {system} installer configured for Maya {version}")
+    return installable
+
+
 # ---------------------------------------------------------------------------
 # Linux
 # ---------------------------------------------------------------------------
 
 
 def _install_maya_linux(version: str) -> Path:
-    config = MAYA_YEAR_TO_CONFIG[version]
-    installer_name = config["installer"]["linux"]
+    installer_name = MAYA_YEAR_TO_CONFIG[version]["installer"]["linux"]
     maya_dir = Path(f"/opt/Autodesk/mayaio/{version}")
 
     # Check if Maya is already installed by looking for the real binary
@@ -280,7 +337,7 @@ def _install_maya_linux(version: str) -> Path:
         installer_path = Path(f"/tmp/{installer_name}")
 
         download_from_s3(f"maya/{version}/{installer_name}", installer_path)
-        verify_checksum(installer_path, MAYA_YEAR_TO_CHECKSUMS[version]["linux"])
+        verify_checksum(installer_path, maya_checksum(version, "linux"))
 
         run(["chmod", "+x", str(installer_path)])
         # Extract to /opt (not /tmp) and clean any stale dir from prior runs
@@ -713,8 +770,7 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
 
 
 def _install_maya_windows(version: str) -> Path:
-    config = MAYA_YEAR_TO_CONFIG[version]
-    installer_name = config["installer"]["windows"]
+    installer_name = MAYA_YEAR_TO_CONFIG[version]["installer"]["windows"]
     maya_dir = Path(f"C:/Program Files/Autodesk/Maya{version}")
     maya_marker = maya_dir / ".installed"
 
@@ -728,7 +784,7 @@ def _install_maya_windows(version: str) -> Path:
     installer_zip = setup_dir / installer_name
 
     download_from_s3(f"maya/{version}/{installer_name}", installer_zip)
-    verify_checksum(installer_zip, MAYA_YEAR_TO_CHECKSUMS[version]["windows"])
+    verify_checksum(installer_zip, maya_checksum(version, "windows"))
 
     print("Extracting Maya installer...")
     run(
@@ -1046,20 +1102,17 @@ if __name__ == "__main__":
         sys.exit(1)
     plat_key = PLATFORM_TO_KEY[system]
 
+    validate_versions(maya_versions)
+
+    maya_versions = select_installable_versions(maya_versions, plat_key, system)
+    if not maya_versions:
+        print(f"Nothing to set up: no requested Maya version has a {system} installer.")
+        sys.exit(0)
+
     print(
         f"Setting up {system} with Maya {', '.join(maya_versions)}"
         + (f" and renderers {', '.join(renderers)}" if renderers else "")
     )
-
-    # Validate versions
-    for v in maya_versions:
-        if v not in MAYA_YEAR_TO_CONFIG:
-            print(f"ERROR: Unsupported Maya version: {v}")
-            print(f"Supported versions: {list(MAYA_YEAR_TO_CONFIG.keys())}")
-            sys.exit(1)
-        if plat_key not in MAYA_YEAR_TO_CONFIG[v]["installer"]:
-            print(f"ERROR: No {system} installer configured for Maya {v}")
-            sys.exit(1)
 
     if system == "Linux":
         setup_linux(maya_versions, renderers)

--- a/test/unit/pipeline/__init__.py
+++ b/test/unit/pipeline/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/pipeline/test_setup_runner.py
+++ b/test/unit/pipeline/test_setup_runner.py
@@ -1,0 +1,136 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Unit tests for Maya version selection in ``pipeline/setup-runner.py``.
+
+The module is loaded by path because its filename is hyphenated and so cannot be
+imported as ``pipeline.setup_runner``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_SETUP_RUNNER_PATH = Path(__file__).parents[3] / "pipeline" / "setup-runner.py"
+
+LINUX_ONLY: dict[str, Any] = {"python": "3.13", "installer": {"linux": "Maya2027.run"}}
+WINDOWS_ONLY: dict[str, Any] = {"python": "3.13", "installer": {"windows": "Maya2027.zip"}}
+NO_INSTALLERS: dict[str, Any] = {"python": "3.13", "installer": {}}
+
+
+@pytest.fixture(scope="module")
+def setup_runner() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("setup_runner", _SETUP_RUNNER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestValidateVersions:
+    def test_accepts_every_configured_version(self, setup_runner: ModuleType) -> None:
+        setup_runner.validate_versions(list(setup_runner.MAYA_YEAR_TO_CONFIG))
+
+    def test_rejects_unknown_version(self, setup_runner: ModuleType) -> None:
+        with pytest.raises(SystemExit) as exit_info:
+            setup_runner.validate_versions(["1999"])
+
+        assert exit_info.value.code == 1
+
+    def test_rejects_version_with_no_installer_for_any_platform(
+        self, setup_runner: ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(setup_runner.MAYA_YEAR_TO_CONFIG, "2027", NO_INSTALLERS)
+
+        with pytest.raises(SystemExit) as exit_info:
+            setup_runner.validate_versions(["2027"])
+
+        assert exit_info.value.code == 1
+
+
+class TestSelectInstallableVersions:
+    @pytest.mark.parametrize(
+        "config, plat_key, system, expected",
+        [
+            pytest.param(LINUX_ONLY, "linux", "Linux", ["2027"], id="linux-only-on-linux"),
+            pytest.param(LINUX_ONLY, "windows", "Windows", [], id="linux-only-on-windows"),
+            pytest.param(
+                WINDOWS_ONLY, "windows", "Windows", ["2027"], id="windows-only-on-windows"
+            ),
+            pytest.param(WINDOWS_ONLY, "linux", "Linux", [], id="windows-only-on-linux"),
+        ],
+    )
+    def test_selects_by_platform_availability(
+        self,
+        setup_runner: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        config: dict[str, Any],
+        plat_key: str,
+        system: str,
+        expected: list[str],
+    ) -> None:
+        monkeypatch.setitem(setup_runner.MAYA_YEAR_TO_CONFIG, "2027", config)
+
+        assert setup_runner.select_installable_versions(["2027"], plat_key, system) == expected
+
+    def test_skipping_one_version_leaves_the_others(
+        self, setup_runner: ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(setup_runner.MAYA_YEAR_TO_CONFIG, "2027", LINUX_ONLY)
+
+        assert setup_runner.select_installable_versions(["2026", "2027"], "windows", "Windows") == [
+            "2026"
+        ]
+
+    def test_keeps_versions_available_on_both_platforms(self, setup_runner: ModuleType) -> None:
+        both = [
+            version
+            for version, config in setup_runner.MAYA_YEAR_TO_CONFIG.items()
+            if config["installer"].keys() >= {"linux", "windows"}
+        ]
+
+        for plat_key, system in (("linux", "Linux"), ("windows", "Windows")):
+            assert setup_runner.select_installable_versions(both, plat_key, system) == both
+
+
+class TestInstallerLookups:
+    def test_absent_platform_has_no_installer_or_checksum(
+        self, setup_runner: ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(setup_runner.MAYA_YEAR_TO_CONFIG, "2027", LINUX_ONLY)
+
+        assert setup_runner.maya_installer_name("2027", "windows") is None
+        assert setup_runner.maya_checksum("2027", "windows") == ""
+
+    def test_configured_platform_resolves_installer_and_sha256(
+        self, setup_runner: ModuleType
+    ) -> None:
+        for version, config in setup_runner.MAYA_YEAR_TO_CONFIG.items():
+            for plat_key, installer in config["installer"].items():
+                assert setup_runner.maya_installer_name(version, plat_key) == installer
+                assert len(setup_runner.maya_checksum(version, plat_key)) == 64
+
+
+class TestVerifyChecksum:
+    def test_unconfigured_checksum_is_allowed(
+        self, setup_runner: ModuleType, tmp_path: Path
+    ) -> None:
+        installer = tmp_path / "Maya2027.run"
+        installer.write_bytes(b"installer")
+
+        assert setup_runner.verify_checksum(installer, "") is True
+
+    def test_mismatched_checksum_still_fails(
+        self, setup_runner: ModuleType, tmp_path: Path
+    ) -> None:
+        installer = tmp_path / "Maya2027.run"
+        installer.write_bytes(b"installer")
+
+        with pytest.raises(SystemExit) as exit_info:
+            setup_runner.verify_checksum(installer, "0" * 64)
+
+        assert exit_info.value.code == 1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`pipeline/setup-runner.py` required every Maya version to declare installers for
both platforms, so a version available on only one platform could not be added to
the `integ-ci` matrix without failing the other platform's leg.

### What was the solution? (How)

Installer and checksum maps are now per-platform dicts, and a version with no
installer for the current platform is skipped instead of failing the run.

**These are the failure/skip cases that can happen under this change:**
| Situation | Result |
|---|---|
| Version not in `MAYA_YEAR_TO_CONFIG` | error, exit 1 |
| Version declared, `installer` empty | error, exit 1 |
| Version declared, absent on this platform only | `SKIP:`, continue |
| No requested version installable here | message, exit 0 |

### What is the impact of this change?

CI-only; `pipeline/` is not shipped with the pip package.

### How was this change tested?

`hatch run test` — 13 new unit tests covering the four cases above and confirming checksum enforcement is unchanged.

#### Integ test result

Linux and Windows both pass against this PR's head `b7f221c` (CodeBuild source version `pr/463`): [run 32317369890](https://github.com/aws-deadline/deadline-cloud-for-maya/actions/runs/32317369890)

#### Installer test result

Not run. `installer/` is unmodified and no files were added to or removed from `src/`.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No. The submitter and adaptor are untouched, so no job bundle output can change.

### Was this change documented?

The module docstring now states the per-platform installer rule. No user-facing docs are affected.

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

