### PR TITLE
ci: Add Maya 2027 to the integ test matrix

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -32,12 +32,13 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+      # TEMPORARY (bring-up): Windows commented out. Restore before merging.
       matrix:
         include:
           - os: linux
             name: Linux
-          - os: windows
-            name: Windows
+          # - os: windows
+          #   name: Windows
     uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
     secrets: inherit
     with:

--- a/hatch.toml
+++ b/hatch.toml
@@ -56,7 +56,7 @@ dependencies = [
 # Matrix across Maya versions. All renderers (mtoa, vray, redshift) are
 # installed by default on Linux and Windows.
 [[envs.integ-ci.matrix]]
-maya = ["2025", "2026"]
+maya = ["2025", "2026", "2027"]
 
 [envs.integ-ci.env-vars]
 MAYA_VERSION = "{matrix:maya}"

--- a/hatch.toml
+++ b/hatch.toml
@@ -55,8 +55,10 @@ dependencies = [
 
 # Matrix across Maya versions. All renderers (mtoa, vray, redshift) are
 # installed by default on Linux and Windows.
+# TEMPORARY (bring-up): 2027 only. Restore the full list before merging.
 [[envs.integ-ci.matrix]]
-maya = ["2025", "2026", "2027"]
+# maya = ["2025", "2026", "2027"]
+maya = ["2027"]
 
 [envs.integ-ci.env-vars]
 MAYA_VERSION = "{matrix:maya}"

--- a/pipeline/diagnose_libpython.py
+++ b/pipeline/diagnose_libpython.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""TEMPORARY diagnostic for the Maya 2027 adaptor SIGSEGV.
+
+Run under mayapy so it inherits exactly the environment the adaptor subprocess
+gets (notably LD_LIBRARY_PATH, which the /usr/local/bin/mayapy wrapper sets).
+
+Hypothesis: Maya 2027 bundles Python 3.13 and the build host's Python is also
+3.13, so they share the libpython3.13.so.1.0 soname. The wrapper puts Maya's
+lib directory first on LD_LIBRARY_PATH, every child inherits it, and the host
+interpreter that runs the MayaAdaptor console script loads Maya's libpython
+instead of its own and crashes before producing any output.
+
+Delete this file and its call in run-integ-tests.py once resolved.
+"""
+
+import glob
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+
+def show(label: str, value: object) -> None:
+    print(f"[diag] {label}: {value}", flush=True)
+
+
+def main() -> None:
+    show("sys.executable", sys.executable)
+    show("sys.version", sys.version.replace("\n", " "))
+    show("platform", platform.system())
+    show("MAYA_LOCATION", os.environ.get("MAYA_LOCATION"))
+    show("LD_LIBRARY_PATH", os.environ.get("LD_LIBRARY_PATH"))
+
+    maya_location = os.environ.get("MAYA_LOCATION", "")
+    if maya_location:
+        libs = sorted(glob.glob(os.path.join(maya_location, "lib", "libpython*")))
+        show("maya bundled libpython", libs or "none found")
+
+    for name in ("MayaAdaptor", "maya-openjd", "mayapy", "python", "python3"):
+        show(f"which {name}", shutil.which(name))
+
+    adaptor = shutil.which("MayaAdaptor")
+    if adaptor:
+        try:
+            with open(adaptor, "rb") as handle:
+                show("MayaAdaptor shebang", handle.readline().decode("utf-8", "replace").strip())
+        except OSError as exc:
+            show("MayaAdaptor shebang", f"unreadable: {exc}")
+
+    host = shutil.which("python") or shutil.which("python3")
+    if not host:
+        show("VERDICT", "no host python on PATH; cannot test the collision")
+        return
+
+    real_host = os.path.realpath(host)
+    show("host python realpath", real_host)
+
+    if platform.system() == "Linux":
+        result = subprocess.run(["ldd", real_host], capture_output=True, text=True, check=False)
+        matches = [line.strip() for line in result.stdout.splitlines() if "libpython" in line]
+        show("host python ldd libpython", matches or "no libpython entries")
+
+    probe = [host, "-c", "print('host interpreter started ok')"]
+
+    # 1. Inherited environment. Expect returncode -11 if the hypothesis holds.
+    inherited = subprocess.run(probe, capture_output=True, text=True, check=False)
+    show("host python returncode (inherited env)", inherited.returncode)
+    show("host python stdout", inherited.stdout.strip())
+    show("host python stderr", inherited.stderr.strip()[:400])
+
+    # 2. Same probe with Maya's lib directory removed from LD_LIBRARY_PATH.
+    #    If this succeeds where the above crashed, the fix is confirmed too.
+    ld_path = os.environ.get("LD_LIBRARY_PATH", "")
+    if ld_path and maya_location:
+        cleaned = os.pathsep.join(
+            entry
+            for entry in ld_path.split(os.pathsep)
+            if entry and not entry.startswith(maya_location)
+        )
+        env = dict(os.environ, LD_LIBRARY_PATH=cleaned)
+        without_maya = subprocess.run(probe, capture_output=True, text=True, check=False, env=env)
+        show("LD_LIBRARY_PATH without maya", cleaned or "(empty)")
+        show("host python returncode (maya lib removed)", without_maya.returncode)
+
+        if inherited.returncode != 0 and without_maya.returncode == 0:
+            show("VERDICT", "CONFIRMED: Maya lib on LD_LIBRARY_PATH crashes the host interpreter")
+        elif inherited.returncode == 0:
+            show("VERDICT", "NOT the cause: host interpreter runs fine under the inherited env")
+        else:
+            show("VERDICT", "INCONCLUSIVE: host interpreter fails either way")
+
+    # 3. The actual failing command, for completeness.
+    if adaptor:
+        helped = subprocess.run([adaptor, "--help"], capture_output=True, text=True, check=False)
+        show("MayaAdaptor --help returncode", helped.returncode)
+        show("MayaAdaptor --help stderr", helped.stderr.strip()[:300])
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/diagnose_libpython.py
+++ b/pipeline/diagnose_libpython.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python3
 """TEMPORARY diagnostic for the Maya 2027 adaptor SIGSEGV.
 
-Run under mayapy so it inherits exactly the environment the adaptor subprocess
-gets (notably LD_LIBRARY_PATH, which the /usr/local/bin/mayapy wrapper sets).
+Round 1 established that the host interpreter (Python 3.13.15) links Maya
+2027's bundled libpython3.13.so.1.0 (Autodesk build 3.13.9-dirty) because
+Autodesk's own mayapy script puts Maya's lib directories on LD_LIBRARY_PATH,
+and every child inherits it. A bare print() survives that; `MayaAdaptor
+--help` segfaults, so the fault needs a native import to trigger.
 
-Hypothesis: Maya 2027 bundles Python 3.13 and the build host's Python is also
-3.13, so they share the libpython3.13.so.1.0 soname. The wrapper puts Maya's
-lib directory first on LD_LIBRARY_PATH, every child inherits it, and the host
-interpreter that runs the MayaAdaptor console script loads Maya's libpython
-instead of its own and crashes before producing any output.
+This round answers two questions:
+  A. Which import kills the host interpreter under the inherited environment?
+  B. Which candidate fix works --
+       B1. scrub Maya's lib entries from LD_LIBRARY_PATH, or
+       B2. run the adaptor under mayapy instead of the host interpreter.
 
 Delete this file and its call in run-integ-tests.py once resolved.
 """
 
-import glob
 import os
-import platform
 import shutil
 import subprocess
 import sys
@@ -25,76 +26,78 @@ def show(label: str, value: object) -> None:
     print(f"[diag] {label}: {value}", flush=True)
 
 
+def run(argv: list[str], env: dict | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, capture_output=True, text=True, check=False, env=env)
+
+
+def describe(label: str, result: subprocess.CompletedProcess) -> None:
+    detail = (result.stderr or result.stdout).strip().splitlines()
+    tail = detail[-1][:200] if detail else ""
+    suffix = f"  ({tail})" if tail else ""
+    show(label, f"rc={result.returncode}{suffix}")
+
+
+def scrubbed_env(maya_location: str) -> dict:
+    """Inherited environment with Maya's lib directories removed from the loader path."""
+    entries = os.environ.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+    kept = [
+        e for e in entries if e and "mayaIO" not in e and maya_location not in os.path.realpath(e)
+    ]
+    env = dict(os.environ)
+    if kept:
+        env["LD_LIBRARY_PATH"] = os.pathsep.join(kept)
+    else:
+        env.pop("LD_LIBRARY_PATH", None)
+    return env
+
+
 def main() -> None:
-    show("sys.executable", sys.executable)
-    show("sys.version", sys.version.replace("\n", " "))
-    show("platform", platform.system())
-    show("MAYA_LOCATION", os.environ.get("MAYA_LOCATION"))
-    show("LD_LIBRARY_PATH", os.environ.get("LD_LIBRARY_PATH"))
-
     maya_location = os.environ.get("MAYA_LOCATION", "")
-    if maya_location:
-        libs = sorted(glob.glob(os.path.join(maya_location, "lib", "libpython*")))
-        show("maya bundled libpython", libs or "none found")
-
-    for name in ("MayaAdaptor", "maya-openjd", "mayapy", "python", "python3"):
-        show(f"which {name}", shutil.which(name))
-
-    adaptor = shutil.which("MayaAdaptor")
-    if adaptor:
-        try:
-            with open(adaptor, "rb") as handle:
-                show("MayaAdaptor shebang", handle.readline().decode("utf-8", "replace").strip())
-        except OSError as exc:
-            show("MayaAdaptor shebang", f"unreadable: {exc}")
-
     host = shutil.which("python") or shutil.which("python3")
-    if not host:
-        show("VERDICT", "no host python on PATH; cannot test the collision")
-        return
+    adaptor = shutil.which("MayaAdaptor")
+    show("host python", host)
+    show("MayaAdaptor", adaptor)
+    show("mayapy (this process)", sys.executable)
 
-    real_host = os.path.realpath(host)
-    show("host python realpath", real_host)
+    # --- A. Find the import that faults, under the inherited environment. ---
+    if host:
+        for module in (
+            "encodings",  # trivial, pure python
+            "yaml",
+            "pydantic_core",
+            "openjd.adaptor_runtime",
+            "deadline.maya_adaptor",
+        ):
+            describe(
+                f"A: host python -c 'import {module}'",
+                run([host, "-c", f"import {module}; print('ok')"]),
+            )
 
-    if platform.system() == "Linux":
-        result = subprocess.run(["ldd", real_host], capture_output=True, text=True, check=False)
-        matches = [line.strip() for line in result.stdout.splitlines() if "libpython" in line]
-        show("host python ldd libpython", matches or "no libpython entries")
+    # --- B1. Does scrubbing Maya's lib from LD_LIBRARY_PATH fix the adaptor? ---
+    if adaptor and maya_location:
+        env = scrubbed_env(maya_location)
+        show("B1: scrubbed LD_LIBRARY_PATH", env.get("LD_LIBRARY_PATH", "(unset)"))
+        describe("B1: MayaAdaptor --help (scrubbed)", run([adaptor, "--help"], env=env))
+        if host:
+            describe(
+                "B1: host python -c 'import deadline.maya_adaptor' (scrubbed)",
+                run([host, "-c", "import deadline.maya_adaptor; print('ok')"], env=env),
+            )
 
-    probe = [host, "-c", "print('host interpreter started ok')"]
+    # --- B2. Does running the adaptor under mayapy work? ---
+    mayapy = shutil.which("mayapy") or sys.executable
+    describe(
+        "B2: mayapy -m deadline.maya_adaptor.MayaAdaptor --help",
+        run([mayapy, "-m", "deadline.maya_adaptor.MayaAdaptor", "--help"]),
+    )
+    describe(
+        "B2: mayapy -c 'import deadline.maya_adaptor'",
+        run([mayapy, "-c", "import deadline.maya_adaptor; print('ok')"]),
+    )
 
-    # 1. Inherited environment. Expect returncode -11 if the hypothesis holds.
-    inherited = subprocess.run(probe, capture_output=True, text=True, check=False)
-    show("host python returncode (inherited env)", inherited.returncode)
-    show("host python stdout", inherited.stdout.strip())
-    show("host python stderr", inherited.stderr.strip()[:400])
-
-    # 2. Same probe with Maya's lib directory removed from LD_LIBRARY_PATH.
-    #    If this succeeds where the above crashed, the fix is confirmed too.
-    ld_path = os.environ.get("LD_LIBRARY_PATH", "")
-    if ld_path and maya_location:
-        cleaned = os.pathsep.join(
-            entry
-            for entry in ld_path.split(os.pathsep)
-            if entry and not entry.startswith(maya_location)
-        )
-        env = dict(os.environ, LD_LIBRARY_PATH=cleaned)
-        without_maya = subprocess.run(probe, capture_output=True, text=True, check=False, env=env)
-        show("LD_LIBRARY_PATH without maya", cleaned or "(empty)")
-        show("host python returncode (maya lib removed)", without_maya.returncode)
-
-        if inherited.returncode != 0 and without_maya.returncode == 0:
-            show("VERDICT", "CONFIRMED: Maya lib on LD_LIBRARY_PATH crashes the host interpreter")
-        elif inherited.returncode == 0:
-            show("VERDICT", "NOT the cause: host interpreter runs fine under the inherited env")
-        else:
-            show("VERDICT", "INCONCLUSIVE: host interpreter fails either way")
-
-    # 3. The actual failing command, for completeness.
+    # Baseline for comparison.
     if adaptor:
-        helped = subprocess.run([adaptor, "--help"], capture_output=True, text=True, check=False)
-        show("MayaAdaptor --help returncode", helped.returncode)
-        show("MayaAdaptor --help stderr", helped.stderr.strip()[:300])
+        describe("baseline: MayaAdaptor --help (inherited)", run([adaptor, "--help"]))
 
 
 if __name__ == "__main__":

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -9,6 +9,37 @@ import os
 import platform
 import subprocess
 import sys
+import tempfile
+
+
+def install_adaptor_shims() -> str:
+    """Route the adaptor entry points through mayapy and return the shim directory.
+
+    The job templates enter their Maya environment with ``command: MayaAdaptor``,
+    which openjd resolves from PATH. That finds the hatch environment's console
+    script, whose interpreter is a different build of Python 3.13 than the one
+    Maya 2027 bundles (3.13.15 vs Autodesk's 3.13.9-dirty). Autodesk's mayapy
+    exports Maya's lib directories on LD_LIBRARY_PATH and every child inherits
+    them, so that foreign interpreter loads Maya's libpython3.13.so.1.0 and
+    segfaults on its first native import -- yaml and pydantic_core both die,
+    which kills the adaptor before it logs anything.
+
+    Maya 2025 and 2026 bundle Python 3.11, so there is no matching soname and no
+    collision; this only affects 2027.
+
+    Running the adaptor under mayapy removes the mismatch: the adaptor and the
+    Maya client it spawns then share one interpreter and one libpython. This
+    matches how the adaptor runs on a farm, where the maya-openjd Conda package
+    installs into Maya's own prefix.
+    """
+    shim_dir = os.path.join(tempfile.gettempdir(), "maya-adaptor-shims")
+    os.makedirs(shim_dir, exist_ok=True)
+    for name in ("MayaAdaptor", "maya-openjd"):
+        shim = os.path.join(shim_dir, name)
+        with open(shim, "w") as handle:
+            handle.write('#!/bin/sh\nexec mayapy -m deadline.maya_adaptor.MayaAdaptor "$@"\n')
+        os.chmod(shim, 0o755)
+    return shim_dir
 
 
 def main():
@@ -43,6 +74,10 @@ def main():
             os.environ.setdefault("ADSKFLEX_LICENSE_FILE", f"2702@{license_dns};2701@{license_dns}")
 
     # Linux uses wrapper script at /usr/local/bin/mayapy that handles all env setup
+    if system == "Linux":
+        shim_dir = install_adaptor_shims()
+        os.environ["PATH"] = shim_dir + os.pathsep + os.environ.get("PATH", "")
+        print(f"Adaptor shims installed at {shim_dir} and prepended to PATH", flush=True)
 
     # TEMPORARY: run the libpython collision diagnostic under mayapy so it sees
     # the same environment the adaptor subprocess does. Remove with the

--- a/pipeline/run-integ-tests.py
+++ b/pipeline/run-integ-tests.py
@@ -44,6 +44,15 @@ def main():
 
     # Linux uses wrapper script at /usr/local/bin/mayapy that handles all env setup
 
+    # TEMPORARY: run the libpython collision diagnostic under mayapy so it sees
+    # the same environment the adaptor subprocess does. Remove with the
+    # diagnose_libpython.py file once the 2027 segfault is resolved.
+    diagnostic = os.path.join(os.path.dirname(os.path.abspath(__file__)), "diagnose_libpython.py")
+    if os.path.isfile(diagnostic):
+        print("=== libpython collision diagnostic ===", flush=True)
+        subprocess.run(["mayapy", diagnostic], check=False)
+        print("=== end diagnostic ===", flush=True)
+
     sys.exit(
         subprocess.run(
             ["mayapy", "-m", "pytest", "--no-cov", "test/integ", "-vvv", "--numprocesses=1"]

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -2,7 +2,7 @@
 #!/usr/bin/env python3
 """Setup runner for Maya integration tests in CodeBuild.
 
-Supports Linux and Windows with Maya 2025 and 2026.
+Supports Linux and Windows with Maya 2025, 2026 and 2027.
 
 Installs the Arnold (MtoA), V-Ray, and Redshift renderers into each Maya
 version so the renderer-specific integ tests can run.
@@ -78,6 +78,13 @@ MAYA_YEAR_TO_CONFIG: dict[str, MayaVersionConfig] = {
             "windows": "Maya2026_Windows.zip",
         },
     },
+    "2027": {
+        "python": "3.13",
+        "installer": {
+            "linux": "Autodesk_MayaIO_2027_2_Update_Linux.run",
+            "windows": "Maya2027_Windows.zip",
+        },
+    },
 }
 
 MAYA_YEAR_TO_CHECKSUMS: dict[str, MayaChecksums] = {
@@ -88,6 +95,10 @@ MAYA_YEAR_TO_CHECKSUMS: dict[str, MayaChecksums] = {
     "2026": {
         "linux": "b17b0700933e8e4329939da38cc52c93ed483a93b02e9fa78031fddae763c8e8",
         "windows": "9c9612f6e4d3f1f6de897a21fde6f9930e2e40bb6ddc3ca9647e2668cdba935c",
+    },
+    "2027": {
+        "linux": "eac310135486b2a33e64223721dc451ffca294444880e3a94a96bcc48a4efe9e",
+        "windows": "5380c20e1ab2321776c000e245819b36f33697918ee2cc344efb3ac22e1ead62",
     },
 }
 
@@ -105,6 +116,10 @@ MTOA_YEAR_TO_CONFIG: dict[str, RendererVersionConfig] = {
         "s3_key": "mtoa/5.5/MtoA-5.5.6.1-linux-2026.run",
         "checksum": "d8881e1cece725178d90aaa6d44507ea017ec64d7d23c76b129b9e349d1c9cc6",
     },
+    "2027": {
+        "s3_key": "mtoa/5.6/MtoA-5.6.3-linux-2027.run",
+        "checksum": "a745b3ef022a1fe41f1d1b90597af6df92deaf2dc49f63593705a96a0f3e6ed1",
+    },
 }
 
 # V-Ray for Maya — Chaos RHEL8 self-extracting installer per Maya version.
@@ -117,13 +132,17 @@ VRAY_YEAR_TO_CONFIG: dict[str, RendererVersionConfig] = {
         "s3_key": "maya-vray/72002/vray_adv_72002_maya2026_dr2_rhel8",
         "checksum": "a6e1e65202f6c9b3d4e12e7eb423a780a34dfeac3540658b16f4e20f8009fca6",
     },
+    "2027": {
+        "s3_key": "maya-vray/74004/vray_74004_maya2027_dr2_rhel8",
+        "checksum": "67dab04ce9f71a23d0fcbfd76bdd096b7fc90863c47e86eae7824a4464dff2cf",
+    },
 }
 
-# Redshift — single installer supports both Maya 2025 and 2026.
+# Redshift — single installer supports Maya 2025, 2026 and 2027.
 REDSHIFT_PLATFORM_CONFIG: dict[str, RedshiftPlatformConfig] = {
     "linux": {
-        "s3_key": "redshift/2026/redshift_2026.3.1_2336394021_linux_x64.run",
-        "checksum": "a95e48d2f4dd68e923c7f40693823d206d11acb51e145038d5625b748294777c",
+        "s3_key": "redshift/2026/redshift_2026.8.1_2741261432_linux_x64.run",
+        "checksum": "d653b210ebd7e51e1ceac8795f385fa0204cc8fde38496a7c92b02c97d384e1f",
     },
 }
 
@@ -383,17 +402,21 @@ def _install_mtoa_linux(version: str) -> None:
 
         run(["chmod", "+x", str(installer_path)])
         mtoa_install_dir.mkdir(parents=True, exist_ok=True)
-        # MtoA is a Makeself archive. Extract then unzip the package.
+        # MtoA is a Makeself archive. Extract then unpack the inner payload.
         extract_tmp = Path(f"/tmp/mtoa-{version}-extract")
         if extract_tmp.exists():
             run(["rm", "-rf", str(extract_tmp)], check=False)
         run([str(installer_path), "--noexec", "--target", str(extract_tmp)])
-        # Unzip the package into the install dir
+        # MtoA 5.5.x (Maya 2025/2026) ships package.zip; MtoA 5.6.x (Maya 2027)
+        # switched to package.tgz.
         pkg_zip = next(extract_tmp.glob("*.zip"), None)
+        pkg_tar = next(extract_tmp.glob("*.tgz"), None) or next(extract_tmp.glob("*.tar.gz"), None)
         if pkg_zip:
             run(["unzip", "-qo", str(pkg_zip), "-d", str(mtoa_install_dir)])
+        elif pkg_tar:
+            run(["tar", "xzf", str(pkg_tar), "-C", str(mtoa_install_dir)])
         else:
-            print(f"ERROR: No .zip found in {extract_tmp}")
+            print(f"ERROR: No .zip or .tgz payload found in {extract_tmp}")
             run(["ls", "-la", str(extract_tmp)], check=False)
             sys.exit(1)
         run(["rm", "-rf", str(extract_tmp)], check=False)
@@ -578,6 +601,8 @@ def setup_linux(maya_versions: Sequence[str], renderers: Sequence[str]) -> None:
             "libglvnd-egl",
             "alsa-lib",
             "nss",
+            "openjpeg2",
+            "libatomic",
         ]
     )
 
@@ -803,6 +828,7 @@ def _install_vray_windows(version: str) -> None:
     vray_win_config = {
         "2025": "maya-vray/70002/vray_adv_70002_maya2025_x64.exe",
         "2026": "maya-vray/71002/vray_adv_71002_maya2026_x64.exe",
+        "2027": "maya-vray/74004/vray_74004_maya2027_dr2_x64.exe",
     }
     if version not in vray_win_config:
         print(f"WARNING: No Windows V-Ray config for Maya {version}, skipping")
@@ -834,6 +860,7 @@ def _install_mtoa_windows(version: str) -> None:
     mtoa_win_config = {
         "2025": "mtoa/5.5/MtoA-5.5.4.2-windows-2025.msi",
         "2026": "mtoa/5.5/MtoA-5.5.4.2-windows-2026.msi",
+        "2027": "mtoa/5.6/MtoA-5.6.3-windows-2027.msi",
     }
     if version not in mtoa_win_config:
         print(f"WARNING: No Windows MtoA config for Maya {version}, skipping")
@@ -864,7 +891,7 @@ def _install_redshift_windows() -> None:
     if plugin_check.exists():
         print("Redshift already installed")
         return
-    s3_key = "redshift/2026/redshift_2026.6.0_2497872080_win_x64.exe"
+    s3_key = "redshift/2026/redshift_2026.8.1_2741261432_win_x64.exe"
     installer_path = Path("C:/temp/redshift_install.exe")
     installer_path.parent.mkdir(parents=True, exist_ok=True)
     print("Installing Redshift...")
@@ -874,13 +901,13 @@ def _install_redshift_windows() -> None:
         [
             "powershell",
             "-Command",
-            f'Start-Process "{installer_path}" -ArgumentList "--mode","unattended","--enable-components","MayaGroup,PluginMaya2025,PluginMaya2026" -Wait -NoNewWindow',
+            f'Start-Process "{installer_path}" -ArgumentList "--mode","unattended","--enable-components","MayaGroup,PluginMaya2025,PluginMaya2026,PluginMaya2027" -Wait -NoNewWindow',
         ]
     )
     installer_path.unlink(missing_ok=True)
 
     # Register Redshift with each Maya version
-    for ver in ["2025", "2026"]:
+    for ver in ["2025", "2026", "2027"]:
         maya_env_dir = Path(f"C:/Users/Default/Documents/maya/{ver}")
         maya_env_dir.mkdir(parents=True, exist_ok=True)
         maya_env_file = maya_env_dir / "Maya.env"


### PR DESCRIPTION
- **ci: Add Maya 2027 to the integ test matrix**
- **ci: Pin integ matrix to 2027 Linux for bring-up**

*delete text starting here*
Please ensure that you have read through the [contributing guidelines](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/CONTRIBUTING.md#contributing-via-pull-requests) before continuing.
*delete text ending here*

Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

*delete text starting here*
See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/DEVELOPMENT.md) for information on running tests.
*delete text ending here*

#### Integ test result

*delete text starting here*
If `src/` was modified or a file was added/removed, then update the integ tests and post the test results below. See
DEVELOPMENT.md on additional instructions on running some, or all integ tests.
*delete text ending here*

#### Installer test result

*delete text starting here*
If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
*delete text ending here*

#### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

*delete text starting here*
See the "Integration Tests" subsection of the
[Running Submitter Tests](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/DEVELOPMENT.md#running-submitter-tests)
section of DEVELOPMENT.md for information on these tests.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```
*delete text ending here*


### Was this change documented?

*delete text starting here*
- Did you update all relevant docstrings for Python functions that you modified?
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?
- Should the schema files for the adaptor's init-data or run-data be updated?

*delete text ending here*

### Did you modify schema files?
- [ ] Yes
- [ ] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/maya_adaptor/MayaAdaptor/adaptor.py` and update the test constants?
See the "Schema Versioning" section in DEVELOPMENT.md for details.
   - [ ] Yes
   - [ ] No

### Is this a breaking change?

*delete text starting here*
A breaking change is one that modifies a public contract in some way or otherwise changes functionality of this application in a way
that is not backwards compatible. Examples of changes that are breaking include:

1. Adding a new required value to the init-data or run-data of the adaptor;
2. Deleting or renaming a value in the init-data or run-data of the adaptor; and
3. Otherwise modifying the interface of the adaptor such that a job submitted with an older version of the Maya submitter plug-in
   will not work with a version of the adaptor that includes your modification.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in 
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
