### PR TITLE
feat: Declare Maya 2027 support

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ ability to run Maya efficiently on your render farm.
 
 This library requires:
 
-1. Maya 2024 - 2026,
+1. Maya 2024 - 2027,
 1. MtoA 5.3.5 or higher,
 1. Python 3.9 or higher; and
 1. Linux, Windows, or a macOS operating system.
 
-Plugin support: Arnold for Maya 2024-2026; VRay and Redshift for Maya 2025-2026.
+Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2026.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ This library requires:
 
 Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2026.
 
-Maya 2027 requires the `deadline-cloud-v2` conda channel, which the submitter uses by
-default; the `deadline-cloud` channel does not support Maya 2027.
+Maya 2027 requires the `deadline-cloud-v2` conda channel; the `deadline-cloud` channel does
+not support Maya 2027. The submitter plug-in uses it when submitting directly, but exported
+job bundles carry no channel, so point the queue environment at it instead.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ This library requires:
 
 Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2026.
 
+Maya 2027 requires the `deadline-cloud-v2` conda channel, which the submitter uses by
+default; the `deadline-cloud` channel does not support Maya 2027.
+
 ## Versioning
 
 This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its

--- a/hatch.toml
+++ b/hatch.toml
@@ -23,7 +23,7 @@ lint = [
 install = "python {root}/scripts/install_dev_submitter.py {args:}"
 
 [[envs.all.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [envs.default.env-vars]
 MAYA_ENV_DIR="{root}/plugin_env"

--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -1,8 +1,8 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. --><!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <component>
     <name>deadline_cloud_for_maya</name>
-    <description>Deadline Cloud for Maya 2024 - 2026</description>
-	<detailedDescription>Maya plugin for submitting jobs to AWS Deadline Cloud. Compatible with Maya 2024 - 2026.</detailedDescription>
+    <description>Deadline Cloud for Maya 2024 - 2027</description>
+	<detailedDescription>Maya plugin for submitting jobs to AWS Deadline Cloud. Compatible with Maya 2024 - 2027.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
@@ -59,9 +59,9 @@
 	</readyToInstallActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_maya_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Maya 2024 - 2026
-- Compatible with Maya 2024 - 2026.
-- Plugin support: Arnold for Maya 2024-2026; VRay and Redshift for Maya 2025-2026.
+			<value>Deadline Cloud for Maya 2024 - 2027
+- Compatible with Maya 2024 - 2027.
+- Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2026.
 - Install the integrated Maya submitter files to the installation directory.
 - Register the plug-in with Maya by creating or updating the MAYA_MODULE_PATH environment variable.</value>
 		</stringParameter>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
-SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
+SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 SUPPORTED_PLATFORMS = ["win_amd64", "manylinux2014_x86_64", "macosx_10_9_x86_64"]
 NATIVE_DEPENDENCIES = ["xxhash", "psutil"]
 

--- a/scripts/install_dev_submitter.py
+++ b/scripts/install_dev_submitter.py
@@ -20,6 +20,7 @@ class MayaVersion:
         "2024": "3.10",
         "2025": "3.11",
         "2026": "3.11",
+        "2027": "3.13",
     }
 
     def __init__(self, arg_version: Optional[str]):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Maya 2027 is supported by the adaptor but not declared anywhere user-facing.

### What was the solution? (How)

Update docs and metadata to support Maya 2027 and Python 3.13.

V-Ray and Redshift stay at 2025-2026, which do not support 2027 yet.

**Note:** I will add integration tests for Maya 2027, and the CI infrastructure for the 2027 test matrix, in a follow-up PR.

### What is the impact of this change?

The installer and README advertise Maya 2027. No behaviour change.

### How was this change tested?

Tested with:
- E2E renders for Maya and MtoA 2027
- Manual installation of unmodified submitter in Maya 2027.
- Manually ran integration tests using `job_bundle_integ_tests`

#### Integ test result

Maya 2027 on Linux, run manually via `job_bundle_integ_tests` on a Service Managed Fleet with `CondaPackages=maya=2027 maya-mtoa=2027.5.6`.

#### Submitter:

```
============================== 5 passed in 20.93s ==============================
```

#### Adaptor:

```
test_minimal_scene_adaptor passed 1 out of the required 1 times. Success!
test_mtoa_scene_adaptor passed 1 out of the required 1 times. Success!
test_vray_scene_adaptor failed; it passed 0 out of the required 1 times.
test_redshift_scene_adaptor failed; it passed 0 out of the required 1 times.
```
_The two failures are expected: we don't support Vray or Redshift for Maya 2027 yet.

#### Windows CI (`Maya Integration Tests`):

```
Maya 2025:  10 passed in 192.75s
Maya 2026:  10 passed in 205.03s
Maya 2027:   8 passed in 127.78s   (V-Ray and Redshift adaptor tests deselected)
```

#### Installer:
- Installed using `hatch run installer:build-installer --install-builder-path /Applications/InstallBuilder\ for\ OS\ X\ 26.5.1 --platform macos --local-dev`
- Submitted test job using submitter.


#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No. Docs and packaging metadata only.

### Was this change documented?

Yes, this change is the documentation.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*