### PR TITLE
docs: Declare V-Ray and Redshift on Maya 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ This library requires:
 1. Python 3.9 or higher; and
 1. Linux, Windows, or a macOS operating system.
 
-Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2026.
+Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2027.
 
 Maya 2027 requires the `deadline-cloud-v2` conda channel; the `deadline-cloud` channel does
 not support Maya 2027. The submitter plug-in uses it when submitting directly, but exported
 job bundles carry no channel, so point the queue environment at it instead.
+
+Redshift's Maya 2027 support ships inside its 2026 version line, so use the `maya-redshift`
+2026 conda package with Maya 2027; there is no 2027 package.
 
 ## Versioning
 

--- a/install_builder/deadline-cloud-for-maya.xml
+++ b/install_builder/deadline-cloud-for-maya.xml
@@ -61,7 +61,7 @@
 		<stringParameter name="deadline_cloud_for_maya_summary" ask="0" cliOptionShow="0">
 			<value>Deadline Cloud for Maya 2024 - 2027
 - Compatible with Maya 2024 - 2027.
-- Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2026.
+- Plugin support: Arnold for Maya 2024-2027; VRay and Redshift for Maya 2025-2027.
 - Install the integrated Maya submitter files to the installation directory.
 - Register the plug-in with Maya by creating or updating the MAYA_MODULE_PATH environment variable.</value>
 		</stringParameter>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The conda recipes backing V-Ray and Redshift on Maya 2027 are merged, but the docs still cap both renderers at Maya 2026.

### What was the solution? (How)

Widened the plugin support line in `README.md` and the installer summary to 2025-2027, and noted that Redshift's Maya 2027 support ships inside its 2026 version line, so there is no `maya-redshift` 2027 package.

### What is the impact of this change?

Docs only. The claim holds once the recipes finish promoting to Prod in all regions.

### How was this change tested?

No code changed. Verified against the merged recipes: `maya-vray` has a 2027 line requiring `maya 2027.*`, and `maya-redshift` 2026.8.1 requires `maya >=2025,<2028`. Confirmed the installer XML still parses.

Ran manual E2E tests for `Redshift 2026.8.1` and `Vray 7.40.04` and successfully completed.

#### Integ test result

N/A — `src/` unchanged.

#### Installer test result

N/A — `installer/` unchanged; the `install_builder/` edit is a display string.

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

No — no submitter or job bundle behaviour changed.

### Was this change documented?

Yes, this change is the documentation.

### Did you modify schema files?
- [ ] Yes
- [x] No

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
