### PR TITLE
fix: Render only the assigned layer with Redshift

### DIFF
--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -240,6 +240,27 @@ class DefaultMayaHandler:
             maya.cmds.workspace(path, openWorkspace=True)
             maya.cmds.workspace(directory=path)
 
+    def isolate_render_layer(self, render_layer_name: str) -> None:
+        """
+        Makes render_layer_name the only renderable layer in the scene.
+
+        rsRender takes no layer argument: it renders every layer whose 'renderable'
+        attribute is on, and editRenderLayerGlobals does not scope it. Redshift is the
+        only handler that needs this. Arnold and V-Ray were measured rendering only
+        their assigned layer, and maya.cmds.render()'s 'layer' flag already scopes
+        DefaultMayaHandler.
+
+        No restore needed: the layer is fixed per adaptor session and the scene is
+        never saved.
+        """
+        for layer in maya.cmds.ls(type="renderLayer"):
+            should_be_renderable = layer == render_layer_name
+            attribute = f"{layer}.renderable"
+            if maya.cmds.getAttr(attribute) == should_be_renderable:
+                continue
+            maya.cmds.setAttr(attribute, should_be_renderable)
+            print(f"MayaClient: Set '{attribute}' to {should_be_renderable}", flush=True)
+
     def set_render_layer(self, data: dict) -> None:
         """
         Sets the render layer.

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/default_maya_handler.py
@@ -250,15 +250,35 @@ class DefaultMayaHandler:
         their assigned layer, and maya.cmds.render()'s 'layer' flag already scopes
         DefaultMayaHandler.
 
-        No restore needed: the layer is fixed per adaptor session and the scene is
-        never saved.
+        No need to restore original state: the assigned layer is set on session
+        initialization, meaning it's fixed for the entire session and each frame
+        rendered within the session uses the same isolation. On session end, no need
+        to revert since the changes are only held in-memory and are not saved to file.
         """
         for layer in maya.cmds.ls(type="renderLayer"):
-            should_be_renderable = layer == render_layer_name
-            attribute = f"{layer}.renderable"
+            should_be_renderable: bool = layer == render_layer_name
+            attribute: str = f"{layer}.renderable"
+
             if maya.cmds.getAttr(attribute) == should_be_renderable:
                 continue
-            maya.cmds.setAttr(attribute, should_be_renderable)
+
+            try:
+                maya.cmds.setAttr(attribute, should_be_renderable)
+            except RuntimeError as exception:
+                if should_be_renderable:
+                    raise RuntimeError(
+                        f"The assigned render layer, '{render_layer_name}', could not be "
+                        f"made renderable: {exception}"
+                    )
+                # Deliberately not the word 'Warning': strict_error_checking fails the
+                # task on it, which is what this branch exists to avoid.
+                print(
+                    f"MayaClient: Could not disable '{attribute}'; it is locked or "
+                    "connected and may render alongside the assigned layer.",
+                    flush=True,
+                )
+                continue
+
             print(f"MayaClient: Set '{attribute}' to {should_be_renderable}", flush=True)
 
     def set_render_layer(self, data: dict) -> None:

--- a/src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py
+++ b/src/deadline/maya_adaptor/MayaClient/render_handlers/redshift_handler.py
@@ -73,3 +73,4 @@ class RedshiftHandler(DefaultMayaHandler):
         render_layer_name = self.get_render_layer_to_render(data)
         if render_layer_name:
             maya.cmds.editRenderLayerGlobals(currentRenderLayer=render_layer_name)
+            self.isolate_render_layer(render_layer_name)

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from io import StringIO
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 
@@ -41,6 +41,66 @@ class TestDefaultMayaHandler:
             ["layer1", "layer2", "layer3"],
         )
     ]
