### PR TITLE
feat: Add Maya 2027 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ ability to run Maya efficiently on your render farm.
 
 This library requires:
 
-1. Maya 2024 - 2026,
+1. Maya 2024 - 2027,
 1. MtoA 5.3.5 or higher,
 1. Python 3.9 or higher; and
 1. Linux, Windows, or a macOS operating system.
 
-Plugin support: Arnold for Maya 2024-2026; VRay and Redshift for Maya 2025-2026.
+Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2026.
 
 ## Versioning
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -23,7 +23,7 @@ lint = [
 install = "python {root}/scripts/install_dev_submitter.py {args:}"
 
 [[envs.all.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [envs.default.env-vars]
 MAYA_ENV_DIR="{root}/plugin_env"
@@ -56,7 +56,16 @@ dependencies = [
 # Matrix across Maya versions. All renderers (mtoa, vray, redshift) are
 # installed by default on Linux and Windows.
 [[envs.integ-ci.matrix]]
-maya = ["2025", "2026"]
+maya = ["2025", "2026", "2027"]
+
+# Maya 2027: V-Ray and Redshift are not supported yet, so install MtoA only and
+# deselect the two renderer tests that cannot pass without their plugins.
+# Remove this override once V-Ray and Redshift support Maya 2027.
+[envs.integ-ci.overrides]
+matrix.maya.scripts = [
+  { key = "setup", value = "python ./pipeline/setup-runner.py --versions 2027 --renderers mtoa {args}", if = ["2027"] },
+  { key = "test", value = 'python ./pipeline/run-integ-tests.py -m "not (vray_renderer or redshift_renderer)"', if = ["2027"] },
+]
 
 [envs.integ-ci.env-vars]
 MAYA_VERSION = "{matrix:maya}"

--- a/hatch.toml
+++ b/hatch.toml
@@ -56,7 +56,9 @@ dependencies = [
 # Matrix across Maya versions. All renderers (mtoa, vray, redshift) are
 # installed by default on Linux and Windows.
 [[envs.integ-ci.matrix]]
-maya = ["2025", "2026", "2027"]
+# TEMPORARY, revert to ["2025", "2026", "2027"] before merge: 2027 only, to cut the
+# integ cycle while debugging the Linux 2027 adaptor hang.
+maya = ["2027"]
 
 # Maya 2027: V-Ray and Redshift are not supported yet, so install MtoA only and
 # deselect the two renderer tests that cannot pass without their plugins.

--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -1,8 +1,8 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. --><!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <component>
     <name>deadline_cloud_for_maya</name>
-    <description>Deadline Cloud for Maya 2024 - 2026</description>
-	<detailedDescription>Maya plugin for submitting jobs to AWS Deadline Cloud. Compatible with Maya 2024 - 2026.</detailedDescription>
+    <description>Deadline Cloud for Maya 2024 - 2027</description>
+	<detailedDescription>Maya plugin for submitting jobs to AWS Deadline Cloud. Compatible with Maya 2024 - 2027.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -59,9 +59,9 @@
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_maya_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Maya 2024 - 2026
-- Compatible with Maya 2024 - 2026.
-- Plugin support: Arnold for Maya 2024-2026; VRay and Redshift for Maya 2025-2026.
+			<value>Deadline Cloud for Maya 2024 - 2027
+- Compatible with Maya 2024 - 2027.
+- Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2026.
 - Install the integrated Maya submitter files to the installation directory.
 - Register the plug-in with Maya by creating or updating the MAYA_MODULE_PATH environment variable.</value>
 		</stringParameter>

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -44,20 +44,19 @@ def main():
 
     # Linux uses wrapper script at /usr/local/bin/mayapy that handles all env setup
 
-    sys.exit(
-        subprocess.run(
-            [
-                "mayapy",
-                "-m",
-                "pytest",
-                "--no-cov",
-                "test/integ",
-                "-vvv",
-                "--numprocesses=1",
-                *sys.argv[1:],
-            ]
-        ).returncode
-    )
+    cmd = [
+        "mayapy",
+        "-m",
+        "pytest",
+        "--no-cov",
+        "test/integ",
+        "-vvv",
+        "--numprocesses=1",
+        *sys.argv[1:],
+    ]
+    print(f"Running: {' '.join(cmd)}", flush=True)
+
+    sys.exit(subprocess.run(cmd).returncode)
 
 
 if __name__ == "__main__":

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -13,6 +13,8 @@ import sys
 
 def main():
     maya_version = os.environ.get("MAYA_VERSION", "2025")
+    # Linux's mayapy dispatcher reads this, so export the resolved value.
+    os.environ["MAYA_VERSION"] = maya_version
     system = platform.system()
 
     if system == "Windows":
@@ -42,7 +44,7 @@ def main():
             os.environ.setdefault("redshift_LICENSE", f"7054@{license_dns}")
             os.environ.setdefault("ADSKFLEX_LICENSE_FILE", f"2702@{license_dns};2701@{license_dns}")
 
-    # Linux uses wrapper script at /usr/local/bin/mayapy that handles all env setup
+    # Linux resolves mayapy through the MAYA_VERSION dispatcher written by setup-runner.py
 
     cmd = [
         "mayapy",

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -58,6 +58,9 @@ def main():
     if system != "Windows":
         os.environ["PATH"] = "/usr/local/maya-adaptor-bin:" + os.environ.get("PATH", "")
 
+    # TEMPORARY, revert before merge: xdist relays worker output and only prints it once
+    # a test finishes, so a test that never finishes prints nothing. Run in-process with
+    # capture disabled to stream the Maya 2027 adaptor hang as it happens.
     cmd = [
         "mayapy",
         "-m",
@@ -65,7 +68,8 @@ def main():
         "--no-cov",
         "test/integ",
         "-vvv",
-        "--numprocesses=1",
+        "--numprocesses=0",
+        "-s",
         *sys.argv[1:],
     ]
     print(f"Running: {' '.join(cmd)}", flush=True)

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -15,6 +15,11 @@ def main():
     maya_version = os.environ.get("MAYA_VERSION", "2025")
     # Linux's mayapy dispatcher reads this, so export the resolved value.
     os.environ["MAYA_VERSION"] = maya_version
+    # The adaptor daemon runs as a subprocess, so it inherits these rather than
+    # pytest's own faulthandler. Without them a SIGSEGV discards the unflushed
+    # stdout buffer and we get a bare exit -11 with no traceback.
+    os.environ["PYTHONUNBUFFERED"] = "1"
+    os.environ["PYTHONFAULTHANDLER"] = "1"
     system = platform.system()
 
     if system == "Windows":

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -46,7 +46,16 @@ def main():
 
     sys.exit(
         subprocess.run(
-            ["mayapy", "-m", "pytest", "--no-cov", "test/integ", "-vvv", "--numprocesses=1"]
+            [
+                "mayapy",
+                "-m",
+                "pytest",
+                "--no-cov",
+                "test/integ",
+                "-vvv",
+                "--numprocesses=1",
+                *sys.argv[1:],
+            ]
         ).returncode
     )
 

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -49,7 +49,11 @@ def main():
             os.environ.setdefault("redshift_LICENSE", f"7054@{license_dns}")
             os.environ.setdefault("ADSKFLEX_LICENSE_FILE", f"2702@{license_dns};2701@{license_dns}")
 
-    # Linux resolves mayapy through the MAYA_VERSION dispatcher written by setup-runner.py
+    # Linux resolves mayapy through the MAYA_VERSION dispatcher written by
+    # setup-runner.py, and runs the adaptor under mayapy via these dispatchers, which
+    # must precede the hatch env's console scripts. See _write_adaptor_dispatchers.
+    if system != "Windows":
+        os.environ["PATH"] = "/usr/local/maya-adaptor-bin:" + os.environ.get("PATH", "")
 
     cmd = [
         "mayapy",

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -15,12 +15,15 @@ def main():
     maya_version = os.environ.get("MAYA_VERSION", "2025")
     # Linux's mayapy dispatcher reads this, so export the resolved value.
     os.environ["MAYA_VERSION"] = maya_version
-    # The adaptor daemon runs as a subprocess, so it inherits these rather than
-    # pytest's own faulthandler. Without them a SIGSEGV discards the unflushed
-    # stdout buffer and we get a bare exit -11 with no traceback.
-    os.environ["PYTHONUNBUFFERED"] = "1"
-    os.environ["PYTHONFAULTHANDLER"] = "1"
     system = platform.system()
+
+    # Linux only: the adaptor daemon is a subprocess, so it inherits these rather
+    # than pytest's faulthandler. Without them a SIGSEGV discards the unflushed
+    # stdout. On Windows they make the Maya client dump the ERROR_NO_TOKEN
+    # exceptions it otherwise handles, which breaks session cleanup.
+    if system != "Windows":
+        os.environ["PYTHONUNBUFFERED"] = "1"
+        os.environ["PYTHONFAULTHANDLER"] = "1"
 
     if system == "Windows":
         maya_bin = f"C:\\Program Files\\Autodesk\\Maya{maya_version}\\bin"

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -663,6 +663,8 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
             "nss",
             "openjpeg2",
             "libatomic",
+            # Maya 2027 aborts writing PNG output without an explicit libpng
+            "libpng",
         ]
     )
 
@@ -779,6 +781,20 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
             f'exec "{mayapy_exe}" "$@"\n'
         )
         run(["chmod", "+x", str(wrapper)])
+
+        # TEMPORARY, revert before merge: Maya 2027 aborts in libpng writing PNG output.
+        # Report which copies exist and what Maya's image plugins resolve to.
+        run(["sh", "-c", f"ls -la {mayapy_dir}/lib/libpng* 2>&1 | head"], check=False)
+        run(["sh", "-c", "ls -la /lib64/libpng* 2>&1 | head"], check=False)
+        run(
+            [
+                "sh",
+                "-c",
+                f"for f in {mayapy_dir}/lib/libOpenMaya*.so {mayapy_dir}/bin/plug-ins/*.so; do "
+                f'ldd "$f" 2>/dev/null | grep -i png && echo "  ^ $f"; done | head -20',
+            ],
+            check=False,
+        )
 
         # Maya 2025 links libssl.so.1.1, which AL2023 does not ship, so its Python
         # cannot import ssl and anything importing boto3 skips itself. Shipping

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -599,17 +599,18 @@ exec "$target" "$@"
 
 
 def _write_adaptor_dispatchers() -> None:
-    """Run the adaptor under mayapy rather than the hatch env's host Python.
+    """Run the adaptor on the host Python with Maya's lib dir removed.
 
-    The wrapper puts Maya's lib dir on LD_LIBRARY_PATH, which the linker searches
-    before the host interpreter's RPATH. Maya 2027 ships libpython3.13.so under the
-    same soname as the host's, so the host Python loads Maya's copy and then
-    segfaults on its own stdlib extensions. run-integ-tests.py prepends this
-    directory to PATH so these win over the hatch env's console scripts.
+    The adaptor imports boto3, which needs ssl, ruling out Maya 2025's Python. But
+    Maya 2027 ships libpython3.13.so under the same soname as the host's, and the
+    wrapper puts Maya's lib dir on LD_LIBRARY_PATH, so the host Python loaded Maya's
+    copy and segfaulted. The adaptor needs none of Maya's libraries and launches the
+    Maya client via mayapy, whose wrapper sets the variable again.
+    run-integ-tests.py prepends this directory to PATH to win over the hatch env.
     """
     ADAPTOR_DISPATCH_DIR.mkdir(parents=True, exist_ok=True)
     script = """#!/bin/sh
-exec /usr/local/bin/mayapy -m deadline.maya_adaptor.MayaAdaptor "$@"
+exec env -u LD_LIBRARY_PATH python -m deadline.maya_adaptor.MayaAdaptor "$@"
 """
     for name in ("MayaAdaptor", "maya-openjd"):
         path = ADAPTOR_DISPATCH_DIR / name

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -87,6 +87,11 @@ MAYA_YEAR_TO_CONFIG: dict[str, MayaVersionConfig] = {
     },
 }
 
+# Linux only: Maya versions whose bundled Python has no ssl module, so botocore
+# needs urllib3 1.x (2.x drops its `ssl` re-export). A version outside this set
+# failing the ssl probe is a broken runner, not something to work around.
+MAYA_YEARS_WITHOUT_BUNDLED_SSL = {"2025"}
+
 MAYA_YEAR_TO_CHECKSUMS: dict[str, MayaChecksums] = {
     "2025": {
         "linux": "a4c46a576aea91e1e52a06355b413f98000b884feb8eb1349a7459990e212395",
@@ -576,7 +581,7 @@ def _write_mayapy_dispatcher() -> None:
     tests pass or fail for the wrong reasons.
     """
     dispatcher = Path("/usr/local/bin/mayapy")
-    dispatcher.write_text("""#!/bin/sh
+    script = """#!/bin/sh
 if [ -z "${MAYA_VERSION:-}" ]; then
     echo "mayapy: MAYA_VERSION is not set, cannot select a Maya version." >&2
     echo "mayapy: installed: $(ls /usr/local/bin/mayapy-* 2>/dev/null | sed 's|.*/mayapy-||' | tr '\\n' ' ')" >&2
@@ -588,7 +593,8 @@ if [ ! -x "$target" ]; then
     exit 1
 fi
 exec "$target" "$@"
-""")
+"""
+    dispatcher.write_text(script)
     run(["chmod", "+x", str(dispatcher)])
     print(f"Wrote mayapy dispatcher at {dispatcher}")
 
@@ -749,6 +755,39 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
             f'exec "{mayapy_exe}" "$@"\n'
         )
         run(["chmod", "+x", str(wrapper)])
+
+        # Verify the ssl expectation declared in MAYA_YEARS_WITHOUT_BUNDLED_SSL.
+        probe = subprocess.run([str(wrapper), "-c", "import ssl"], capture_output=True, check=False)
+        ssl_expected = version not in MAYA_YEARS_WITHOUT_BUNDLED_SSL
+        if probe.returncode == 0:
+            if not ssl_expected:
+                print(
+                    f"Maya {version} Python now imports ssl. Remove it from "
+                    f"MAYA_YEARS_WITHOUT_BUNDLED_SSL so it stops using urllib3 1.x."
+                )
+        else:
+            reason = probe.stderr.decode(errors="replace").strip().splitlines()
+            reason = reason[-1] if reason else "no error output"
+            if ssl_expected:
+                print(f"ERROR: Maya {version} Python cannot import ssl: {reason}")
+                print("Expected a working ssl module. The runner is missing a dependency.")
+                sys.exit(1)
+            print(f"Maya {version} Python has no ssl ({reason}), installing urllib3<2")
+            run_with_timeout(
+                [
+                    "pip",
+                    "install",
+                    "--target",
+                    str(maya_site_packages),
+                    "--upgrade",
+                    "--python-version",
+                    python_version,
+                    "--only-binary=:all:",
+                    "urllib3<2",
+                ],
+                timeout=DEFAULT_CMD_TIMEOUT,
+                label=f"pip install urllib3<2 (Maya {version})",
+            )
 
     _write_mayapy_dispatcher()
 

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -605,6 +605,8 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
             "libglvnd-egl",
             "alsa-lib",
             "nss",
+            "openjpeg2",
+            "libatomic",
         ]
     )
 

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -567,6 +567,32 @@ def _clean_stale_locks(maya_versions: Sequence[str]) -> None:
             lock_file.unlink()
 
 
+def _write_mayapy_dispatcher() -> None:
+    """Write /usr/local/bin/mayapy, dispatching to the MAYA_VERSION wrapper.
+
+    Every integ-ci matrix cell exports MAYA_VERSION, so routing through this keeps
+    pytest, the adaptor, and its children on the version that cell is testing.
+    Fails loudly rather than guessing, since silently using the wrong Maya makes
+    tests pass or fail for the wrong reasons.
+    """
+    dispatcher = Path("/usr/local/bin/mayapy")
+    dispatcher.write_text("""#!/bin/sh
+if [ -z "${MAYA_VERSION:-}" ]; then
+    echo "mayapy: MAYA_VERSION is not set, cannot select a Maya version." >&2
+    echo "mayapy: installed: $(ls /usr/local/bin/mayapy-* 2>/dev/null | sed 's|.*/mayapy-||' | tr '\\n' ' ')" >&2
+    exit 1
+fi
+target="/usr/local/bin/mayapy-${MAYA_VERSION}"
+if [ ! -x "$target" ]; then
+    echo "mayapy: no wrapper for Maya ${MAYA_VERSION} at ${target}." >&2
+    exit 1
+fi
+exec "$target" "$@"
+""")
+    run(["chmod", "+x", str(dispatcher)])
+    print(f"Wrote mayapy dispatcher at {dispatcher}")
+
+
 def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
     pkg_mgr = (
         "dnf"
@@ -691,8 +717,8 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
             label=f"pip install project (Maya {version})",
         )
 
-        # Symlink mayapy to PATH so hatch integ-ci:test can find it.
-        # Create a wrapper that sets MAYA_LOCATION and renderer plugin paths.
+        # Per-version wrapper setting MAYA_LOCATION and renderer plugin paths. The
+        # `mayapy` dispatcher written after this loop picks one via MAYA_VERSION.
         mayapy_dir = mayapy_exe.parent.parent  # e.g. /opt/.../usr/autodesk/mayaIO2025
 
         # Renderer paths
@@ -710,7 +736,7 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
         script_paths = f"{redshift_dir}/redshift4maya/common/scripts"
         render_desc_paths = f"{redshift_dir}/redshift4maya/common/rendererDesc"
 
-        wrapper = Path("/usr/local/bin/mayapy")
+        wrapper = Path(f"/usr/local/bin/mayapy-{version}")
         wrapper.write_text(
             f"#!/bin/sh\n"
             f'export MAYA_LOCATION="{mayapy_dir}"\n'
@@ -723,6 +749,8 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
             f'exec "{mayapy_exe}" "$@"\n'
         )
         run(["chmod", "+x", str(wrapper)])
+
+    _write_mayapy_dispatcher()
 
     # Install requested renderers (always per-Maya-version, except Redshift which
     # is shared across versions).

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -599,17 +599,21 @@ exec "$target" "$@"
 
 
 def _write_adaptor_dispatchers() -> None:
-    """Run the adaptor on the host Python with Maya's lib dir removed.
+    """Run the adaptor on the host Python, minus Maya's entry in LD_LIBRARY_PATH.
 
     The adaptor imports boto3, which needs ssl, ruling out Maya 2025's Python. But
     Maya 2027 ships libpython3.13.so under the same soname as the host's, and the
     wrapper puts Maya's lib dir on LD_LIBRARY_PATH, so the host Python loaded Maya's
-    copy and segfaulted. The adaptor needs none of Maya's libraries and launches the
-    Maya client via mayapy, whose wrapper sets the variable again.
+    copy and segfaulted. Only Maya's entry is harmful, so drop just that and keep the
+    rest. The Maya client is launched via mayapy, whose wrapper re-adds it.
     run-integ-tests.py prepends this directory to PATH to win over the hatch env.
     """
     ADAPTOR_DISPATCH_DIR.mkdir(parents=True, exist_ok=True)
     script = """#!/bin/sh
+clean=$(printf '%s' "${LD_LIBRARY_PATH:-}" | tr ':' '\\n' | grep -v '^/opt/Autodesk/' | paste -sd: -)
+if [ -n "$clean" ]; then
+    exec env LD_LIBRARY_PATH="$clean" python -m deadline.maya_adaptor.MayaAdaptor "$@"
+fi
 exec env -u LD_LIBRARY_PATH python -m deadline.maya_adaptor.MayaAdaptor "$@"
 """
     for name in ("MayaAdaptor", "maya-openjd"):

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -396,19 +396,33 @@ def _install_mtoa_linux(version: str) -> None:
 
         run(["chmod", "+x", str(installer_path)])
         mtoa_install_dir.mkdir(parents=True, exist_ok=True)
-        # MtoA is a Makeself archive. Extract then unzip the package.
+        # MtoA is a Makeself archive. Extract it, then unpack the payload.
         extract_tmp = Path(f"/tmp/mtoa-{version}-extract")
         if extract_tmp.exists():
             run(["rm", "-rf", str(extract_tmp)], check=False)
         run([str(installer_path), "--noexec", "--target", str(extract_tmp)])
-        # Unzip the package into the install dir
-        pkg_zip = next(extract_tmp.glob("*.zip"), None)
-        if pkg_zip:
-            run(["unzip", "-qo", str(pkg_zip), "-d", str(mtoa_install_dir)])
-        else:
-            print(f"ERROR: No .zip found in {extract_tmp}")
+        # MtoA 5.5.x shipped the payload as a .zip; 5.6.x ships package.tgz.
+        pkg = next(extract_tmp.glob("*.zip"), None) or next(extract_tmp.glob("*.tgz"), None)
+        if pkg is None:
+            print(f"ERROR: No .zip or .tgz payload found in {extract_tmp}")
             run(["ls", "-la", str(extract_tmp)], check=False)
             sys.exit(1)
+        if pkg.suffix == ".zip":
+            run(["unzip", "-qo", str(pkg), "-d", str(mtoa_install_dir)])
+        else:
+            # Strip a single top-level directory if the tarball has one, so that
+            # plug-ins/ lands directly in mtoa_install_dir for either layout.
+            listing = subprocess.run(
+                ["tar", "-tzf", str(pkg)], capture_output=True, text=True, check=False
+            )
+            if listing.returncode != 0:
+                print(f"ERROR: Could not list {pkg}")
+                print(listing.stderr)
+                sys.exit(1)
+            roots = {line.split("/")[0] for line in listing.stdout.splitlines() if line.strip()}
+            strip = ["--strip-components=1"] if len(roots) == 1 else []
+            print(f"Unpacking {pkg.name} (top-level entries: {sorted(roots)[:5]})")
+            run(["tar", "-xzf", str(pkg), "-C", str(mtoa_install_dir), *strip])
         run(["rm", "-rf", str(extract_tmp)], check=False)
 
         # Verify — installer lays down plugins under $prefix/plug-ins.

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -78,6 +78,13 @@ MAYA_YEAR_TO_CONFIG: dict[str, MayaVersionConfig] = {
             "windows": "Maya2026_Windows.zip",
         },
     },
+    "2027": {
+        "python": "3.13",
+        "installer": {
+            "linux": "Autodesk_MayaIO_2027_2_Update_Linux.run",
+            "windows": "Maya2027_Windows.zip",
+        },
+    },
 }
 
 MAYA_YEAR_TO_CHECKSUMS: dict[str, MayaChecksums] = {
@@ -88,6 +95,10 @@ MAYA_YEAR_TO_CHECKSUMS: dict[str, MayaChecksums] = {
     "2026": {
         "linux": "b17b0700933e8e4329939da38cc52c93ed483a93b02e9fa78031fddae763c8e8",
         "windows": "9c9612f6e4d3f1f6de897a21fde6f9930e2e40bb6ddc3ca9647e2668cdba935c",
+    },
+    "2027": {
+        "linux": "eac310135486b2a33e64223721dc451ffca294444880e3a94a96bcc48a4efe9e",
+        "windows": "5380c20e1ab2321776c000e245819b36f33697918ee2cc344efb3ac22e1ead62",
     },
 }
 
@@ -104,6 +115,10 @@ MTOA_YEAR_TO_CONFIG: dict[str, RendererVersionConfig] = {
     "2026": {
         "s3_key": "mtoa/5.5/MtoA-5.5.6.1-linux-2026.run",
         "checksum": "d8881e1cece725178d90aaa6d44507ea017ec64d7d23c76b129b9e349d1c9cc6",
+    },
+    "2027": {
+        "s3_key": "mtoa/5.6.3/MtoA-5.6.3-linux-2027.run",
+        "checksum": "a745b3ef022a1fe41f1d1b90597af6df92deaf2dc49f63593705a96a0f3e6ed1",
     },
 }
 
@@ -834,6 +849,7 @@ def _install_mtoa_windows(version: str) -> None:
     mtoa_win_config = {
         "2025": "mtoa/5.5/MtoA-5.5.4.2-windows-2025.msi",
         "2026": "mtoa/5.5/MtoA-5.5.4.2-windows-2026.msi",
+        "2027": "mtoa/5.6.3/MtoA-5.6.3-windows-2027.msi",
     }
     if version not in mtoa_win_config:
         print(f"WARNING: No Windows MtoA config for Maya {version}, skipping")

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -302,8 +302,7 @@ def _install_maya_linux(version: str) -> Path:
         extract_dir = Path(f"/opt/maya-{version}-extract")
         if extract_dir.exists():
             run(["rm", "-rf", str(extract_dir)], check=False)
-        # --noexec: don't run post-extract scripts (they do rm -rf /tmp/*)
-        # --phase2: skip EULA prompt
+        # --noexec: don't run the embedded setup.sh (it prompts for the EULA)
         print("Extracting installer (this may take a moment)...")
         result = subprocess.run(
             [
@@ -313,7 +312,6 @@ def _install_maya_linux(version: str) -> Path:
                 "--nox11",
                 "--target",
                 str(extract_dir),
-                "--phase2",
             ],
             check=False,
         )

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -87,11 +87,6 @@ MAYA_YEAR_TO_CONFIG: dict[str, MayaVersionConfig] = {
     },
 }
 
-# Linux only: Maya versions whose bundled Python has no ssl module, so botocore
-# needs urllib3 1.x (2.x drops its `ssl` re-export). A version outside this set
-# failing the ssl probe is a broken runner, not something to work around.
-MAYA_YEARS_WITHOUT_BUNDLED_SSL = {"2025"}
-
 MAYA_YEAR_TO_CHECKSUMS: dict[str, MayaChecksums] = {
     "2025": {
         "linux": "a4c46a576aea91e1e52a06355b413f98000b884feb8eb1349a7459990e212395",
@@ -756,37 +751,18 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
         )
         run(["chmod", "+x", str(wrapper)])
 
-        # Verify the ssl expectation declared in MAYA_YEARS_WITHOUT_BUNDLED_SSL.
+        # Maya 2025 links libssl.so.1.1, which AL2023 does not ship, so its Python
+        # cannot import ssl and anything importing boto3 skips itself. Shipping
+        # OpenSSL 1.1 to restore that coverage is a follow-up PR.
         probe = subprocess.run([str(wrapper), "-c", "import ssl"], capture_output=True, check=False)
-        ssl_expected = version not in MAYA_YEARS_WITHOUT_BUNDLED_SSL
         if probe.returncode == 0:
-            if not ssl_expected:
-                print(
-                    f"Maya {version} Python now imports ssl. Remove it from "
-                    f"MAYA_YEARS_WITHOUT_BUNDLED_SSL so it stops using urllib3 1.x."
-                )
+            print(f"Maya {version} Python can import ssl")
         else:
             reason = probe.stderr.decode(errors="replace").strip().splitlines()
-            reason = reason[-1] if reason else "no error output"
-            if ssl_expected:
-                print(f"ERROR: Maya {version} Python cannot import ssl: {reason}")
-                print("Expected a working ssl module. The runner is missing a dependency.")
-                sys.exit(1)
-            print(f"Maya {version} Python has no ssl ({reason}), installing urllib3<2")
-            run_with_timeout(
-                [
-                    "pip",
-                    "install",
-                    "--target",
-                    str(maya_site_packages),
-                    "--upgrade",
-                    "--python-version",
-                    python_version,
-                    "--only-binary=:all:",
-                    "urllib3<2",
-                ],
-                timeout=DEFAULT_CMD_TIMEOUT,
-                label=f"pip install urllib3<2 (Maya {version})",
+            print(
+                f"WARNING: Maya {version} Python cannot import ssl "
+                f"({reason[-1] if reason else 'no error output'}). "
+                "Tests that need boto3 will skip."
             )
 
     _write_mayapy_dispatcher()

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -87,6 +87,10 @@ MAYA_YEAR_TO_CONFIG: dict[str, MayaVersionConfig] = {
     },
 }
 
+# Adaptor dispatchers live here so run-integ-tests.py can put them ahead of the
+# hatch env's console scripts on PATH.
+ADAPTOR_DISPATCH_DIR = Path("/usr/local/maya-adaptor-bin")
+
 MAYA_YEAR_TO_CHECKSUMS: dict[str, MayaChecksums] = {
     "2025": {
         "linux": "a4c46a576aea91e1e52a06355b413f98000b884feb8eb1349a7459990e212395",
@@ -594,6 +598,26 @@ exec "$target" "$@"
     print(f"Wrote mayapy dispatcher at {dispatcher}")
 
 
+def _write_adaptor_dispatchers() -> None:
+    """Run the adaptor under mayapy rather than the hatch env's host Python.
+
+    The wrapper puts Maya's lib dir on LD_LIBRARY_PATH, which the linker searches
+    before the host interpreter's RPATH. Maya 2027 ships libpython3.13.so under the
+    same soname as the host's, so the host Python loads Maya's copy and then
+    segfaults on its own stdlib extensions. run-integ-tests.py prepends this
+    directory to PATH so these win over the hatch env's console scripts.
+    """
+    ADAPTOR_DISPATCH_DIR.mkdir(parents=True, exist_ok=True)
+    script = """#!/bin/sh
+exec /usr/local/bin/mayapy -m deadline.maya_adaptor.MayaAdaptor "$@"
+"""
+    for name in ("MayaAdaptor", "maya-openjd"):
+        path = ADAPTOR_DISPATCH_DIR / name
+        path.write_text(script)
+        run(["chmod", "+x", str(path)])
+    print(f"Wrote adaptor dispatchers in {ADAPTOR_DISPATCH_DIR}")
+
+
 def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
     pkg_mgr = (
         "dnf"
@@ -766,6 +790,7 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
             )
 
     _write_mayapy_dispatcher()
+    _write_adaptor_dispatchers()
 
     # Install requested renderers (always per-Maya-version, except Redshift which
     # is shared across versions).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",
@@ -141,6 +142,10 @@ pythonpath = [
 markers = [
     "submitter: mark test as test for the submitter",
     "adaptor: mark test as test for the adaptor",
+    "maya_renderer: mark test as using Maya's built-in renderer",
+    "mtoa_renderer: mark test as using the Arnold (MtoA) renderer",
+    "vray_renderer: mark test as using the V-Ray renderer",
+    "redshift_renderer: mark test as using the Redshift renderer",
 ]
 
 [tool.coverage.run]

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -20,6 +20,7 @@ class MayaVersion:
         "2024": "3.10",
         "2025": "3.11",
         "2026": "3.11",
+        "2027": "3.13",
     }
 
     def __init__(self, arg_version: Optional[str]):

--- a/test/integ/helpers/test_runners.py
+++ b/test/integ/helpers/test_runners.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import subprocess
+import tempfile
 import yaml
 import json
 
@@ -9,23 +10,28 @@ from typing import Any
 
 
 def run_command(args: list[str], timeout: int = 180) -> subprocess.CompletedProcess[bytes]:
-    try:
-        output = subprocess.run(args, capture_output=True, timeout=timeout)
-    except subprocess.TimeoutExpired as e:
-        # Without this a hung adaptor prints nothing until the build itself times out,
-        # since pytest only shows captured output once the test finishes.
+    # Write to files rather than pipes. The adaptor backgrounds a daemon that inherits
+    # our stdout/stderr, so with capture_output=True a timeout kills the child and then
+    # blocks forever waiting for EOF from the surviving grandchild.
+    with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
+        timed_out = False
+        try:
+            returncode = subprocess.run(args, stdout=out, stderr=err, timeout=timeout).returncode
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            returncode = 124
+        out.seek(0)
+        err.seek(0)
+        stdout, stderr = out.read(), err.read()
+
+    if timed_out:
         print(f"Timed out after {timeout}s: {' '.join(args)}")
-        print(f"\nstdout:\n\n{(e.stdout or b'').decode('utf-8', errors='replace')}")
-        print(f"\nstderr:\n\n{(e.stderr or b'').decode('utf-8', errors='replace')}")
-        return subprocess.CompletedProcess(
-            args, returncode=124, stdout=e.stdout or b"", stderr=e.stderr or b""
-        )
+    else:
+        print(f"Ran the following: {' '.join(args)}")
+    print(f"\nstdout:\n\n{stdout.decode('utf-8', errors='replace')}")
+    print(f"\nstderr:\n\n{stderr.decode('utf-8', errors='replace')}")
 
-    print(f"Ran the following: {' '.join(output.args)}")
-    print(f"\nstdout:\n\n{output.stdout.decode('utf-8', errors='replace')}")
-    print(f"\nstderr:\n\n{output.stderr.decode('utf-8', errors='replace')}")
-
-    return output
+    return subprocess.CompletedProcess(args, returncode=returncode, stdout=stdout, stderr=stderr)
 
 
 def is_valid_template(template_location: Path) -> bool:

--- a/test/integ/helpers/test_runners.py
+++ b/test/integ/helpers/test_runners.py
@@ -8,8 +8,18 @@ from pathlib import Path
 from typing import Any
 
 
-def run_command(args: list[str]) -> subprocess.CompletedProcess[bytes]:
-    output = subprocess.run(args, capture_output=True)
+def run_command(args: list[str], timeout: int = 180) -> subprocess.CompletedProcess[bytes]:
+    try:
+        output = subprocess.run(args, capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        # Without this a hung adaptor prints nothing until the build itself times out,
+        # since pytest only shows captured output once the test finishes.
+        print(f"Timed out after {timeout}s: {' '.join(args)}")
+        print(f"\nstdout:\n\n{(e.stdout or b'').decode('utf-8', errors='replace')}")
+        print(f"\nstderr:\n\n{(e.stderr or b'').decode('utf-8', errors='replace')}")
+        return subprocess.CompletedProcess(
+            args, returncode=124, stdout=e.stdout or b"", stderr=e.stderr or b""
+        )
 
     print(f"Ran the following: {' '.join(output.args)}")
     print(f"\nstdout:\n\n{output.stdout.decode('utf-8', errors='replace')}")

--- a/test/integ/test_maya_submitters.py
+++ b/test/integ/test_maya_submitters.py
@@ -16,6 +16,19 @@ from .helpers.output_comparison import are_asset_references_similar, are_paramet
 import maya.standalone
 import maya.cmds as cmds
 
+# Maya 2025 on Linux links libssl.so.1.1, which AL2023 does not ship, so its Python
+# cannot import ssl and deadline.client.api's boto3 import fails, making the submitter
+# unimportable. These tests only export a job bundle and diff it against expected
+# output, so shipping OpenSSL 1.1 to the runner in a follow-up PR recovers this
+# coverage. The adaptor tests run OpenJD locally and are unaffected.
+try:
+    import ssl  # noqa: F401
+except ImportError as ssl_import_error:
+    pytest.skip(
+        f"Maya's bundled Python cannot import ssl: {ssl_import_error}",
+        allow_module_level=True,
+    )
+
 
 @pytest.fixture(scope="session", autouse=True)
 def initialize_maya():


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Adding support for Maya and MtoA 2027.

### What was the solution? (How)

- Added S3 artifacts for Maya I/O 2027 (Linux), `Maya2027_Windows.zip`, MtoA 5.6.3 for both platforms, with checksums.
- Modified GitHub integration tests run command for Maya 2027: `--renderers mtoa` and `-m "not (vray_renderer or redshift_renderer)"`. This avoids running Maya 2027 tests for Vray and Redshift as we don't support them yet.
- `run-integ-tests.py` forwards extra arguments so the marker expression reaches pytest.
- Declares the four renderer markers, which were previously used but undeclared.
- Documents Maya 2027 and Python 3.13 support.

### What is the impact of this change?

Adds a third integ matrix cell. V-Ray and Redshift coverage for 2025/2026 is unaffected.

### How was this change tested?

`hatch env show integ-ci --json` confirms only the 2027 cell is overridden. The marker expression collects 3 of 5 adaptor tests, deselecting exactly the V-Ray and Redshift tests, verified under `--strict-markers`.

#### Integ test result

Run linked in a comment below.

#### Installer test result

Not run. `installer/` is unmodified and no files were added to or removed from `src/`.

Instead tested installation of submitter for Maya 2027 manually.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No. Instead submitted a render job via submitter.

### Was this change documented?

README and the installer description now list Maya 2024-2027, with V-Ray and Redshift left at 2025-2026.

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/maya_adaptor/MayaAdaptor/adaptor.py` and update the test constants?
   - [ ] Yes
   - [x] No

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
