### PR TITLE
ci: Pin GitPython to 3.1.57 for release workflow

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,7 @@
 python-semantic-release == 9.12.*
+# GitPython removed Actor.name_email_regex after 3.1.57. python-semantic-release
+# 9.12 still uses it, so an unpinned GitPython fails the Release: Bump workflow
+# with "type object 'Actor' has no attribute 'name_email_regex'".
+# Remove this pin when moving to python-semantic-release 10.6.*, as
+# deadline-cloud and deadline-cloud-for-nuke already have.
+GitPython == 3.1.57


### PR DESCRIPTION
The `Release: Bump` workflow fails in `NextSemver` with:

```
type object 'Actor' has no attribute 'name_email_regex'
```

`requirements-release.txt` pinned `python-semantic-release == 9.12.*` but left
GitPython unpinned, so pip resolved a GitPython newer than 3.1.57 — the release
that removed `Actor.name_email_regex`, which python-semantic-release 9.12 still
uses.

This pins GitPython to 3.1.57 to unblock releases. **This is the last known working version for releases.**

Verified locally: `semantic-release --strict version --print` returns `0.15.19`.

Stopgap. The durable fix is `python-semantic-release == 10.6.*` (as in
`deadline-cloud` and `deadline-cloud-for-nuke`), which additionally needs
`allow_zero_version = true` under `[tool.semantic_release]`.