+
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds")
+    def test_isolate_render_layer(self, mock_cmds: Mock, mayahandlerbase: DefaultMayaHandler):
+        """
+        Tests that only the assigned layer is left renderable. The renderer-native batch
+        commands render every layer whose 'renderable' attribute is on, so any other layer
+        left on is one this task renders without having been assigned it.
+        """
+        # GIVEN
+        mock_cmds.ls.return_value = ["defaultRenderLayer", "rs_beauty", "rs_shadow"]
+        mock_cmds.getAttr.return_value = True
+
+        # WHEN
+        mayahandlerbase.isolate_render_layer("rs_beauty")
+
+        # THEN
+        # rs_beauty is already renderable, so it is left alone.
+        assert mock_cmds.setAttr.call_args_list == [
+            call("defaultRenderLayer.renderable", False),
+            call("rs_shadow.renderable", False),
+        ]
+
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds")
+    def test_isolate_render_layer_enables_the_assigned_layer(
+        self, mock_cmds: Mock, mayahandlerbase: DefaultMayaHandler
+    ):
+        """
+        Tests that an assigned layer whose 'renderable' attribute is off gets switched on.
+        Otherwise a step for that layer renders the other layers instead of erroring.
+        """
+        # GIVEN
+        mock_cmds.ls.return_value = ["rs_beauty", "rs_shadow"]
+        mock_cmds.getAttr.side_effect = lambda attribute: attribute == "rs_shadow.renderable"
+
+        # WHEN
+        mayahandlerbase.isolate_render_layer("rs_beauty")
+
+        # THEN
+        assert mock_cmds.setAttr.call_args_list == [
+            call("rs_beauty.renderable", True),
+            call("rs_shadow.renderable", False),
+        ]
+
+    def test_set_render_layer_does_not_isolate(self, mayahandlerbase: DefaultMayaHandler):
+        """
+        Tests that the default handler does not touch the renderable attributes.
+        maya.cmds.render()'s 'layer' flag renders only that layer regardless of them, so
+        isolating here would be redundant risk.
+        """
+        # GIVEN
+        with (
+            patch.object(mayahandlerbase, "get_render_layer_to_render", return_value="rs_beauty"),
+            patch.object(mayahandlerbase, "isolate_render_layer") as mock_isolate,
+        ):
+            # WHEN
+            mayahandlerbase.set_render_layer({"render_layer": "beauty"})
+
+        # THEN
+        assert mayahandlerbase.render_kwargs["layer"] == "rs_beauty"
+        mock_isolate.assert_not_called()
 
     @pytest.mark.parametrize("args", [{"path_mapping_rules": {}}])
     @patch.object(DirectoryMapping.mappings, "__setitem__")

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_maya_handler_base.py
@@ -84,6 +84,53 @@ class TestDefaultMayaHandler:
             call("rs_shadow.renderable", False),
         ]
 
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds")
+    def test_isolate_render_layer_tolerates_a_failed_disable(
+        self, mock_cmds: Mock, mayahandlerbase: DefaultMayaHandler
+    ):
+        """
+        Tests that a layer which cannot be disabled does not fail the task. A locked or
+        connected 'renderable' attribute raises, and failing init over a layer this step
+        was not assigned is worse than rendering it, which is the pre-fix behaviour.
+        """
+        # GIVEN
+        mock_cmds.ls.return_value = ["rs_beauty", "rs_shadow", "rs_utility"]
+        mock_cmds.getAttr.return_value = True
+
+        def fail_for_shadow(attribute, value):
+            if attribute == "rs_shadow.renderable":
+                raise RuntimeError("locked or connected and cannot be modified")
+
+        mock_cmds.setAttr.side_effect = fail_for_shadow
+
+        # WHEN
+        mayahandlerbase.isolate_render_layer("rs_beauty")
+
+        # THEN
+        # rs_utility is still attempted, so the failure did not abandon the remaining layers.
+        assert mock_cmds.setAttr.call_args_list == [
+            call("rs_shadow.renderable", False),
+            call("rs_utility.renderable", False),
+        ]
+
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.default_maya_handler.maya.cmds")
+    def test_isolate_render_layer_raises_when_the_assigned_layer_cannot_be_enabled(
+        self, mock_cmds: Mock, mayahandlerbase: DefaultMayaHandler
+    ):
+        """
+        Tests that failing to enable the assigned layer fails the task. The step cannot
+        deliver the layer it was assigned, so rendering nothing or another layer silently
+        is worse than erroring.
+        """
+        # GIVEN
+        mock_cmds.ls.return_value = ["rs_beauty", "rs_shadow"]
+        mock_cmds.getAttr.return_value = False
+        mock_cmds.setAttr.side_effect = RuntimeError("locked or connected and cannot be modified")
+
+        # WHEN / THEN
+        with pytest.raises(RuntimeError, match="could not be made renderable"):
+            mayahandlerbase.isolate_render_layer("rs_beauty")
+
     def test_set_render_layer_does_not_isolate(self, mayahandlerbase: DefaultMayaHandler):
         """
         Tests that the default handler does not touch the renderable attributes.

--- a/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_redshift_handler.py
+++ b/test/unit/deadline_adaptor_for_maya/MayaClient/render_handlers/test_redshift_handler.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -68,3 +69,23 @@ class TestRedshiftHandler:
         # THEN
         with pytest.raises(RuntimeError):
             handler.start_render(start_render_data)
+
+    @patch("deadline.maya_adaptor.MayaClient.render_handlers.redshift_handler.maya.cmds")
+    def test_set_render_layer_isolates_the_layer(self, mock_cmds: Mock) -> None:
+        """
+        Tests that setting the render layer both switches the current render layer and
+        isolates it. rsRender takes no layer argument, so the current render layer alone
+        does not stop it rendering every renderable layer in the scene.
+        """
+        # GIVEN
+        handler = RedshiftHandler()
+        with (
+            patch.object(handler, "get_render_layer_to_render", return_value="rs_beauty"),
+            patch.object(handler, "isolate_render_layer") as mock_isolate,
+        ):
+            # WHEN
+            handler.set_render_layer({"render_layer": "beauty"})
+
+        # THEN
+        mock_cmds.editRenderLayerGlobals.assert_called_once_with(currentRenderLayer="rs_beauty")
+        mock_isolate.assert_called_once_with("rs_beauty")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Maya submitter gives each render layer its own step, so step `i` should render only layer `i`. Redshift instead renders every layer whose `renderable` attribute is on, so each task writes `n` images rather than 1, and a job with `n` layers does `n` times the work it was asked for. This was likely not uncovered before because each step writes the same per-layer paths as every other step, so the images overwrite each other and the final output still looks correct.

### What was the solution? (How)
`isolate_render_layer` turns the `renderable` attribute off on every layer except the assigned one, before the render starts.

Arnold and V-Ray did not have the same error as Redshift. Both were tested using the currently released adaptor and each step only rendered its assigned layer.

Note: No need to revert to original state after the frame is rendered: the render layer only needs to be set per adaptor session (by design, every frame rendered within an adaptor session uses the same layer) and the scene is never saved.

### What is the impact of this change?

Redshift jobs that render layers in separate steps now correctly produce one image per step.

### How was this change tested?

Unit tests: `hatch run test` — 211 pass. `hatch run lint`.

On a render farm (Maya 2026, Linux), using a job that gives each of three render layers its own step, writes each step's output to its own directory, and then fails if any step produced images for a layer it was not assigned:

| Renderer | Adaptor | Result |
| --- | --- | --- |
| Redshift | released | every step rendered all 4 layers — FAIL |
| Redshift | this change | every step rendered only its assigned layer — PASS |
| Arnold | released | every step rendered only its assigned layer — PASS |
| V-Ray | released | every step rendered only its assigned layer — PASS |

#### Integ test result

Not run. `test/integ` needs a local Maya with each renderer licensed, which was not available. Worth noting separately that the existing adaptor integ scenes are single-layer, so they cannot detect this class of bug even when they do run; the multi-layer farm job above was used instead.

#### Installer test result

N/A — `installer/` was not modified, and no files were added or removed.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No. This change only affects the adaptor's render handlers at render time. It does not alter submitter behaviour or the contents of a generated job bundle.

### Was this change documented?

Yes.

### Did you modify schema files?
- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/maya_adaptor/MayaAdaptor/adaptor.py` and update the test constants?
   - [ ] Yes
   - [x] No

### Is this a breaking change?

No. A job submitted by an older submitter works unchanged against this adaptor.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*